### PR TITLE
fix: docgen fails when installing from a custom registry defined in the HOME directory

### DIFF
--- a/src/docgen/transpile/transpile.ts
+++ b/src/docgen/transpile/transpile.ts
@@ -149,6 +149,17 @@ export interface TranspiledInterface {
  * Outcome of transpiling a generic jsii type.
  */
 export interface TranspiledType {
+
+  /**
+   * The source type this was transliterated from.
+   */
+  readonly source: reflect.Type;
+
+  /**
+   * The transliteration language.
+   */
+  readonly language: Language;
+
   /**
    * The language specific fqn.
    */
@@ -563,6 +574,8 @@ export abstract class TranspileBase implements Transpile {
       namespace: type.namespace,
       module: moduleLike.name,
       submodule: moduleLike.submodule,
+      source: type,
+      language: this.language,
     };
   }
 

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -114,22 +114,16 @@ export class Documentation {
 
       const name = options?.name ?? extractPackageName(target);
 
-      const env = {
-        ...process.env,
-        // npm fails with EROFS if $HOME is read-only, even if it won't write there
-        HOME: os.tmpdir(),
-      };
-
       // npm7 is needed so that we also install peerDependencies - they are needed to construct
       // the full type system.
+      console.log('Installing npm7...');
       await spawn('npm', ['install', 'npm@7'], {
         cwd: workdir,
-        env,
         shell: true,
         stdio: ['ignore', 'inherit', 'inherit'],
       });
 
-      console.log('Installing package');
+      console.log(`Installing package ${target}`);
       await spawn(path.join(workdir, 'node_modules', '.bin', 'npm'), [
         'install',
         // this is critical from a security perspective to prevent
@@ -141,7 +135,6 @@ export class Documentation {
         target,
       ], {
         cwd: workdir,
-        env,
         shell: true,
         stdio: ['ignore', 'inherit', 'inherit'],
       });

--- a/src/docgen/view/parameter.ts
+++ b/src/docgen/view/parameter.ts
@@ -16,7 +16,7 @@ export class Parameter {
     const optionality = this.parameter.optional ? 'Optional' : 'Required';
 
     const md = new Markdown({
-      id: `${this.transpiled.parentType.fqn}.${this.transpiled.name}`,
+      id: `${this.transpiled.parentType.fqn}.parameter.${this.transpiled.name}`,
       header: {
         title: this.transpiled.name,
         sup: optionality,

--- a/src/docgen/view/property.ts
+++ b/src/docgen/view/property.ts
@@ -20,7 +20,7 @@ export class Property {
         : 'Required';
 
     const md = new Markdown({
-      id: `${this.transpiled.parentType.fqn}.${this.transpiled.name}`,
+      id: `${this.transpiled.parentType.fqn}.property.${this.transpiled.name}`,
       header: {
         title: this.transpiled.name,
         sup: optionality,

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -15,19 +15,19 @@ import { GreeterBucket } from 'construct-library'
 new GreeterBucket(scope: Construct, id: string, props?: BucketProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"construct-library.GreeterBucket.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"construct-library.GreeterBucket.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"construct-library.GreeterBucket.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"construct-library.GreeterBucket.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Optional</sup> <a name=\\"construct-library.GreeterBucket.props\\"></a>
+##### \`props\`<sup>Optional</sup> <a name=\\"construct-library.GreeterBucket.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-s3.BucketProps\`](#@aws-cdk/aws-s3.BucketProps)
 

--- a/test/docgen/view/__snapshots__/class.test.ts.snap
+++ b/test/docgen/view/__snapshots__/class.test.ts.snap
@@ -18,7 +18,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.AuthorizationToken.grant_read(grantee: IGrantable)
 \`\`\`
 
-### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.grantee\\"></a>
+### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -46,7 +46,7 @@ import { AuthorizationToken } from '@aws-cdk/aws-ecr'
 AuthorizationToken.grantRead(grantee: IGrantable)
 \`\`\`
 
-### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken.grantee\\"></a>
+### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 

--- a/test/docgen/view/__snapshots__/documentation.test.ts.snap
+++ b/test/docgen/view/__snapshots__/documentation.test.ts.snap
@@ -127,7 +127,7 @@ aws_cdk.aws_ecr.CfnPublicRepository(scope: Construct,
                                     tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#custom-aws_cdk.core.Construct)
 
@@ -135,7 +135,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -143,7 +143,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_catalog_data\\"></a>
+##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.repository_catalog_data\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -153,7 +153,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -163,7 +163,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -173,7 +173,7 @@ scoped id of the resource.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#custom-aws_cdk.core.CfnTag)]
 
@@ -191,7 +191,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#custom-aws_cdk.core.TreeInspector)
 
@@ -202,13 +202,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.attr_arn\\"></a>
+##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.attr_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.tags\\"></a>
 
 - *Type:* [\`aws_cdk.core.TagManager\`](#custom-aws_cdk.core.TagManager)
 
@@ -218,7 +218,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_catalog_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.repository_catalog_data\\"></a>
+##### \`repository_catalog_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_catalog_data\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -228,7 +228,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -238,7 +238,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -250,7 +250,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -276,7 +276,7 @@ aws_cdk.aws_ecr.CfnRegistryPolicy(scope: Construct,
                                   policy_text: typing.Any)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#custom-aws_cdk.core.Construct)
 
@@ -284,7 +284,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -292,7 +292,7 @@ scoped id of the resource.
 
 ---
 
-##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.policy_text\\"></a>
+##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.parameter.policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -310,7 +310,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#custom-aws_cdk.core.TreeInspector)
 
@@ -321,13 +321,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.attr_registry_id\\"></a>
+##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.attr_registry_id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.policy_text\\"></a>
+##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -339,7 +339,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -365,7 +365,7 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration(scope: Construct,
                                             replication_configuration: typing.Union[IResolvable, ReplicationConfigurationProperty])
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#custom-aws_cdk.core.Construct)
 
@@ -373,7 +373,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -381,7 +381,7 @@ scoped id of the resource.
 
 ---
 
-##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.replication_configuration\\"></a>
+##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.parameter.replication_configuration\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#custom-aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -399,7 +399,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#custom-aws_cdk.core.TreeInspector)
 
@@ -410,13 +410,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.attr_registry_id\\"></a>
+##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.attr_registry_id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.replication_configuration\\"></a>
+##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.replication_configuration\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#custom-aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -428,7 +428,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -460,7 +460,7 @@ aws_cdk.aws_ecr.CfnRepository(scope: Construct,
                               tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#custom-aws_cdk.core.Construct)
 
@@ -468,7 +468,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -476,7 +476,7 @@ scoped id of the resource.
 
 ---
 
-##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.encryption_configuration\\"></a>
+##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.encryption_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -486,7 +486,7 @@ scoped id of the resource.
 
 ---
 
-##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.image_scanning_configuration\\"></a>
+##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.image_scanning_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -496,7 +496,7 @@ scoped id of the resource.
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.image_tag_mutability\\"></a>
 
 - *Type:* \`str\`
 
@@ -506,7 +506,7 @@ scoped id of the resource.
 
 ---
 
-##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.lifecycle_policy\\"></a>
+##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.lifecycle_policy\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#custom-aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
@@ -516,7 +516,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -526,7 +526,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -536,7 +536,7 @@ scoped id of the resource.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#custom-aws_cdk.core.CfnTag)]
 
@@ -554,7 +554,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#custom-aws_cdk.core.TreeInspector)
 
@@ -565,19 +565,19 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.attr_arn\\"></a>
+##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.attr_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`attr_repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.attr_repository_uri\\"></a>
+##### \`attr_repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.attr_repository_uri\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.tags\\"></a>
 
 - *Type:* [\`aws_cdk.core.TagManager\`](#custom-aws_cdk.core.TagManager)
 
@@ -587,7 +587,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`encryption_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.encryption_configuration\\"></a>
+##### \`encryption_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.encryption_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -597,7 +597,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`image_scanning_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.image_scanning_configuration\\"></a>
+##### \`image_scanning_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.image_scanning_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -607,7 +607,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -617,7 +617,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.image_tag_mutability\\"></a>
 
 - *Type:* \`str\`
 
@@ -627,7 +627,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.lifecycle_policy\\"></a>
+##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.lifecycle_policy\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#custom-aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
@@ -637,7 +637,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -649,7 +649,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRepository.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -676,19 +676,19 @@ aws_cdk.aws_ecr.Repository(scope: Construct,
                            repository_name: str = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#custom-constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.image_scan_on_push\\"></a>
+##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.image_scan_on_push\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -697,7 +697,7 @@ Enable the scan on push when creating the repository.
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.image_tag_mutability\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ecr.TagMutability\`](#custom-aws_cdk.aws_ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -708,7 +708,7 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ---
 
-##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.lifecycle_registry_id\\"></a>
+##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.lifecycle_registry_id\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The default registry is assumed.
@@ -719,7 +719,7 @@ The AWS account ID associated with the registry that contains the repository.
 
 ---
 
-##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.lifecycle_rules\\"></a>
+##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.lifecycle_rules\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ecr.LifecycleRule\`](#custom-aws_cdk.aws_ecr.LifecycleRule)]
 - *Default:* No life cycle rules
@@ -728,7 +728,7 @@ Life cycle rules to apply to this registry.
 
 ---
 
-##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.removal_policy\\"></a>
+##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.removal_policy\\"></a>
 
 - *Type:* [\`aws_cdk.core.RemovalPolicy\`](#custom-aws_cdk.core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
@@ -737,7 +737,7 @@ Determine what happens to the repository when the resource/stack is deleted.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name.
@@ -759,7 +759,7 @@ def add_lifecycle_rule(description: str = None,
                        tag_status: TagStatus = None)
 \`\`\`
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -768,7 +768,7 @@ Describes the purpose of the rule.
 
 ---
 
-###### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.max_image_age\\"></a>
+###### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.max_image_age\\"></a>
 
 - *Type:* [\`aws_cdk.core.Duration\`](#custom-aws_cdk.core.Duration)
 
@@ -778,7 +778,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-###### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.max_image_count\\"></a>
+###### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.max_image_count\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -788,7 +788,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-###### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.rule_priority\\"></a>
+###### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.rule_priority\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* Automatically assigned
@@ -806,7 +806,7 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
-###### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.tag_prefix_list\\"></a>
+###### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.tag_prefix_list\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -816,7 +816,7 @@ Only if tagStatus == TagStatus.Tagged
 
 ---
 
-###### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.tag_status\\"></a>
+###### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.tag_status\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ecr.TagStatus\`](#custom-aws_cdk.aws_ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -834,7 +834,7 @@ have the highest rulePriority.
 def add_to_resource_policy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.statement\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.PolicyStatement\`](#custom-aws_cdk.aws_iam.PolicyStatement)
 
@@ -852,19 +852,19 @@ aws_cdk.aws_ecr.Repository.arn_for_local_repository(repository_name: str,
                                                     account: str = None)
 \`\`\`
 
-###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_name\\"></a>
+###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.IConstruct\`](#custom-constructs.IConstruct)
 
 ---
 
-###### \`account\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.Repository.account\\"></a>
+###### \`account\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.account\\"></a>
 
 - *Type:* \`str\`
 
@@ -880,19 +880,19 @@ aws_cdk.aws_ecr.Repository.from_repository_arn(scope: Construct,
                                                repository_arn: str)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#custom-constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_arn\\"></a>
+###### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -909,25 +909,25 @@ aws_cdk.aws_ecr.Repository.from_repository_attributes(scope: Construct,
                                                       repository_name: str)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#custom-constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.repository_arn\\"></a>
+###### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.parameter.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.repository_name\\"></a>
+###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -943,19 +943,19 @@ aws_cdk.aws_ecr.Repository.from_repository_name(scope: Construct,
                                                 repository_name: str)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#custom-constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_name\\"></a>
+###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -963,7 +963,7 @@ aws_cdk.aws_ecr.Repository.from_repository_name(scope: Construct,
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_arn\\"></a>
+##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -971,7 +971,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_name\\"></a>
+##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -1001,19 +1001,19 @@ aws_cdk.aws_ecr.RepositoryBase(scope: Construct,
                                region: str = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#custom-constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`account\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.account\\"></a>
+##### \`account\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.parameter.account\\"></a>
 
 - *Type:* \`str\`
 - *Default:* the resource is in the same account as the stack it belongs to
@@ -1022,7 +1022,7 @@ The AWS account ID this resource belongs to.
 
 ---
 
-##### \`environment_from_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.environment_from_arn\\"></a>
+##### \`environment_from_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.parameter.environment_from_arn\\"></a>
 
 - *Type:* \`str\`
 - *Default:* take environment from \`account\`, \`region\` parameters, or use Stack environment.
@@ -1036,7 +1036,7 @@ Cannot be supplied together with either \`account\` or \`region\`.
 
 ---
 
-##### \`physical_name\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.physical_name\\"></a>
+##### \`physical_name\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.parameter.physical_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The physical name will be allocated by CloudFormation at deployment time
@@ -1051,7 +1051,7 @@ The value passed in by users to the physical name prop of the resource.
 
 ---
 
-##### \`region\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.region\\"></a>
+##### \`region\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.parameter.region\\"></a>
 
 - *Type:* \`str\`
 - *Default:* the resource is in the same region as the stack it belongs to
@@ -1068,7 +1068,7 @@ The AWS region this resource belongs to.
 def add_to_resource_policy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.statement\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.PolicyStatement\`](#custom-aws_cdk.aws_iam.PolicyStatement)
 
@@ -1081,13 +1081,13 @@ def grant(grantee: IGrantable,
           actions: str)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#custom-aws_cdk.aws_iam.IGrantable)
 
 ---
 
-###### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.actions\\"></a>
+###### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.actions\\"></a>
 
 - *Type:* \`str\`
 
@@ -1099,7 +1099,7 @@ def grant(grantee: IGrantable,
 def grant_pull(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#custom-aws_cdk.aws_iam.IGrantable)
 
@@ -1111,7 +1111,7 @@ def grant_pull(grantee: IGrantable)
 def grant_pull_push(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#custom-aws_cdk.aws_iam.IGrantable)
 
@@ -1127,7 +1127,7 @@ def on_cloud_trail_event(id: str,
                          target: IRuleTarget = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -1135,7 +1135,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -1144,7 +1144,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#custom-aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -1159,7 +1159,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -1168,7 +1168,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#custom-aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -1188,7 +1188,7 @@ def on_cloud_trail_image_pushed(id: str,
                                 image_tag: str = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -1196,7 +1196,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -1205,7 +1205,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#custom-aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -1220,7 +1220,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -1229,7 +1229,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#custom-aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -1238,7 +1238,7 @@ The target to register for the event.
 
 ---
 
-###### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.image_tag\\"></a>
+###### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.image_tag\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -1257,13 +1257,13 @@ def on_event(id: str,
              target: IRuleTarget = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -1272,7 +1272,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#custom-aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -1287,7 +1287,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -1296,7 +1296,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#custom-aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -1316,7 +1316,7 @@ def on_image_scan_completed(id: str,
                             image_tags: typing.List[str] = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -1324,7 +1324,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -1333,7 +1333,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#custom-aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -1348,7 +1348,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -1357,7 +1357,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#custom-aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -1366,7 +1366,7 @@ The target to register for the event.
 
 ---
 
-###### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.image_tags\\"></a>
+###### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.image_tags\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -1383,7 +1383,7 @@ Leave it undefined to watch the full repository.
 def repository_uri_for_digest(digest: str = None)
 \`\`\`
 
-###### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.digest\\"></a>
+###### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.digest\\"></a>
 
 - *Type:* \`str\`
 
@@ -1397,7 +1397,7 @@ Optional image digest.
 def repository_uri_for_tag(tag: str = None)
 \`\`\`
 
-###### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.tag\\"></a>
+###### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.tag\\"></a>
 
 - *Type:* \`str\`
 
@@ -1408,7 +1408,7 @@ Optional image tag.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.repository_arn\\"></a>
+##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -1416,7 +1416,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.repository_name\\"></a>
+##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -1424,7 +1424,7 @@ The name of the repository.
 
 ---
 
-##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.repository_uri\\"></a>
+##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_uri\\"></a>
 
 - *Type:* \`str\`
 
@@ -1454,7 +1454,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
                                          tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_catalog_data\\"></a>
+##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_catalog_data\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -1464,7 +1464,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -1474,7 +1474,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
 
 ---
 
-##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -1484,7 +1484,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#custom-aws_cdk.core.CfnTag)]
 
@@ -1508,7 +1508,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.CfnRegistryPolicyProps(policy_text: typing.Any)
 \`\`\`
 
-##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.policy_text\\"></a>
+##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.property.policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -1532,7 +1532,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.CfnReplicationConfigurationProps(replication_configuration: typing.Union[IResolvable, ReplicationConfigurationProperty])
 \`\`\`
 
-##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.replication_configuration\\"></a>
+##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.property.replication_configuration\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#custom-aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -1562,7 +1562,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
                                    tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.encryption_configuration\\"></a>
+##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.encryption_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -1572,7 +1572,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.image_scanning_configuration\\"></a>
+##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.image_scanning_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -1582,7 +1582,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.image_tag_mutability\\"></a>
 
 - *Type:* \`str\`
 
@@ -1592,7 +1592,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.lifecycle_policy\\"></a>
+##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.lifecycle_policy\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#custom-aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
@@ -1602,7 +1602,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -1612,7 +1612,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -1622,7 +1622,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#custom-aws_cdk.core.CfnTag)]
 
@@ -1645,7 +1645,7 @@ aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty(lifecycle_policy_text: str
                                                       registry_id: str = None)
 \`\`\`
 
-##### \`lifecycle_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.lifecycle_policy_text\\"></a>
+##### \`lifecycle_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.property.lifecycle_policy_text\\"></a>
 
 - *Type:* \`str\`
 
@@ -1655,7 +1655,7 @@ aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty(lifecycle_policy_text: str
 
 ---
 
-##### \`registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.registry_id\\"></a>
+##### \`registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.property.registry_id\\"></a>
 
 - *Type:* \`str\`
 
@@ -1682,7 +1682,7 @@ aws_cdk.aws_ecr.LifecycleRule(description: str = None,
                               tag_status: TagStatus = None)
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -1691,7 +1691,7 @@ Describes the purpose of the rule.
 
 ---
 
-##### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.max_image_age\\"></a>
+##### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.max_image_age\\"></a>
 
 - *Type:* [\`aws_cdk.core.Duration\`](#custom-aws_cdk.core.Duration)
 
@@ -1701,7 +1701,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-##### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.max_image_count\\"></a>
+##### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.max_image_count\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -1711,7 +1711,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-##### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.rule_priority\\"></a>
+##### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.rule_priority\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* Automatically assigned
@@ -1729,7 +1729,7 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
-##### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.tag_prefix_list\\"></a>
+##### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.tag_prefix_list\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -1739,7 +1739,7 @@ Only if tagStatus == TagStatus.Tagged
 
 ---
 
-##### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.tag_status\\"></a>
+##### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.tag_status\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ecr.TagStatus\`](#custom-aws_cdk.aws_ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -1767,7 +1767,7 @@ aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions(description: str = None,
                                                image_tag: str = None)
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -1776,7 +1776,7 @@ A description of the rule's purpose.
 
 ---
 
-##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.event_pattern\\"></a>
+##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#custom-aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -1791,7 +1791,7 @@ on top of that filtering.
 
 ---
 
-##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.rule_name\\"></a>
+##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -1800,7 +1800,7 @@ A name for the rule.
 
 ---
 
-##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.target\\"></a>
+##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#custom-aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -1809,7 +1809,7 @@ The target to register for the event.
 
 ---
 
-##### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.image_tag\\"></a>
+##### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.image_tag\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -1834,7 +1834,7 @@ aws_cdk.aws_ecr.OnImageScanCompletedOptions(description: str = None,
                                             image_tags: typing.List[str] = None)
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -1843,7 +1843,7 @@ A description of the rule's purpose.
 
 ---
 
-##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.event_pattern\\"></a>
+##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#custom-aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -1858,7 +1858,7 @@ on top of that filtering.
 
 ---
 
-##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.rule_name\\"></a>
+##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -1867,7 +1867,7 @@ A name for the rule.
 
 ---
 
-##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.target\\"></a>
+##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#custom-aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -1876,7 +1876,7 @@ The target to register for the event.
 
 ---
 
-##### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.image_tags\\"></a>
+##### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.image_tags\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -1899,7 +1899,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty(rules: typing.Union[IResolvable, typing.List[typing.Union[IResolvable, ReplicationRuleProperty]]])
 \`\`\`
 
-##### \`rules\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.rules\\"></a>
+##### \`rules\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), typing.List[typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#custom-aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty)]]]
 
@@ -1922,7 +1922,7 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty(regio
                                                                            registry_id: str)
 \`\`\`
 
-##### \`region\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.region\\"></a>
+##### \`region\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
 - *Type:* \`str\`
 
@@ -1932,7 +1932,7 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty(regio
 
 ---
 
-##### \`registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.registry_id\\"></a>
+##### \`registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registry_id\\"></a>
 
 - *Type:* \`str\`
 
@@ -1954,7 +1954,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty(destinations: typing.Union[IResolvable, typing.List[typing.Union[IResolvable, ReplicationDestinationProperty]]])
 \`\`\`
 
-##### \`destinations\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty.destinations\\"></a>
+##### \`destinations\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), typing.List[typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#custom-aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)]]]
 
@@ -1975,13 +1975,13 @@ aws_cdk.aws_ecr.RepositoryAttributes(repository_arn: str,
                                      repository_name: str)
 \`\`\`
 
-##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.repository_arn\\"></a>
+##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.repository_name\\"></a>
+##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -2002,7 +2002,7 @@ aws_cdk.aws_ecr.RepositoryProps(image_scan_on_push: bool = None,
                                 repository_name: str = None)
 \`\`\`
 
-##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.image_scan_on_push\\"></a>
+##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.image_scan_on_push\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -2011,7 +2011,7 @@ Enable the scan on push when creating the repository.
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.image_tag_mutability\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ecr.TagMutability\`](#custom-aws_cdk.aws_ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -2022,7 +2022,7 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ---
 
-##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.lifecycle_registry_id\\"></a>
+##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.lifecycle_registry_id\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The default registry is assumed.
@@ -2033,7 +2033,7 @@ The AWS account ID associated with the registry that contains the repository.
 
 ---
 
-##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.lifecycle_rules\\"></a>
+##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.lifecycle_rules\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ecr.LifecycleRule\`](#custom-aws_cdk.aws_ecr.LifecycleRule)]
 - *Default:* No life cycle rules
@@ -2042,7 +2042,7 @@ Life cycle rules to apply to this registry.
 
 ---
 
-##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.removal_policy\\"></a>
+##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.removal_policy\\"></a>
 
 - *Type:* [\`aws_cdk.core.RemovalPolicy\`](#custom-aws_cdk.core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
@@ -2051,7 +2051,7 @@ Determine what happens to the repository when the resource/stack is deleted.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name.
@@ -2079,7 +2079,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.AuthorizationToken.grant_read(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#custom-aws_cdk.aws_iam.IGrantable)
 
@@ -2104,7 +2104,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.PublicGalleryAuthorizationToken.grant_read(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.PublicGalleryAuthorizationToken.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.PublicGalleryAuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#custom-aws_cdk.aws_iam.IGrantable)
 
@@ -2130,7 +2130,7 @@ Represents an ECR repository.
 def add_to_resource_policy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.statement\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.PolicyStatement\`](#custom-aws_cdk.aws_iam.PolicyStatement)
 
@@ -2143,13 +2143,13 @@ def grant(grantee: IGrantable,
           actions: str)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#custom-aws_cdk.aws_iam.IGrantable)
 
 ---
 
-###### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.actions\\"></a>
+###### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.actions\\"></a>
 
 - *Type:* \`str\`
 
@@ -2161,7 +2161,7 @@ def grant(grantee: IGrantable,
 def grant_pull(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#custom-aws_cdk.aws_iam.IGrantable)
 
@@ -2173,7 +2173,7 @@ def grant_pull(grantee: IGrantable)
 def grant_pull_push(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#custom-aws_cdk.aws_iam.IGrantable)
 
@@ -2189,7 +2189,7 @@ def on_cloud_trail_event(id: str,
                          target: IRuleTarget = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -2197,7 +2197,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -2206,7 +2206,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#custom-aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -2221,7 +2221,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -2230,7 +2230,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#custom-aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -2250,7 +2250,7 @@ def on_cloud_trail_image_pushed(id: str,
                                 image_tag: str = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -2258,7 +2258,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -2267,7 +2267,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#custom-aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -2282,7 +2282,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -2291,7 +2291,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#custom-aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -2300,7 +2300,7 @@ The target to register for the event.
 
 ---
 
-###### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.image_tag\\"></a>
+###### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.image_tag\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -2319,13 +2319,13 @@ def on_event(id: str,
              target: IRuleTarget = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -2334,7 +2334,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#custom-aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -2349,7 +2349,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -2358,7 +2358,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#custom-aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -2378,7 +2378,7 @@ def on_image_scan_completed(id: str,
                             image_tags: typing.List[str] = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -2386,7 +2386,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -2395,7 +2395,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#custom-aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -2410,7 +2410,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -2419,7 +2419,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#custom-aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -2428,7 +2428,7 @@ The target to register for the event.
 
 ---
 
-###### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.image_tags\\"></a>
+###### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.image_tags\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -2445,7 +2445,7 @@ Leave it undefined to watch the full repository.
 def repository_uri_for_digest(digest: str = None)
 \`\`\`
 
-###### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.digest\\"></a>
+###### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.digest\\"></a>
 
 - *Type:* \`str\`
 
@@ -2459,7 +2459,7 @@ Image digest to use (tools usually default to the image with the \\"latest\\" ta
 def repository_uri_for_tag(tag: str = None)
 \`\`\`
 
-###### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.tag\\"></a>
+###### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.tag\\"></a>
 
 - *Type:* \`str\`
 
@@ -2469,7 +2469,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.node\\"></a>
+##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.node\\"></a>
 
 - *Type:* [\`aws_cdk.core.ConstructNode\`](#custom-aws_cdk.core.ConstructNode)
 
@@ -2477,7 +2477,7 @@ The construct tree node for this construct.
 
 ---
 
-##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.env\\"></a>
+##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.env\\"></a>
 
 - *Type:* [\`aws_cdk.core.ResourceEnvironment\`](#custom-aws_cdk.core.ResourceEnvironment)
 
@@ -2492,7 +2492,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.stack\\"></a>
+##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.stack\\"></a>
 
 - *Type:* [\`aws_cdk.core.Stack\`](#custom-aws_cdk.core.Stack)
 
@@ -2500,7 +2500,7 @@ The stack in which this resource is defined.
 
 ---
 
-##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.repository_arn\\"></a>
+##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -2508,7 +2508,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.repository_name\\"></a>
+##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -2516,7 +2516,7 @@ The name of the repository.
 
 ---
 
-##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.repository_uri\\"></a>
+##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_uri\\"></a>
 
 - *Type:* \`str\`
 
@@ -2592,19 +2592,19 @@ import { GreeterBucket } from 'construct-library'
 new GreeterBucket(scope: Construct, id: string, props?: BucketProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"construct-library.GreeterBucket.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"construct-library.GreeterBucket.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"construct-library.GreeterBucket.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"construct-library.GreeterBucket.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Optional</sup> <a name=\\"construct-library.GreeterBucket.props\\"></a>
+##### \`props\`<sup>Optional</sup> <a name=\\"construct-library.GreeterBucket.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-s3.BucketProps\`](#@aws-cdk/aws-s3.BucketProps)
 
@@ -2754,7 +2754,7 @@ aws_cdk.aws_ecr.CfnPublicRepository(scope: Construct,
                                     tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#aws_cdk.core.Construct)
 
@@ -2762,7 +2762,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -2770,7 +2770,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_catalog_data\\"></a>
+##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.repository_catalog_data\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -2780,7 +2780,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -2790,7 +2790,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -2800,7 +2800,7 @@ scoped id of the resource.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -2818,7 +2818,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#aws_cdk.core.TreeInspector)
 
@@ -2829,13 +2829,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.attr_arn\\"></a>
+##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.attr_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.tags\\"></a>
 
 - *Type:* [\`aws_cdk.core.TagManager\`](#aws_cdk.core.TagManager)
 
@@ -2845,7 +2845,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_catalog_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.repository_catalog_data\\"></a>
+##### \`repository_catalog_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_catalog_data\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -2855,7 +2855,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -2865,7 +2865,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -2877,7 +2877,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -2903,7 +2903,7 @@ aws_cdk.aws_ecr.CfnRegistryPolicy(scope: Construct,
                                   policy_text: typing.Any)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#aws_cdk.core.Construct)
 
@@ -2911,7 +2911,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -2919,7 +2919,7 @@ scoped id of the resource.
 
 ---
 
-##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.policy_text\\"></a>
+##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.parameter.policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -2937,7 +2937,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#aws_cdk.core.TreeInspector)
 
@@ -2948,13 +2948,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.attr_registry_id\\"></a>
+##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.attr_registry_id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.policy_text\\"></a>
+##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -2966,7 +2966,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -2992,7 +2992,7 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration(scope: Construct,
                                             replication_configuration: typing.Union[IResolvable, ReplicationConfigurationProperty])
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#aws_cdk.core.Construct)
 
@@ -3000,7 +3000,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -3008,7 +3008,7 @@ scoped id of the resource.
 
 ---
 
-##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.replication_configuration\\"></a>
+##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.parameter.replication_configuration\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -3026,7 +3026,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#aws_cdk.core.TreeInspector)
 
@@ -3037,13 +3037,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.attr_registry_id\\"></a>
+##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.attr_registry_id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.replication_configuration\\"></a>
+##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.replication_configuration\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -3055,7 +3055,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -3087,7 +3087,7 @@ aws_cdk.aws_ecr.CfnRepository(scope: Construct,
                               tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#aws_cdk.core.Construct)
 
@@ -3095,7 +3095,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -3103,7 +3103,7 @@ scoped id of the resource.
 
 ---
 
-##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.encryption_configuration\\"></a>
+##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.encryption_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -3113,7 +3113,7 @@ scoped id of the resource.
 
 ---
 
-##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.image_scanning_configuration\\"></a>
+##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.image_scanning_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -3123,7 +3123,7 @@ scoped id of the resource.
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.image_tag_mutability\\"></a>
 
 - *Type:* \`str\`
 
@@ -3133,7 +3133,7 @@ scoped id of the resource.
 
 ---
 
-##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.lifecycle_policy\\"></a>
+##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.lifecycle_policy\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
@@ -3143,7 +3143,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -3153,7 +3153,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -3163,7 +3163,7 @@ scoped id of the resource.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -3181,7 +3181,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#aws_cdk.core.TreeInspector)
 
@@ -3192,19 +3192,19 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.attr_arn\\"></a>
+##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.attr_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`attr_repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.attr_repository_uri\\"></a>
+##### \`attr_repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.attr_repository_uri\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.tags\\"></a>
 
 - *Type:* [\`aws_cdk.core.TagManager\`](#aws_cdk.core.TagManager)
 
@@ -3214,7 +3214,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`encryption_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.encryption_configuration\\"></a>
+##### \`encryption_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.encryption_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -3224,7 +3224,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`image_scanning_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.image_scanning_configuration\\"></a>
+##### \`image_scanning_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.image_scanning_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -3234,7 +3234,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -3244,7 +3244,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.image_tag_mutability\\"></a>
 
 - *Type:* \`str\`
 
@@ -3254,7 +3254,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.lifecycle_policy\\"></a>
+##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.lifecycle_policy\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
@@ -3264,7 +3264,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -3276,7 +3276,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRepository.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -3303,19 +3303,19 @@ aws_cdk.aws_ecr.Repository(scope: Construct,
                            repository_name: str = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.image_scan_on_push\\"></a>
+##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.image_scan_on_push\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -3324,7 +3324,7 @@ Enable the scan on push when creating the repository.
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.image_tag_mutability\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ecr.TagMutability\`](#aws_cdk.aws_ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -3335,7 +3335,7 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ---
 
-##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.lifecycle_registry_id\\"></a>
+##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.lifecycle_registry_id\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The default registry is assumed.
@@ -3346,7 +3346,7 @@ The AWS account ID associated with the registry that contains the repository.
 
 ---
 
-##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.lifecycle_rules\\"></a>
+##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.lifecycle_rules\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ecr.LifecycleRule\`](#aws_cdk.aws_ecr.LifecycleRule)]
 - *Default:* No life cycle rules
@@ -3355,7 +3355,7 @@ Life cycle rules to apply to this registry.
 
 ---
 
-##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.removal_policy\\"></a>
+##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.removal_policy\\"></a>
 
 - *Type:* [\`aws_cdk.core.RemovalPolicy\`](#aws_cdk.core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
@@ -3364,7 +3364,7 @@ Determine what happens to the repository when the resource/stack is deleted.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name.
@@ -3386,7 +3386,7 @@ def add_lifecycle_rule(description: str = None,
                        tag_status: TagStatus = None)
 \`\`\`
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -3395,7 +3395,7 @@ Describes the purpose of the rule.
 
 ---
 
-###### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.max_image_age\\"></a>
+###### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.max_image_age\\"></a>
 
 - *Type:* [\`aws_cdk.core.Duration\`](#aws_cdk.core.Duration)
 
@@ -3405,7 +3405,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-###### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.max_image_count\\"></a>
+###### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.max_image_count\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -3415,7 +3415,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-###### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.rule_priority\\"></a>
+###### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.rule_priority\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* Automatically assigned
@@ -3433,7 +3433,7 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
-###### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.tag_prefix_list\\"></a>
+###### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.tag_prefix_list\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -3443,7 +3443,7 @@ Only if tagStatus == TagStatus.Tagged
 
 ---
 
-###### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.tag_status\\"></a>
+###### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.tag_status\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ecr.TagStatus\`](#aws_cdk.aws_ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -3461,7 +3461,7 @@ have the highest rulePriority.
 def add_to_resource_policy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.statement\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.PolicyStatement\`](#aws_cdk.aws_iam.PolicyStatement)
 
@@ -3479,19 +3479,19 @@ aws_cdk.aws_ecr.Repository.arn_for_local_repository(repository_name: str,
                                                     account: str = None)
 \`\`\`
 
-###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_name\\"></a>
+###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.IConstruct\`](#constructs.IConstruct)
 
 ---
 
-###### \`account\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.Repository.account\\"></a>
+###### \`account\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.account\\"></a>
 
 - *Type:* \`str\`
 
@@ -3507,19 +3507,19 @@ aws_cdk.aws_ecr.Repository.from_repository_arn(scope: Construct,
                                                repository_arn: str)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_arn\\"></a>
+###### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -3536,25 +3536,25 @@ aws_cdk.aws_ecr.Repository.from_repository_attributes(scope: Construct,
                                                       repository_name: str)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.repository_arn\\"></a>
+###### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.parameter.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.repository_name\\"></a>
+###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -3570,19 +3570,19 @@ aws_cdk.aws_ecr.Repository.from_repository_name(scope: Construct,
                                                 repository_name: str)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_name\\"></a>
+###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -3590,7 +3590,7 @@ aws_cdk.aws_ecr.Repository.from_repository_name(scope: Construct,
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_arn\\"></a>
+##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -3598,7 +3598,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_name\\"></a>
+##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -3628,19 +3628,19 @@ aws_cdk.aws_ecr.RepositoryBase(scope: Construct,
                                region: str = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`account\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.account\\"></a>
+##### \`account\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.parameter.account\\"></a>
 
 - *Type:* \`str\`
 - *Default:* the resource is in the same account as the stack it belongs to
@@ -3649,7 +3649,7 @@ The AWS account ID this resource belongs to.
 
 ---
 
-##### \`environment_from_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.environment_from_arn\\"></a>
+##### \`environment_from_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.parameter.environment_from_arn\\"></a>
 
 - *Type:* \`str\`
 - *Default:* take environment from \`account\`, \`region\` parameters, or use Stack environment.
@@ -3663,7 +3663,7 @@ Cannot be supplied together with either \`account\` or \`region\`.
 
 ---
 
-##### \`physical_name\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.physical_name\\"></a>
+##### \`physical_name\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.parameter.physical_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The physical name will be allocated by CloudFormation at deployment time
@@ -3678,7 +3678,7 @@ The value passed in by users to the physical name prop of the resource.
 
 ---
 
-##### \`region\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.region\\"></a>
+##### \`region\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.parameter.region\\"></a>
 
 - *Type:* \`str\`
 - *Default:* the resource is in the same region as the stack it belongs to
@@ -3695,7 +3695,7 @@ The AWS region this resource belongs to.
 def add_to_resource_policy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.statement\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.PolicyStatement\`](#aws_cdk.aws_iam.PolicyStatement)
 
@@ -3708,13 +3708,13 @@ def grant(grantee: IGrantable,
           actions: str)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
 ---
 
-###### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.actions\\"></a>
+###### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.actions\\"></a>
 
 - *Type:* \`str\`
 
@@ -3726,7 +3726,7 @@ def grant(grantee: IGrantable,
 def grant_pull(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -3738,7 +3738,7 @@ def grant_pull(grantee: IGrantable)
 def grant_pull_push(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -3754,7 +3754,7 @@ def on_cloud_trail_event(id: str,
                          target: IRuleTarget = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -3762,7 +3762,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -3771,7 +3771,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -3786,7 +3786,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -3795,7 +3795,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -3815,7 +3815,7 @@ def on_cloud_trail_image_pushed(id: str,
                                 image_tag: str = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -3823,7 +3823,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -3832,7 +3832,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -3847,7 +3847,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -3856,7 +3856,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -3865,7 +3865,7 @@ The target to register for the event.
 
 ---
 
-###### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.image_tag\\"></a>
+###### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.image_tag\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -3884,13 +3884,13 @@ def on_event(id: str,
              target: IRuleTarget = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -3899,7 +3899,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -3914,7 +3914,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -3923,7 +3923,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -3943,7 +3943,7 @@ def on_image_scan_completed(id: str,
                             image_tags: typing.List[str] = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -3951,7 +3951,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -3960,7 +3960,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -3975,7 +3975,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -3984,7 +3984,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -3993,7 +3993,7 @@ The target to register for the event.
 
 ---
 
-###### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.image_tags\\"></a>
+###### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.image_tags\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -4010,7 +4010,7 @@ Leave it undefined to watch the full repository.
 def repository_uri_for_digest(digest: str = None)
 \`\`\`
 
-###### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.digest\\"></a>
+###### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.digest\\"></a>
 
 - *Type:* \`str\`
 
@@ -4024,7 +4024,7 @@ Optional image digest.
 def repository_uri_for_tag(tag: str = None)
 \`\`\`
 
-###### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.tag\\"></a>
+###### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.tag\\"></a>
 
 - *Type:* \`str\`
 
@@ -4035,7 +4035,7 @@ Optional image tag.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.repository_arn\\"></a>
+##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -4043,7 +4043,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.repository_name\\"></a>
+##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -4051,7 +4051,7 @@ The name of the repository.
 
 ---
 
-##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.repository_uri\\"></a>
+##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_uri\\"></a>
 
 - *Type:* \`str\`
 
@@ -4081,7 +4081,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
                                          tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_catalog_data\\"></a>
+##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_catalog_data\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -4091,7 +4091,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -4101,7 +4101,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
 
 ---
 
-##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -4111,7 +4111,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -4135,7 +4135,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.CfnRegistryPolicyProps(policy_text: typing.Any)
 \`\`\`
 
-##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.policy_text\\"></a>
+##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.property.policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -4159,7 +4159,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.CfnReplicationConfigurationProps(replication_configuration: typing.Union[IResolvable, ReplicationConfigurationProperty])
 \`\`\`
 
-##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.replication_configuration\\"></a>
+##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.property.replication_configuration\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -4189,7 +4189,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
                                    tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.encryption_configuration\\"></a>
+##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.encryption_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -4199,7 +4199,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.image_scanning_configuration\\"></a>
+##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.image_scanning_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -4209,7 +4209,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.image_tag_mutability\\"></a>
 
 - *Type:* \`str\`
 
@@ -4219,7 +4219,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.lifecycle_policy\\"></a>
+##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.lifecycle_policy\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
@@ -4229,7 +4229,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -4239,7 +4239,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -4249,7 +4249,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -4272,7 +4272,7 @@ aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty(lifecycle_policy_text: str
                                                       registry_id: str = None)
 \`\`\`
 
-##### \`lifecycle_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.lifecycle_policy_text\\"></a>
+##### \`lifecycle_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.property.lifecycle_policy_text\\"></a>
 
 - *Type:* \`str\`
 
@@ -4282,7 +4282,7 @@ aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty(lifecycle_policy_text: str
 
 ---
 
-##### \`registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.registry_id\\"></a>
+##### \`registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.property.registry_id\\"></a>
 
 - *Type:* \`str\`
 
@@ -4309,7 +4309,7 @@ aws_cdk.aws_ecr.LifecycleRule(description: str = None,
                               tag_status: TagStatus = None)
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -4318,7 +4318,7 @@ Describes the purpose of the rule.
 
 ---
 
-##### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.max_image_age\\"></a>
+##### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.max_image_age\\"></a>
 
 - *Type:* [\`aws_cdk.core.Duration\`](#aws_cdk.core.Duration)
 
@@ -4328,7 +4328,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-##### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.max_image_count\\"></a>
+##### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.max_image_count\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -4338,7 +4338,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-##### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.rule_priority\\"></a>
+##### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.rule_priority\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* Automatically assigned
@@ -4356,7 +4356,7 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
-##### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.tag_prefix_list\\"></a>
+##### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.tag_prefix_list\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -4366,7 +4366,7 @@ Only if tagStatus == TagStatus.Tagged
 
 ---
 
-##### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.tag_status\\"></a>
+##### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.tag_status\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ecr.TagStatus\`](#aws_cdk.aws_ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -4394,7 +4394,7 @@ aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions(description: str = None,
                                                image_tag: str = None)
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -4403,7 +4403,7 @@ A description of the rule's purpose.
 
 ---
 
-##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.event_pattern\\"></a>
+##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -4418,7 +4418,7 @@ on top of that filtering.
 
 ---
 
-##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.rule_name\\"></a>
+##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -4427,7 +4427,7 @@ A name for the rule.
 
 ---
 
-##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.target\\"></a>
+##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -4436,7 +4436,7 @@ The target to register for the event.
 
 ---
 
-##### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.image_tag\\"></a>
+##### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.image_tag\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -4461,7 +4461,7 @@ aws_cdk.aws_ecr.OnImageScanCompletedOptions(description: str = None,
                                             image_tags: typing.List[str] = None)
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -4470,7 +4470,7 @@ A description of the rule's purpose.
 
 ---
 
-##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.event_pattern\\"></a>
+##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -4485,7 +4485,7 @@ on top of that filtering.
 
 ---
 
-##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.rule_name\\"></a>
+##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -4494,7 +4494,7 @@ A name for the rule.
 
 ---
 
-##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.target\\"></a>
+##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -4503,7 +4503,7 @@ The target to register for the event.
 
 ---
 
-##### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.image_tags\\"></a>
+##### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.image_tags\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -4526,7 +4526,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty(rules: typing.Union[IResolvable, typing.List[typing.Union[IResolvable, ReplicationRuleProperty]]])
 \`\`\`
 
-##### \`rules\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.rules\\"></a>
+##### \`rules\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), typing.List[typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty)]]]
 
@@ -4549,7 +4549,7 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty(regio
                                                                            registry_id: str)
 \`\`\`
 
-##### \`region\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.region\\"></a>
+##### \`region\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
 - *Type:* \`str\`
 
@@ -4559,7 +4559,7 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty(regio
 
 ---
 
-##### \`registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.registry_id\\"></a>
+##### \`registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registry_id\\"></a>
 
 - *Type:* \`str\`
 
@@ -4581,7 +4581,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty(destinations: typing.Union[IResolvable, typing.List[typing.Union[IResolvable, ReplicationDestinationProperty]]])
 \`\`\`
 
-##### \`destinations\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty.destinations\\"></a>
+##### \`destinations\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), typing.List[typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)]]]
 
@@ -4602,13 +4602,13 @@ aws_cdk.aws_ecr.RepositoryAttributes(repository_arn: str,
                                      repository_name: str)
 \`\`\`
 
-##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.repository_arn\\"></a>
+##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.repository_name\\"></a>
+##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -4629,7 +4629,7 @@ aws_cdk.aws_ecr.RepositoryProps(image_scan_on_push: bool = None,
                                 repository_name: str = None)
 \`\`\`
 
-##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.image_scan_on_push\\"></a>
+##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.image_scan_on_push\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -4638,7 +4638,7 @@ Enable the scan on push when creating the repository.
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.image_tag_mutability\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ecr.TagMutability\`](#aws_cdk.aws_ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -4649,7 +4649,7 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ---
 
-##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.lifecycle_registry_id\\"></a>
+##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.lifecycle_registry_id\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The default registry is assumed.
@@ -4660,7 +4660,7 @@ The AWS account ID associated with the registry that contains the repository.
 
 ---
 
-##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.lifecycle_rules\\"></a>
+##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.lifecycle_rules\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ecr.LifecycleRule\`](#aws_cdk.aws_ecr.LifecycleRule)]
 - *Default:* No life cycle rules
@@ -4669,7 +4669,7 @@ Life cycle rules to apply to this registry.
 
 ---
 
-##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.removal_policy\\"></a>
+##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.removal_policy\\"></a>
 
 - *Type:* [\`aws_cdk.core.RemovalPolicy\`](#aws_cdk.core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
@@ -4678,7 +4678,7 @@ Determine what happens to the repository when the resource/stack is deleted.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name.
@@ -4706,7 +4706,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.AuthorizationToken.grant_read(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -4731,7 +4731,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.PublicGalleryAuthorizationToken.grant_read(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.PublicGalleryAuthorizationToken.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.PublicGalleryAuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -4757,7 +4757,7 @@ Represents an ECR repository.
 def add_to_resource_policy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.statement\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.PolicyStatement\`](#aws_cdk.aws_iam.PolicyStatement)
 
@@ -4770,13 +4770,13 @@ def grant(grantee: IGrantable,
           actions: str)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
 ---
 
-###### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.actions\\"></a>
+###### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.actions\\"></a>
 
 - *Type:* \`str\`
 
@@ -4788,7 +4788,7 @@ def grant(grantee: IGrantable,
 def grant_pull(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -4800,7 +4800,7 @@ def grant_pull(grantee: IGrantable)
 def grant_pull_push(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -4816,7 +4816,7 @@ def on_cloud_trail_event(id: str,
                          target: IRuleTarget = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -4824,7 +4824,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -4833,7 +4833,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -4848,7 +4848,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -4857,7 +4857,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -4877,7 +4877,7 @@ def on_cloud_trail_image_pushed(id: str,
                                 image_tag: str = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -4885,7 +4885,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -4894,7 +4894,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -4909,7 +4909,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -4918,7 +4918,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -4927,7 +4927,7 @@ The target to register for the event.
 
 ---
 
-###### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.image_tag\\"></a>
+###### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.image_tag\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -4946,13 +4946,13 @@ def on_event(id: str,
              target: IRuleTarget = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -4961,7 +4961,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -4976,7 +4976,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -4985,7 +4985,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -5005,7 +5005,7 @@ def on_image_scan_completed(id: str,
                             image_tags: typing.List[str] = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -5013,7 +5013,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -5022,7 +5022,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -5037,7 +5037,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -5046,7 +5046,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -5055,7 +5055,7 @@ The target to register for the event.
 
 ---
 
-###### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.image_tags\\"></a>
+###### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.image_tags\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -5072,7 +5072,7 @@ Leave it undefined to watch the full repository.
 def repository_uri_for_digest(digest: str = None)
 \`\`\`
 
-###### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.digest\\"></a>
+###### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.digest\\"></a>
 
 - *Type:* \`str\`
 
@@ -5086,7 +5086,7 @@ Image digest to use (tools usually default to the image with the \\"latest\\" ta
 def repository_uri_for_tag(tag: str = None)
 \`\`\`
 
-###### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.tag\\"></a>
+###### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.tag\\"></a>
 
 - *Type:* \`str\`
 
@@ -5096,7 +5096,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.node\\"></a>
+##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.node\\"></a>
 
 - *Type:* [\`aws_cdk.core.ConstructNode\`](#aws_cdk.core.ConstructNode)
 
@@ -5104,7 +5104,7 @@ The construct tree node for this construct.
 
 ---
 
-##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.env\\"></a>
+##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.env\\"></a>
 
 - *Type:* [\`aws_cdk.core.ResourceEnvironment\`](#aws_cdk.core.ResourceEnvironment)
 
@@ -5119,7 +5119,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.stack\\"></a>
+##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.stack\\"></a>
 
 - *Type:* [\`aws_cdk.core.Stack\`](#aws_cdk.core.Stack)
 
@@ -5127,7 +5127,7 @@ The stack in which this resource is defined.
 
 ---
 
-##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.repository_arn\\"></a>
+##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -5135,7 +5135,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.repository_name\\"></a>
+##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -5143,7 +5143,7 @@ The name of the repository.
 
 ---
 
-##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.repository_uri\\"></a>
+##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_uri\\"></a>
 
 - *Type:* \`str\`
 
@@ -5327,7 +5327,7 @@ aws_cdk.aws_ecr.CfnPublicRepository(scope: Construct,
                                     tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#aws_cdk.core.Construct)
 
@@ -5335,7 +5335,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -5343,7 +5343,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_catalog_data\\"></a>
+##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.repository_catalog_data\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -5353,7 +5353,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -5363,7 +5363,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -5373,7 +5373,7 @@ scoped id of the resource.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -5391,7 +5391,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#aws_cdk.core.TreeInspector)
 
@@ -5402,13 +5402,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.attr_arn\\"></a>
+##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.attr_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.tags\\"></a>
 
 - *Type:* [\`aws_cdk.core.TagManager\`](#aws_cdk.core.TagManager)
 
@@ -5418,7 +5418,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_catalog_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.repository_catalog_data\\"></a>
+##### \`repository_catalog_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_catalog_data\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -5428,7 +5428,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -5438,7 +5438,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -5450,7 +5450,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -5476,7 +5476,7 @@ aws_cdk.aws_ecr.CfnRegistryPolicy(scope: Construct,
                                   policy_text: typing.Any)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#aws_cdk.core.Construct)
 
@@ -5484,7 +5484,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -5492,7 +5492,7 @@ scoped id of the resource.
 
 ---
 
-##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.policy_text\\"></a>
+##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.parameter.policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -5510,7 +5510,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#aws_cdk.core.TreeInspector)
 
@@ -5521,13 +5521,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.attr_registry_id\\"></a>
+##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.attr_registry_id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.policy_text\\"></a>
+##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -5539,7 +5539,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -5565,7 +5565,7 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration(scope: Construct,
                                             replication_configuration: typing.Union[IResolvable, ReplicationConfigurationProperty])
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#aws_cdk.core.Construct)
 
@@ -5573,7 +5573,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -5581,7 +5581,7 @@ scoped id of the resource.
 
 ---
 
-##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.replication_configuration\\"></a>
+##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.parameter.replication_configuration\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -5599,7 +5599,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#aws_cdk.core.TreeInspector)
 
@@ -5610,13 +5610,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.attr_registry_id\\"></a>
+##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.attr_registry_id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.replication_configuration\\"></a>
+##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.replication_configuration\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -5628,7 +5628,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -5660,7 +5660,7 @@ aws_cdk.aws_ecr.CfnRepository(scope: Construct,
                               tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#aws_cdk.core.Construct)
 
@@ -5668,7 +5668,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -5676,7 +5676,7 @@ scoped id of the resource.
 
 ---
 
-##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.encryption_configuration\\"></a>
+##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.encryption_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -5686,7 +5686,7 @@ scoped id of the resource.
 
 ---
 
-##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.image_scanning_configuration\\"></a>
+##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.image_scanning_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -5696,7 +5696,7 @@ scoped id of the resource.
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.image_tag_mutability\\"></a>
 
 - *Type:* \`str\`
 
@@ -5706,7 +5706,7 @@ scoped id of the resource.
 
 ---
 
-##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.lifecycle_policy\\"></a>
+##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.lifecycle_policy\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
@@ -5716,7 +5716,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -5726,7 +5726,7 @@ scoped id of the resource.
 
 ---
 
-##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -5736,7 +5736,7 @@ scoped id of the resource.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.parameter.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -5754,7 +5754,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#aws_cdk.core.TreeInspector)
 
@@ -5765,19 +5765,19 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.attr_arn\\"></a>
+##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.attr_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`attr_repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.attr_repository_uri\\"></a>
+##### \`attr_repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.attr_repository_uri\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.tags\\"></a>
 
 - *Type:* [\`aws_cdk.core.TagManager\`](#aws_cdk.core.TagManager)
 
@@ -5787,7 +5787,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`encryption_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.encryption_configuration\\"></a>
+##### \`encryption_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.encryption_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -5797,7 +5797,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`image_scanning_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.image_scanning_configuration\\"></a>
+##### \`image_scanning_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.image_scanning_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -5807,7 +5807,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -5817,7 +5817,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.image_tag_mutability\\"></a>
 
 - *Type:* \`str\`
 
@@ -5827,7 +5827,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.lifecycle_policy\\"></a>
+##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.lifecycle_policy\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
@@ -5837,7 +5837,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -5849,7 +5849,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRepository.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -5876,19 +5876,19 @@ aws_cdk.aws_ecr.Repository(scope: Construct,
                            repository_name: str = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.image_scan_on_push\\"></a>
+##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.image_scan_on_push\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -5897,7 +5897,7 @@ Enable the scan on push when creating the repository.
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.image_tag_mutability\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ecr.TagMutability\`](#aws_cdk.aws_ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -5908,7 +5908,7 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ---
 
-##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.lifecycle_registry_id\\"></a>
+##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.lifecycle_registry_id\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The default registry is assumed.
@@ -5919,7 +5919,7 @@ The AWS account ID associated with the registry that contains the repository.
 
 ---
 
-##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.lifecycle_rules\\"></a>
+##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.lifecycle_rules\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ecr.LifecycleRule\`](#aws_cdk.aws_ecr.LifecycleRule)]
 - *Default:* No life cycle rules
@@ -5928,7 +5928,7 @@ Life cycle rules to apply to this registry.
 
 ---
 
-##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.removal_policy\\"></a>
+##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.removal_policy\\"></a>
 
 - *Type:* [\`aws_cdk.core.RemovalPolicy\`](#aws_cdk.core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
@@ -5937,7 +5937,7 @@ Determine what happens to the repository when the resource/stack is deleted.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name.
@@ -5959,7 +5959,7 @@ def add_lifecycle_rule(description: str = None,
                        tag_status: TagStatus = None)
 \`\`\`
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -5968,7 +5968,7 @@ Describes the purpose of the rule.
 
 ---
 
-###### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.max_image_age\\"></a>
+###### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.max_image_age\\"></a>
 
 - *Type:* [\`aws_cdk.core.Duration\`](#aws_cdk.core.Duration)
 
@@ -5978,7 +5978,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-###### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.max_image_count\\"></a>
+###### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.max_image_count\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -5988,7 +5988,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-###### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.rule_priority\\"></a>
+###### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.rule_priority\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* Automatically assigned
@@ -6006,7 +6006,7 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
-###### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.tag_prefix_list\\"></a>
+###### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.tag_prefix_list\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -6016,7 +6016,7 @@ Only if tagStatus == TagStatus.Tagged
 
 ---
 
-###### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.tag_status\\"></a>
+###### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.parameter.tag_status\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ecr.TagStatus\`](#aws_cdk.aws_ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -6034,7 +6034,7 @@ have the highest rulePriority.
 def add_to_resource_policy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.statement\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.PolicyStatement\`](#aws_cdk.aws_iam.PolicyStatement)
 
@@ -6052,19 +6052,19 @@ aws_cdk.aws_ecr.Repository.arn_for_local_repository(repository_name: str,
                                                     account: str = None)
 \`\`\`
 
-###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_name\\"></a>
+###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.IConstruct\`](#constructs.IConstruct)
 
 ---
 
-###### \`account\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.Repository.account\\"></a>
+###### \`account\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.account\\"></a>
 
 - *Type:* \`str\`
 
@@ -6080,19 +6080,19 @@ aws_cdk.aws_ecr.Repository.from_repository_arn(scope: Construct,
                                                repository_arn: str)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_arn\\"></a>
+###### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -6109,25 +6109,25 @@ aws_cdk.aws_ecr.Repository.from_repository_attributes(scope: Construct,
                                                       repository_name: str)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.repository_arn\\"></a>
+###### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.parameter.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.repository_name\\"></a>
+###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -6143,19 +6143,19 @@ aws_cdk.aws_ecr.Repository.from_repository_name(scope: Construct,
                                                 repository_name: str)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_name\\"></a>
+###### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -6163,7 +6163,7 @@ aws_cdk.aws_ecr.Repository.from_repository_name(scope: Construct,
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_arn\\"></a>
+##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -6171,7 +6171,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.repository_name\\"></a>
+##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -6201,19 +6201,19 @@ aws_cdk.aws_ecr.RepositoryBase(scope: Construct,
                                region: str = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`account\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.account\\"></a>
+##### \`account\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.parameter.account\\"></a>
 
 - *Type:* \`str\`
 - *Default:* the resource is in the same account as the stack it belongs to
@@ -6222,7 +6222,7 @@ The AWS account ID this resource belongs to.
 
 ---
 
-##### \`environment_from_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.environment_from_arn\\"></a>
+##### \`environment_from_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.parameter.environment_from_arn\\"></a>
 
 - *Type:* \`str\`
 - *Default:* take environment from \`account\`, \`region\` parameters, or use Stack environment.
@@ -6236,7 +6236,7 @@ Cannot be supplied together with either \`account\` or \`region\`.
 
 ---
 
-##### \`physical_name\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.physical_name\\"></a>
+##### \`physical_name\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.parameter.physical_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The physical name will be allocated by CloudFormation at deployment time
@@ -6251,7 +6251,7 @@ The value passed in by users to the physical name prop of the resource.
 
 ---
 
-##### \`region\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.region\\"></a>
+##### \`region\`<sup>Optional</sup> <a name=\\"aws_cdk.core.ResourceProps.parameter.region\\"></a>
 
 - *Type:* \`str\`
 - *Default:* the resource is in the same region as the stack it belongs to
@@ -6268,7 +6268,7 @@ The AWS region this resource belongs to.
 def add_to_resource_policy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.statement\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.PolicyStatement\`](#aws_cdk.aws_iam.PolicyStatement)
 
@@ -6281,13 +6281,13 @@ def grant(grantee: IGrantable,
           actions: str)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
 ---
 
-###### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.actions\\"></a>
+###### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.actions\\"></a>
 
 - *Type:* \`str\`
 
@@ -6299,7 +6299,7 @@ def grant(grantee: IGrantable,
 def grant_pull(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -6311,7 +6311,7 @@ def grant_pull(grantee: IGrantable)
 def grant_pull_push(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -6327,7 +6327,7 @@ def on_cloud_trail_event(id: str,
                          target: IRuleTarget = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -6335,7 +6335,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -6344,7 +6344,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -6359,7 +6359,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -6368,7 +6368,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -6388,7 +6388,7 @@ def on_cloud_trail_image_pushed(id: str,
                                 image_tag: str = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -6396,7 +6396,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -6405,7 +6405,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -6420,7 +6420,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -6429,7 +6429,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -6438,7 +6438,7 @@ The target to register for the event.
 
 ---
 
-###### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.image_tag\\"></a>
+###### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.image_tag\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -6457,13 +6457,13 @@ def on_event(id: str,
              target: IRuleTarget = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -6472,7 +6472,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -6487,7 +6487,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -6496,7 +6496,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -6516,7 +6516,7 @@ def on_image_scan_completed(id: str,
                             image_tags: typing.List[str] = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -6524,7 +6524,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -6533,7 +6533,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -6548,7 +6548,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -6557,7 +6557,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -6566,7 +6566,7 @@ The target to register for the event.
 
 ---
 
-###### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.image_tags\\"></a>
+###### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.image_tags\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -6583,7 +6583,7 @@ Leave it undefined to watch the full repository.
 def repository_uri_for_digest(digest: str = None)
 \`\`\`
 
-###### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.digest\\"></a>
+###### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.digest\\"></a>
 
 - *Type:* \`str\`
 
@@ -6597,7 +6597,7 @@ Optional image digest.
 def repository_uri_for_tag(tag: str = None)
 \`\`\`
 
-###### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.tag\\"></a>
+###### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.parameter.tag\\"></a>
 
 - *Type:* \`str\`
 
@@ -6608,7 +6608,7 @@ Optional image tag.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.repository_arn\\"></a>
+##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -6616,7 +6616,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.repository_name\\"></a>
+##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -6624,7 +6624,7 @@ The name of the repository.
 
 ---
 
-##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.repository_uri\\"></a>
+##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_uri\\"></a>
 
 - *Type:* \`str\`
 
@@ -6654,7 +6654,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
                                          tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_catalog_data\\"></a>
+##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_catalog_data\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -6664,7 +6664,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -6674,7 +6674,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
 
 ---
 
-##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -6684,7 +6684,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -6708,7 +6708,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.CfnRegistryPolicyProps(policy_text: typing.Any)
 \`\`\`
 
-##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.policy_text\\"></a>
+##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.property.policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -6732,7 +6732,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.CfnReplicationConfigurationProps(replication_configuration: typing.Union[IResolvable, ReplicationConfigurationProperty])
 \`\`\`
 
-##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.replication_configuration\\"></a>
+##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.property.replication_configuration\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -6762,7 +6762,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
                                    tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.encryption_configuration\\"></a>
+##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.encryption_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -6772,7 +6772,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.image_scanning_configuration\\"></a>
+##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.image_scanning_configuration\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -6782,7 +6782,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.image_tag_mutability\\"></a>
 
 - *Type:* \`str\`
 
@@ -6792,7 +6792,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.lifecycle_policy\\"></a>
+##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.lifecycle_policy\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
@@ -6802,7 +6802,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -6812,7 +6812,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.repository_policy_text\\"></a>
+##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -6822,7 +6822,7 @@ aws_cdk.aws_ecr.CfnRepositoryProps(encryption_configuration: typing.Any = None,
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -6845,7 +6845,7 @@ aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty(lifecycle_policy_text: str
                                                       registry_id: str = None)
 \`\`\`
 
-##### \`lifecycle_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.lifecycle_policy_text\\"></a>
+##### \`lifecycle_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.property.lifecycle_policy_text\\"></a>
 
 - *Type:* \`str\`
 
@@ -6855,7 +6855,7 @@ aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty(lifecycle_policy_text: str
 
 ---
 
-##### \`registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.registry_id\\"></a>
+##### \`registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.property.registry_id\\"></a>
 
 - *Type:* \`str\`
 
@@ -6882,7 +6882,7 @@ aws_cdk.aws_ecr.LifecycleRule(description: str = None,
                               tag_status: TagStatus = None)
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -6891,7 +6891,7 @@ Describes the purpose of the rule.
 
 ---
 
-##### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.max_image_age\\"></a>
+##### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.max_image_age\\"></a>
 
 - *Type:* [\`aws_cdk.core.Duration\`](#aws_cdk.core.Duration)
 
@@ -6901,7 +6901,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-##### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.max_image_count\\"></a>
+##### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.max_image_count\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -6911,7 +6911,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-##### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.rule_priority\\"></a>
+##### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.rule_priority\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* Automatically assigned
@@ -6929,7 +6929,7 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
-##### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.tag_prefix_list\\"></a>
+##### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.tag_prefix_list\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -6939,7 +6939,7 @@ Only if tagStatus == TagStatus.Tagged
 
 ---
 
-##### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.tag_status\\"></a>
+##### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.tag_status\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ecr.TagStatus\`](#aws_cdk.aws_ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -6967,7 +6967,7 @@ aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions(description: str = None,
                                                image_tag: str = None)
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -6976,7 +6976,7 @@ A description of the rule's purpose.
 
 ---
 
-##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.event_pattern\\"></a>
+##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -6991,7 +6991,7 @@ on top of that filtering.
 
 ---
 
-##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.rule_name\\"></a>
+##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -7000,7 +7000,7 @@ A name for the rule.
 
 ---
 
-##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.target\\"></a>
+##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -7009,7 +7009,7 @@ The target to register for the event.
 
 ---
 
-##### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.image_tag\\"></a>
+##### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.image_tag\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -7034,7 +7034,7 @@ aws_cdk.aws_ecr.OnImageScanCompletedOptions(description: str = None,
                                             image_tags: typing.List[str] = None)
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -7043,7 +7043,7 @@ A description of the rule's purpose.
 
 ---
 
-##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.event_pattern\\"></a>
+##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -7058,7 +7058,7 @@ on top of that filtering.
 
 ---
 
-##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.rule_name\\"></a>
+##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -7067,7 +7067,7 @@ A name for the rule.
 
 ---
 
-##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.target\\"></a>
+##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -7076,7 +7076,7 @@ The target to register for the event.
 
 ---
 
-##### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.image_tags\\"></a>
+##### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.image_tags\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -7099,7 +7099,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty(rules: typing.Union[IResolvable, typing.List[typing.Union[IResolvable, ReplicationRuleProperty]]])
 \`\`\`
 
-##### \`rules\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.rules\\"></a>
+##### \`rules\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), typing.List[typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty)]]]
 
@@ -7122,7 +7122,7 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty(regio
                                                                            registry_id: str)
 \`\`\`
 
-##### \`region\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.region\\"></a>
+##### \`region\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
 - *Type:* \`str\`
 
@@ -7132,7 +7132,7 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty(regio
 
 ---
 
-##### \`registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.registry_id\\"></a>
+##### \`registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registry_id\\"></a>
 
 - *Type:* \`str\`
 
@@ -7154,7 +7154,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty(destinations: typing.Union[IResolvable, typing.List[typing.Union[IResolvable, ReplicationDestinationProperty]]])
 \`\`\`
 
-##### \`destinations\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty.destinations\\"></a>
+##### \`destinations\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), typing.List[typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)]]]
 
@@ -7175,13 +7175,13 @@ aws_cdk.aws_ecr.RepositoryAttributes(repository_arn: str,
                                      repository_name: str)
 \`\`\`
 
-##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.repository_arn\\"></a>
+##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.repository_name\\"></a>
+##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -7202,7 +7202,7 @@ aws_cdk.aws_ecr.RepositoryProps(image_scan_on_push: bool = None,
                                 repository_name: str = None)
 \`\`\`
 
-##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.image_scan_on_push\\"></a>
+##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.image_scan_on_push\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -7211,7 +7211,7 @@ Enable the scan on push when creating the repository.
 
 ---
 
-##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.image_tag_mutability\\"></a>
+##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.image_tag_mutability\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ecr.TagMutability\`](#aws_cdk.aws_ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -7222,7 +7222,7 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ---
 
-##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.lifecycle_registry_id\\"></a>
+##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.lifecycle_registry_id\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The default registry is assumed.
@@ -7233,7 +7233,7 @@ The AWS account ID associated with the registry that contains the repository.
 
 ---
 
-##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.lifecycle_rules\\"></a>
+##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.lifecycle_rules\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ecr.LifecycleRule\`](#aws_cdk.aws_ecr.LifecycleRule)]
 - *Default:* No life cycle rules
@@ -7242,7 +7242,7 @@ Life cycle rules to apply to this registry.
 
 ---
 
-##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.removal_policy\\"></a>
+##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.removal_policy\\"></a>
 
 - *Type:* [\`aws_cdk.core.RemovalPolicy\`](#aws_cdk.core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
@@ -7251,7 +7251,7 @@ Determine what happens to the repository when the resource/stack is deleted.
 
 ---
 
-##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.repository_name\\"></a>
+##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name.
@@ -7279,7 +7279,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.AuthorizationToken.grant_read(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -7304,7 +7304,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.PublicGalleryAuthorizationToken.grant_read(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.PublicGalleryAuthorizationToken.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.PublicGalleryAuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -7330,7 +7330,7 @@ Represents an ECR repository.
 def add_to_resource_policy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.statement\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.PolicyStatement\`](#aws_cdk.aws_iam.PolicyStatement)
 
@@ -7343,13 +7343,13 @@ def grant(grantee: IGrantable,
           actions: str)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
 ---
 
-###### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.actions\\"></a>
+###### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.actions\\"></a>
 
 - *Type:* \`str\`
 
@@ -7361,7 +7361,7 @@ def grant(grantee: IGrantable,
 def grant_pull(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -7373,7 +7373,7 @@ def grant_pull(grantee: IGrantable)
 def grant_pull_push(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -7389,7 +7389,7 @@ def on_cloud_trail_event(id: str,
                          target: IRuleTarget = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -7397,7 +7397,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -7406,7 +7406,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -7421,7 +7421,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -7430,7 +7430,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -7450,7 +7450,7 @@ def on_cloud_trail_image_pushed(id: str,
                                 image_tag: str = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -7458,7 +7458,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -7467,7 +7467,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -7482,7 +7482,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -7491,7 +7491,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -7500,7 +7500,7 @@ The target to register for the event.
 
 ---
 
-###### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.image_tag\\"></a>
+###### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.image_tag\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -7519,13 +7519,13 @@ def on_event(id: str,
              target: IRuleTarget = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -7534,7 +7534,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -7549,7 +7549,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -7558,7 +7558,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -7578,7 +7578,7 @@ def on_image_scan_completed(id: str,
                             image_tags: typing.List[str] = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -7586,7 +7586,7 @@ The id of the rule.
 
 ---
 
-###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.description\\"></a>
+###### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -7595,7 +7595,7 @@ A description of the rule's purpose.
 
 ---
 
-###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.event_pattern\\"></a>
+###### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -7610,7 +7610,7 @@ on top of that filtering.
 
 ---
 
-###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.rule_name\\"></a>
+###### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -7619,7 +7619,7 @@ A name for the rule.
 
 ---
 
-###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.target\\"></a>
+###### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -7628,7 +7628,7 @@ The target to register for the event.
 
 ---
 
-###### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.image_tags\\"></a>
+###### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.image_tags\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -7645,7 +7645,7 @@ Leave it undefined to watch the full repository.
 def repository_uri_for_digest(digest: str = None)
 \`\`\`
 
-###### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.digest\\"></a>
+###### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.digest\\"></a>
 
 - *Type:* \`str\`
 
@@ -7659,7 +7659,7 @@ Image digest to use (tools usually default to the image with the \\"latest\\" ta
 def repository_uri_for_tag(tag: str = None)
 \`\`\`
 
-###### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.tag\\"></a>
+###### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.tag\\"></a>
 
 - *Type:* \`str\`
 
@@ -7669,7 +7669,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.node\\"></a>
+##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.node\\"></a>
 
 - *Type:* [\`aws_cdk.core.ConstructNode\`](#aws_cdk.core.ConstructNode)
 
@@ -7677,7 +7677,7 @@ The construct tree node for this construct.
 
 ---
 
-##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.env\\"></a>
+##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.env\\"></a>
 
 - *Type:* [\`aws_cdk.core.ResourceEnvironment\`](#aws_cdk.core.ResourceEnvironment)
 
@@ -7692,7 +7692,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.stack\\"></a>
+##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.stack\\"></a>
 
 - *Type:* [\`aws_cdk.core.Stack\`](#aws_cdk.core.Stack)
 
@@ -7700,7 +7700,7 @@ The stack in which this resource is defined.
 
 ---
 
-##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.repository_arn\\"></a>
+##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -7708,7 +7708,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.repository_name\\"></a>
+##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -7716,7 +7716,7 @@ The name of the repository.
 
 ---
 
-##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.repository_uri\\"></a>
+##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_uri\\"></a>
 
 - *Type:* \`str\`
 
@@ -9005,19 +9005,19 @@ aws_eks.AwsAuth(scope: Construct,
                 cluster: Cluster)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthProps.parameter.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.Cluster\`](#aws_cdk.aws_eks.Cluster)
 
@@ -9035,7 +9035,7 @@ The EKS cluster to apply this configuration to.
 def add_account(account_id: str)
 \`\`\`
 
-###### \`account_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.account_id\\"></a>
+###### \`account_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.parameter.account_id\\"></a>
 
 - *Type:* \`str\`
 
@@ -9050,7 +9050,7 @@ def add_masters_role(role: IRole,
                      username: str = None)
 \`\`\`
 
-###### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.role\\"></a>
+###### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.parameter.role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
@@ -9058,7 +9058,7 @@ The IAM role to add.
 
 ---
 
-###### \`username\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.username\\"></a>
+###### \`username\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.parameter.username\\"></a>
 
 - *Type:* \`str\`
 
@@ -9074,7 +9074,7 @@ def add_role_mapping(role: IRole,
                      username: str = None)
 \`\`\`
 
-###### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.role\\"></a>
+###### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.parameter.role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
@@ -9082,7 +9082,7 @@ The IAM role to map.
 
 ---
 
-###### \`groups\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.groups\\"></a>
+###### \`groups\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.parameter.groups\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -9092,7 +9092,7 @@ A list of groups within Kubernetes to which the role is mapped.
 
 ---
 
-###### \`username\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.username\\"></a>
+###### \`username\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.parameter.username\\"></a>
 
 - *Type:* \`str\`
 - *Default:* By default, the user name is the ARN of the IAM role.
@@ -9109,7 +9109,7 @@ def add_user_mapping(user: IUser,
                      username: str = None)
 \`\`\`
 
-###### \`user\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.user\\"></a>
+###### \`user\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuth.parameter.user\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IUser\`](#aws_cdk.aws_iam.IUser)
 
@@ -9117,7 +9117,7 @@ The IAM user to map.
 
 ---
 
-###### \`groups\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.groups\\"></a>
+###### \`groups\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.parameter.groups\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -9127,7 +9127,7 @@ A list of groups within Kubernetes to which the role is mapped.
 
 ---
 
-###### \`username\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.username\\"></a>
+###### \`username\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.parameter.username\\"></a>
 
 - *Type:* \`str\`
 - *Default:* By default, the user name is the ARN of the IAM role.
@@ -9162,7 +9162,7 @@ aws_eks.CfnAddon(scope: Construct,
                  tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -9170,7 +9170,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -9178,7 +9178,7 @@ scoped id of the resource.
 
 ---
 
-##### \`addon_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.addon_name\\"></a>
+##### \`addon_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.parameter.addon_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -9188,7 +9188,7 @@ scoped id of the resource.
 
 ---
 
-##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.parameter.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -9198,7 +9198,7 @@ scoped id of the resource.
 
 ---
 
-##### \`addon_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.addon_version\\"></a>
+##### \`addon_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.parameter.addon_version\\"></a>
 
 - *Type:* \`str\`
 
@@ -9208,7 +9208,7 @@ scoped id of the resource.
 
 ---
 
-##### \`resolve_conflicts\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.resolve_conflicts\\"></a>
+##### \`resolve_conflicts\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.parameter.resolve_conflicts\\"></a>
 
 - *Type:* \`str\`
 
@@ -9218,7 +9218,7 @@ scoped id of the resource.
 
 ---
 
-##### \`service_account_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.service_account_role_arn\\"></a>
+##### \`service_account_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.parameter.service_account_role_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -9228,7 +9228,7 @@ scoped id of the resource.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.parameter.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.CfnTag\`](#aws_cdk.CfnTag)]
 
@@ -9246,7 +9246,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.TreeInspector\`](#aws_cdk.TreeInspector)
 
@@ -9257,13 +9257,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.attr_arn\\"></a>
+##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.attr_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.tags\\"></a>
 
 - *Type:* [\`aws_cdk.TagManager\`](#aws_cdk.TagManager)
 
@@ -9273,7 +9273,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`addon_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.addon_name\\"></a>
+##### \`addon_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.addon_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -9283,7 +9283,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -9293,7 +9293,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`addon_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.addon_version\\"></a>
+##### \`addon_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.addon_version\\"></a>
 
 - *Type:* \`str\`
 
@@ -9303,7 +9303,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`resolve_conflicts\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.resolve_conflicts\\"></a>
+##### \`resolve_conflicts\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.resolve_conflicts\\"></a>
 
 - *Type:* \`str\`
 
@@ -9313,7 +9313,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`service_account_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.service_account_role_arn\\"></a>
+##### \`service_account_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.service_account_role_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -9325,7 +9325,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnAddon.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnAddon.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -9356,7 +9356,7 @@ aws_eks.CfnCluster(scope: Construct,
                    version: str = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -9364,7 +9364,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -9372,7 +9372,7 @@ scoped id of the resource.
 
 ---
 
-##### \`resources_vpc_config\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.resources_vpc_config\\"></a>
+##### \`resources_vpc_config\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.parameter.resources_vpc_config\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -9382,7 +9382,7 @@ scoped id of the resource.
 
 ---
 
-##### \`role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.role_arn\\"></a>
+##### \`role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.parameter.role_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -9392,7 +9392,7 @@ scoped id of the resource.
 
 ---
 
-##### \`encryption_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.encryption_config\\"></a>
+##### \`encryption_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.parameter.encryption_config\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
@@ -9402,7 +9402,7 @@ scoped id of the resource.
 
 ---
 
-##### \`kubernetes_network_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.kubernetes_network_config\\"></a>
+##### \`kubernetes_network_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.parameter.kubernetes_network_config\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -9412,7 +9412,7 @@ scoped id of the resource.
 
 ---
 
-##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.name\\"></a>
+##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.parameter.name\\"></a>
 
 - *Type:* \`str\`
 
@@ -9422,7 +9422,7 @@ scoped id of the resource.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.parameter.version\\"></a>
 
 - *Type:* \`str\`
 
@@ -9440,7 +9440,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.TreeInspector\`](#aws_cdk.TreeInspector)
 
@@ -9451,43 +9451,43 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.attr_arn\\"></a>
+##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.attr_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`attr_certificate_authority_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.attr_certificate_authority_data\\"></a>
+##### \`attr_certificate_authority_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.attr_certificate_authority_data\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`attr_cluster_security_group_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.attr_cluster_security_group_id\\"></a>
+##### \`attr_cluster_security_group_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.attr_cluster_security_group_id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`attr_encryption_config_key_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.attr_encryption_config_key_arn\\"></a>
+##### \`attr_encryption_config_key_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.attr_encryption_config_key_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`attr_endpoint\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.attr_endpoint\\"></a>
+##### \`attr_endpoint\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.attr_endpoint\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`attr_open_id_connect_issuer_url\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.attr_open_id_connect_issuer_url\\"></a>
+##### \`attr_open_id_connect_issuer_url\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.attr_open_id_connect_issuer_url\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`resources_vpc_config\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.resources_vpc_config\\"></a>
+##### \`resources_vpc_config\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.resources_vpc_config\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -9497,7 +9497,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.role_arn\\"></a>
+##### \`role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.role_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -9507,7 +9507,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`encryption_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.encryption_config\\"></a>
+##### \`encryption_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.encryption_config\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
@@ -9517,7 +9517,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`kubernetes_network_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.kubernetes_network_config\\"></a>
+##### \`kubernetes_network_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.kubernetes_network_config\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -9527,7 +9527,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.name\\"></a>
+##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.name\\"></a>
 
 - *Type:* \`str\`
 
@@ -9537,7 +9537,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.version\\"></a>
 
 - *Type:* \`str\`
 
@@ -9549,7 +9549,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnCluster.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnCluster.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -9580,7 +9580,7 @@ aws_eks.CfnFargateProfile(scope: Construct,
                           tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -9588,7 +9588,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -9596,7 +9596,7 @@ scoped id of the resource.
 
 ---
 
-##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.parameter.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -9606,7 +9606,7 @@ scoped id of the resource.
 
 ---
 
-##### \`pod_execution_role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.pod_execution_role_arn\\"></a>
+##### \`pod_execution_role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.parameter.pod_execution_role_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -9616,7 +9616,7 @@ scoped id of the resource.
 
 ---
 
-##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.selectors\\"></a>
+##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.parameter.selectors\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
@@ -9626,7 +9626,7 @@ scoped id of the resource.
 
 ---
 
-##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.fargate_profile_name\\"></a>
+##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.parameter.fargate_profile_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -9636,7 +9636,7 @@ scoped id of the resource.
 
 ---
 
-##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.subnets\\"></a>
+##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.parameter.subnets\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -9646,7 +9646,7 @@ scoped id of the resource.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.parameter.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.CfnTag\`](#aws_cdk.CfnTag)]
 
@@ -9664,7 +9664,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.TreeInspector\`](#aws_cdk.TreeInspector)
 
@@ -9675,13 +9675,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.attr_arn\\"></a>
+##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.attr_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.tags\\"></a>
 
 - *Type:* [\`aws_cdk.TagManager\`](#aws_cdk.TagManager)
 
@@ -9691,7 +9691,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -9701,7 +9701,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`pod_execution_role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.pod_execution_role_arn\\"></a>
+##### \`pod_execution_role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.pod_execution_role_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -9711,7 +9711,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.selectors\\"></a>
+##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.selectors\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
@@ -9721,7 +9721,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.fargate_profile_name\\"></a>
+##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.fargate_profile_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -9731,7 +9731,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.subnets\\"></a>
+##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.subnets\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -9743,7 +9743,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -9785,7 +9785,7 @@ aws_eks.CfnNodegroup(scope: Construct,
                      version: str = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -9793,7 +9793,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -9801,7 +9801,7 @@ scoped id of the resource.
 
 ---
 
-##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -9811,7 +9811,7 @@ scoped id of the resource.
 
 ---
 
-##### \`node_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.node_role\\"></a>
+##### \`node_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.node_role\\"></a>
 
 - *Type:* \`str\`
 
@@ -9821,7 +9821,7 @@ scoped id of the resource.
 
 ---
 
-##### \`subnets\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.subnets\\"></a>
+##### \`subnets\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.subnets\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -9831,7 +9831,7 @@ scoped id of the resource.
 
 ---
 
-##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.ami_type\\"></a>
+##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.ami_type\\"></a>
 
 - *Type:* \`str\`
 
@@ -9841,7 +9841,7 @@ scoped id of the resource.
 
 ---
 
-##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.capacity_type\\"></a>
+##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.capacity_type\\"></a>
 
 - *Type:* \`str\`
 
@@ -9851,7 +9851,7 @@ scoped id of the resource.
 
 ---
 
-##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.disk_size\\"></a>
+##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.disk_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -9861,7 +9861,7 @@ scoped id of the resource.
 
 ---
 
-##### \`force_update_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.force_update_enabled\\"></a>
+##### \`force_update_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.force_update_enabled\\"></a>
 
 - *Type:* typing.Union[\`bool\`, [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -9871,7 +9871,7 @@ scoped id of the resource.
 
 ---
 
-##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.instance_types\\"></a>
+##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.instance_types\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -9881,7 +9881,7 @@ scoped id of the resource.
 
 ---
 
-##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.labels\\"></a>
+##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.labels\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -9891,7 +9891,7 @@ scoped id of the resource.
 
 ---
 
-##### \`launch_template\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.launch_template\\"></a>
+##### \`launch_template\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.launch_template\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -9901,7 +9901,7 @@ scoped id of the resource.
 
 ---
 
-##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.nodegroup_name\\"></a>
+##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.nodegroup_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -9911,7 +9911,7 @@ scoped id of the resource.
 
 ---
 
-##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.release_version\\"></a>
+##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.release_version\\"></a>
 
 - *Type:* \`str\`
 
@@ -9921,7 +9921,7 @@ scoped id of the resource.
 
 ---
 
-##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.remote_access\\"></a>
+##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.remote_access\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -9931,7 +9931,7 @@ scoped id of the resource.
 
 ---
 
-##### \`scaling_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.scaling_config\\"></a>
+##### \`scaling_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.scaling_config\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -9941,7 +9941,7 @@ scoped id of the resource.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.tags\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -9951,7 +9951,7 @@ scoped id of the resource.
 
 ---
 
-##### \`taints\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.taints\\"></a>
+##### \`taints\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.taints\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.TaintProperty\`](#aws_cdk.aws_eks.CfnNodegroup.TaintProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
@@ -9961,7 +9961,7 @@ scoped id of the resource.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.parameter.version\\"></a>
 
 - *Type:* \`str\`
 
@@ -9979,7 +9979,7 @@ scoped id of the resource.
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.TreeInspector\`](#aws_cdk.TreeInspector)
 
@@ -9990,25 +9990,25 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.attr_arn\\"></a>
+##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.attr_arn\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`attr_cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.attr_cluster_name\\"></a>
+##### \`attr_cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.attr_cluster_name\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`attr_nodegroup_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.attr_nodegroup_name\\"></a>
+##### \`attr_nodegroup_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.attr_nodegroup_name\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.tags\\"></a>
 
 - *Type:* [\`aws_cdk.TagManager\`](#aws_cdk.TagManager)
 
@@ -10018,7 +10018,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -10028,7 +10028,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`labels\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.labels\\"></a>
+##### \`labels\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.labels\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -10038,7 +10038,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`node_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.node_role\\"></a>
+##### \`node_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.node_role\\"></a>
 
 - *Type:* \`str\`
 
@@ -10048,7 +10048,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`subnets\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.subnets\\"></a>
+##### \`subnets\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.subnets\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -10058,7 +10058,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.ami_type\\"></a>
+##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.ami_type\\"></a>
 
 - *Type:* \`str\`
 
@@ -10068,7 +10068,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.capacity_type\\"></a>
+##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.capacity_type\\"></a>
 
 - *Type:* \`str\`
 
@@ -10078,7 +10078,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.disk_size\\"></a>
+##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.disk_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -10088,7 +10088,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`force_update_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.force_update_enabled\\"></a>
+##### \`force_update_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.force_update_enabled\\"></a>
 
 - *Type:* typing.Union[\`bool\`, [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -10098,7 +10098,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.instance_types\\"></a>
+##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.instance_types\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -10108,7 +10108,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`launch_template\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.launch_template\\"></a>
+##### \`launch_template\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.launch_template\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -10118,7 +10118,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.nodegroup_name\\"></a>
+##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.nodegroup_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -10128,7 +10128,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.release_version\\"></a>
+##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.release_version\\"></a>
 
 - *Type:* \`str\`
 
@@ -10138,7 +10138,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.remote_access\\"></a>
+##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.remote_access\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -10148,7 +10148,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`scaling_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.scaling_config\\"></a>
+##### \`scaling_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.scaling_config\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -10158,7 +10158,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`taints\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.taints\\"></a>
+##### \`taints\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.taints\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.TaintProperty\`](#aws_cdk.aws_eks.CfnNodegroup.TaintProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
@@ -10168,7 +10168,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.version\\"></a>
 
 - *Type:* \`str\`
 
@@ -10180,7 +10180,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnNodegroup.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`str\`
 
@@ -10228,7 +10228,7 @@ aws_eks.Cluster(scope: Construct,
                 default_capacity_type: DefaultCapacityType = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -10236,7 +10236,7 @@ a Construct, most likely a cdk.Stack created.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -10244,7 +10244,7 @@ the id of the Construct to create.
 
 ---
 
-##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.version\\"></a>
+##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.version\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -10252,7 +10252,7 @@ The Kubernetes version to run in the cluster.
 
 ---
 
-##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.cluster_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name
@@ -10261,7 +10261,7 @@ Name for the cluster.
 
 ---
 
-##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.output_cluster_name\\"></a>
+##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.output_cluster_name\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -10270,7 +10270,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 
 ---
 
-##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.output_config_command\\"></a>
+##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.output_config_command\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -10282,7 +10282,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ---
 
-##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.role\\"></a>
+##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* A role is automatically created for you
@@ -10291,7 +10291,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 
 ---
 
-##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.security_group\\"></a>
+##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.security_group\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -10300,7 +10300,7 @@ Security Group to use for Control Plane ENIs.
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
@@ -10309,7 +10309,7 @@ The VPC in which to create the Cluster.
 
 ---
 
-##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.vpc_subnets\\"></a>
+##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.vpc_subnets\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
 - *Default:* All public and private subnets
@@ -10328,7 +10328,7 @@ vpcSubnets: [
 
 ---
 
-##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.cluster_handler_environment\\"></a>
+##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.cluster_handler_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
@@ -10337,7 +10337,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ---
 
-##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.core_dns_compute_type\\"></a>
+##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.core_dns_compute_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
@@ -10346,7 +10346,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 
 ---
 
-##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.endpoint_access\\"></a>
+##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.endpoint_access\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -10357,7 +10357,7 @@ Configure access to the Kubernetes API server endpoint..
 
 ---
 
-##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.kubectl_environment\\"></a>
+##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.kubectl_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
@@ -10368,7 +10368,7 @@ Only relevant for kubectl enabled clusters.
 
 ---
 
-##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.kubectl_layer\\"></a>
+##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.kubectl_layer\\"></a>
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -10395,7 +10395,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ---
 
-##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.kubectl_memory\\"></a>
+##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.kubectl_memory\\"></a>
 
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 - *Default:* Size.gibibytes(1)
@@ -10404,7 +10404,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.masters_role\\"></a>
+##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.masters_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -10416,7 +10416,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ---
 
-##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.output_masters_role_arn\\"></a>
+##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.output_masters_role_arn\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -10425,7 +10425,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ---
 
-##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.place_cluster_handler_in_vpc\\"></a>
+##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.place_cluster_handler_in_vpc\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -10434,7 +10434,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 
 ---
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.prune\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -10447,7 +10447,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ---
 
-##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.secrets_encryption_key\\"></a>
+##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.secrets_encryption_key\\"></a>
 
 - *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
@@ -10458,7 +10458,7 @@ KMS secret for envelope encryption for Kubernetes secrets.
 
 ---
 
-##### \`default_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.default_capacity\\"></a>
+##### \`default_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.default_capacity\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 2
@@ -10473,7 +10473,7 @@ to \`0\` is you wish to avoid the initial capacity allocation.
 
 ---
 
-##### \`default_capacity_instance\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.default_capacity_instance\\"></a>
+##### \`default_capacity_instance\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.default_capacity_instance\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)
 - *Default:* m5.large
@@ -10485,7 +10485,7 @@ into account if \`defaultCapacity\` is > 0.
 
 ---
 
-##### \`default_capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.default_capacity_type\\"></a>
+##### \`default_capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.parameter.default_capacity_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.DefaultCapacityType\`](#aws_cdk.aws_eks.DefaultCapacityType)
 - *Default:* NODEGROUP
@@ -10528,13 +10528,13 @@ def add_auto_scaling_group_capacity(id: str,
                                     spot_interrupt_handler: bool = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`allow_all_outbound\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.allow_all_outbound\\"></a>
+###### \`allow_all_outbound\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.allow_all_outbound\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -10543,7 +10543,7 @@ Whether the instances can initiate connections to anywhere by default.
 
 ---
 
-###### \`associate_public_ip_address\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.associate_public_ip_address\\"></a>
+###### \`associate_public_ip_address\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.associate_public_ip_address\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* Use subnet setting.
@@ -10552,7 +10552,7 @@ Whether instances in the Auto Scaling Group should have public IP addresses asso
 
 ---
 
-###### \`auto_scaling_group_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.auto_scaling_group_name\\"></a>
+###### \`auto_scaling_group_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.auto_scaling_group_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Auto generated by CloudFormation
@@ -10563,7 +10563,7 @@ This name must be unique per Region per account.
 
 ---
 
-###### \`block_devices\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.block_devices\\"></a>
+###### \`block_devices\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.block_devices\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_autoscaling.BlockDevice\`](#aws_cdk.aws_autoscaling.BlockDevice)]
 - *Default:* Uses the block device mapping of the AMI
@@ -10579,7 +10579,7 @@ instance store volumes to attach to an instance when it is launched.
 
 ---
 
-###### \`cooldown\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.cooldown\\"></a>
+###### \`cooldown\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.cooldown\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -10588,7 +10588,7 @@ Default scaling cooldown for this AutoScalingGroup.
 
 ---
 
-###### \`desired_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.desired_capacity\\"></a>
+###### \`desired_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.desired_capacity\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* minCapacity, and leave unchanged during deployment
@@ -10602,7 +10602,7 @@ instances to this number. It is recommended to leave this value blank.
 
 ---
 
-###### \`group_metrics\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.group_metrics\\"></a>
+###### \`group_metrics\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.group_metrics\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_autoscaling.GroupMetrics\`](#aws_cdk.aws_autoscaling.GroupMetrics)]
 - *Default:* no group metrics will be reported
@@ -10614,7 +10614,7 @@ Group metrics are reported in a granularity of 1 minute at no additional charge.
 
 ---
 
-###### \`health_check\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.health_check\\"></a>
+###### \`health_check\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.health_check\\"></a>
 
 - *Type:* [\`aws_cdk.aws_autoscaling.HealthCheck\`](#aws_cdk.aws_autoscaling.HealthCheck)
 - *Default:* HealthCheck.ec2 with no grace period
@@ -10623,7 +10623,7 @@ Configuration for health checks.
 
 ---
 
-###### \`ignore_unmodified_size_properties\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.ignore_unmodified_size_properties\\"></a>
+###### \`ignore_unmodified_size_properties\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.ignore_unmodified_size_properties\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -10638,7 +10638,7 @@ on deployment.
 
 ---
 
-###### \`instance_monitoring\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.instance_monitoring\\"></a>
+###### \`instance_monitoring\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.instance_monitoring\\"></a>
 
 - *Type:* [\`aws_cdk.aws_autoscaling.Monitoring\`](#aws_cdk.aws_autoscaling.Monitoring)
 - *Default:* Monitoring.DETAILED
@@ -10652,7 +10652,7 @@ is charged a fee. When you disable detailed monitoring, CloudWatch generates met
 
 ---
 
-###### \`key_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.key_name\\"></a>
+###### \`key_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.key_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No SSH access will be possible.
@@ -10661,7 +10661,7 @@ Name of SSH keypair to grant access to instances.
 
 ---
 
-###### \`max_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.max_capacity\\"></a>
+###### \`max_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.max_capacity\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* desiredCapacity
@@ -10670,7 +10670,7 @@ Maximum number of instances in the fleet.
 
 ---
 
-###### \`max_instance_lifetime\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.max_instance_lifetime\\"></a>
+###### \`max_instance_lifetime\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.max_instance_lifetime\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* none
@@ -10688,7 +10688,7 @@ leave this property undefined.
 
 ---
 
-###### \`min_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.min_capacity\\"></a>
+###### \`min_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.min_capacity\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 1
@@ -10697,7 +10697,7 @@ Minimum number of instances in the fleet.
 
 ---
 
-###### \`new_instances_protected_from_scale_in\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.new_instances_protected_from_scale_in\\"></a>
+###### \`new_instances_protected_from_scale_in\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.new_instances_protected_from_scale_in\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -10715,7 +10715,7 @@ an ECS Capacity Provider with managed termination protection.
 
 ---
 
-###### \`notifications\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.notifications\\"></a>
+###### \`notifications\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.notifications\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_autoscaling.NotificationConfiguration\`](#aws_cdk.aws_autoscaling.NotificationConfiguration)]
 - *Default:* No fleet change notifications will be sent.
@@ -10726,7 +10726,7 @@ Configure autoscaling group to send notifications about fleet changes to an SNS 
 
 ---
 
-###### \`signals\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.signals\\"></a>
+###### \`signals\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.signals\\"></a>
 
 - *Type:* [\`aws_cdk.aws_autoscaling.Signals\`](#aws_cdk.aws_autoscaling.Signals)
 - *Default:* Do not wait for signals
@@ -10751,7 +10751,7 @@ https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services
 
 ---
 
-###### \`spot_price\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.spot_price\\"></a>
+###### \`spot_price\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.spot_price\\"></a>
 
 - *Type:* \`str\`
 - *Default:* none
@@ -10763,7 +10763,7 @@ launched when the price you specify exceeds the current Spot market price.
 
 ---
 
-###### \`update_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.update_policy\\"></a>
+###### \`update_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.update_policy\\"></a>
 
 - *Type:* [\`aws_cdk.aws_autoscaling.UpdatePolicy\`](#aws_cdk.aws_autoscaling.UpdatePolicy)
 - *Default:* \`UpdatePolicy.rollingUpdate()\` if using \`init\`, \`UpdatePolicy.none()\` otherwise
@@ -10778,7 +10778,7 @@ is done and only new instances are launched with the new config.
 
 ---
 
-###### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.vpc_subnets\\"></a>
+###### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.vpc_subnets\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* All Private subnets.
@@ -10787,7 +10787,7 @@ Where to place instances within the VPC.
 
 ---
 
-###### \`instance_type\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.instance_type\\"></a>
+###### \`instance_type\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.instance_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)
 
@@ -10795,7 +10795,7 @@ Instance type of the instances to start.
 
 ---
 
-###### \`bootstrap_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.bootstrap_enabled\\"></a>
+###### \`bootstrap_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.bootstrap_enabled\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -10807,7 +10807,7 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 
 ---
 
-###### \`bootstrap_options\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.bootstrap_options\\"></a>
+###### \`bootstrap_options\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.bootstrap_options\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.BootstrapOptions\`](#aws_cdk.aws_eks.BootstrapOptions)
 - *Default:* none
@@ -10816,7 +10816,7 @@ EKS node bootstrapping options.
 
 ---
 
-###### \`machine_image_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.machine_image_type\\"></a>
+###### \`machine_image_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.machine_image_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.MachineImageType\`](#aws_cdk.aws_eks.MachineImageType)
 - *Default:* MachineImageType.AMAZON_LINUX_2
@@ -10825,7 +10825,7 @@ Machine image type.
 
 ---
 
-###### \`map_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.map_role\\"></a>
+###### \`map_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.map_role\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true if the cluster has kubectl enabled (which is the default).
@@ -10836,7 +10836,7 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 
 ---
 
-###### \`spot_interrupt_handler\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.spot_interrupt_handler\\"></a>
+###### \`spot_interrupt_handler\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.parameter.spot_interrupt_handler\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -10854,7 +10854,7 @@ def add_cdk8s_chart(id: str,
                     chart: Construct)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -10862,7 +10862,7 @@ logical id of this chart.
 
 ---
 
-###### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.chart\\"></a>
+###### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.chart\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -10881,7 +10881,7 @@ def add_fargate_profile(id: str,
                         vpc: IVpc = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -10889,7 +10889,7 @@ the id of this profile.
 
 ---
 
-###### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.selectors\\"></a>
+###### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.parameter.selectors\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_eks.Selector\`](#aws_cdk.aws_eks.Selector)]
 
@@ -10903,7 +10903,7 @@ At least one selector is required and you may specify up to five selectors.
 
 ---
 
-###### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.fargate_profile_name\\"></a>
+###### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.parameter.fargate_profile_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* generated
@@ -10912,7 +10912,7 @@ The name of the Fargate profile.
 
 ---
 
-###### \`pod_execution_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.pod_execution_role\\"></a>
+###### \`pod_execution_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.parameter.pod_execution_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role will be automatically created
@@ -10927,7 +10927,7 @@ ECR image repositories.
 
 ---
 
-###### \`subnet_selection\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.subnet_selection\\"></a>
+###### \`subnet_selection\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.parameter.subnet_selection\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* all private subnets of the VPC are selected.
@@ -10940,7 +10940,7 @@ on Fargate are not assigned public IP addresses, so only private subnets
 
 ---
 
-###### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.vpc\\"></a>
+###### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.parameter.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* all private subnets used by theEKS cluster
@@ -10967,7 +10967,7 @@ def add_helm_chart(id: str,
                    wait: bool = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -10975,7 +10975,7 @@ logical id of this chart.
 
 ---
 
-###### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.chart\\"></a>
+###### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.chart\\"></a>
 
 - *Type:* \`str\`
 
@@ -10983,7 +10983,7 @@ The name of the chart.
 
 ---
 
-###### \`create_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.create_namespace\\"></a>
+###### \`create_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.create_namespace\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -10992,7 +10992,7 @@ create namespace if not exist.
 
 ---
 
-###### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.namespace\\"></a>
+###### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* default
@@ -11001,7 +11001,7 @@ The Kubernetes namespace scope of the requests.
 
 ---
 
-###### \`release\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.release\\"></a>
+###### \`release\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.release\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
@@ -11010,7 +11010,7 @@ The name of the release.
 
 ---
 
-###### \`repository\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.repository\\"></a>
+###### \`repository\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.repository\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -11021,7 +11021,7 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ---
 
-###### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.timeout\\"></a>
+###### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.timeout\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -11032,7 +11032,7 @@ Maximum 15 minutes.
 
 ---
 
-###### \`values\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.values\\"></a>
+###### \`values\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.values\\"></a>
 
 - *Type:* typing.Mapping[\`typing.Any\`]
 - *Default:* No values are provided to the chart.
@@ -11041,7 +11041,7 @@ The values to be used by the chart.
 
 ---
 
-###### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.version\\"></a>
+###### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.version\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If this is not specified, the latest version is installed
@@ -11050,7 +11050,7 @@ The chart version to install.
 
 ---
 
-###### \`wait\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.wait\\"></a>
+###### \`wait\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.wait\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* Helm will not wait before marking release as successful
@@ -11066,7 +11066,7 @@ def add_manifest(id: str,
                  manifest: typing.Mapping[typing.Any])
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -11074,7 +11074,7 @@ logical id of this manifest.
 
 ---
 
-###### \`manifest\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.manifest\\"></a>
+###### \`manifest\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.manifest\\"></a>
 
 - *Type:* typing.Mapping[\`typing.Any\`]
 
@@ -11104,7 +11104,7 @@ def add_nodegroup_capacity(id: str,
                            tags: typing.Mapping[str] = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -11112,7 +11112,7 @@ The ID of the nodegroup.
 
 ---
 
-###### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.ami_type\\"></a>
+###### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.ami_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.NodegroupAmiType\`](#aws_cdk.aws_eks.NodegroupAmiType)
 - *Default:* auto-determined from the instanceTypes property.
@@ -11121,7 +11121,7 @@ The AMI type for your node group.
 
 ---
 
-###### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.capacity_type\\"></a>
+###### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.capacity_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.CapacityType\`](#aws_cdk.aws_eks.CapacityType)
 - *Default:* ON_DEMAND
@@ -11130,7 +11130,7 @@ The capacity type of the nodegroup.
 
 ---
 
-###### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.desired_size\\"></a>
+###### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.desired_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 2
@@ -11142,7 +11142,7 @@ the nodewgroup will initially create \`minSize\` instances.
 
 ---
 
-###### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.disk_size\\"></a>
+###### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.disk_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 20
@@ -11151,7 +11151,7 @@ The root device disk size (in GiB) for your node group instances.
 
 ---
 
-###### \`force_update\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.force_update\\"></a>
+###### \`force_update\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.force_update\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -11164,7 +11164,7 @@ running on the node.
 
 ---
 
-###### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.instance_types\\"></a>
+###### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.instance_types\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)]
 - *Default:* t3.medium will be used according to the cloudformation document.
@@ -11175,7 +11175,7 @@ The instance types to use for your node group.
 
 ---
 
-###### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.labels\\"></a>
+###### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.labels\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* None
@@ -11184,7 +11184,7 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 
 ---
 
-###### \`launch_template_spec\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.launch_template_spec\\"></a>
+###### \`launch_template_spec\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.launch_template_spec\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.LaunchTemplateSpec\`](#aws_cdk.aws_eks.LaunchTemplateSpec)
 - *Default:* no launch template
@@ -11195,7 +11195,7 @@ Launch template specification used for the nodegroup.
 
 ---
 
-###### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.max_size\\"></a>
+###### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.max_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* desiredSize
@@ -11206,7 +11206,7 @@ Managed node groups can support up to 100 nodes by default.
 
 ---
 
-###### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.min_size\\"></a>
+###### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.min_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 1
@@ -11217,7 +11217,7 @@ This number must be greater than zero.
 
 ---
 
-###### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.nodegroup_name\\"></a>
+###### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.nodegroup_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* resource ID
@@ -11226,7 +11226,7 @@ Name of the Nodegroup.
 
 ---
 
-###### \`node_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.node_role\\"></a>
+###### \`node_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.node_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* None. Auto-generated if not specified.
@@ -11240,7 +11240,7 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 
 ---
 
-###### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.release_version\\"></a>
+###### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.release_version\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
@@ -11249,7 +11249,7 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 
 ---
 
-###### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.remote_access\\"></a>
+###### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.remote_access\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.NodegroupRemoteAccess\`](#aws_cdk.aws_eks.NodegroupRemoteAccess)
 - *Default:* disabled
@@ -11262,7 +11262,7 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 
 ---
 
-###### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.subnets\\"></a>
+###### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.subnets\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* private subnets
@@ -11276,7 +11276,7 @@ the name of your cluster.
 
 ---
 
-###### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.tags\\"></a>
+###### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.parameter.tags\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* None
@@ -11297,13 +11297,13 @@ def add_service_account(id: str,
                         namespace: str = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.name\\"></a>
+###### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.parameter.name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If no name is given, it will use the id of the resource.
@@ -11312,7 +11312,7 @@ The name of the service account.
 
 ---
 
-###### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.namespace\\"></a>
+###### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.parameter.namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* \\"default\\"
@@ -11332,7 +11332,7 @@ def connect_auto_scaling_group_capacity(auto_scaling_group: AutoScalingGroup,
                                         spot_interrupt_handler: bool = None)
 \`\`\`
 
-###### \`auto_scaling_group\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.auto_scaling_group\\"></a>
+###### \`auto_scaling_group\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.auto_scaling_group\\"></a>
 
 - *Type:* [\`aws_cdk.aws_autoscaling.AutoScalingGroup\`](#aws_cdk.aws_autoscaling.AutoScalingGroup)
 
@@ -11340,7 +11340,7 @@ def connect_auto_scaling_group_capacity(auto_scaling_group: AutoScalingGroup,
 
 ---
 
-###### \`bootstrap_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.bootstrap_enabled\\"></a>
+###### \`bootstrap_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.parameter.bootstrap_enabled\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -11352,7 +11352,7 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 
 ---
 
-###### \`bootstrap_options\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.bootstrap_options\\"></a>
+###### \`bootstrap_options\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.parameter.bootstrap_options\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.BootstrapOptions\`](#aws_cdk.aws_eks.BootstrapOptions)
 - *Default:* default options
@@ -11361,7 +11361,7 @@ Allows options for node bootstrapping through EC2 user data.
 
 ---
 
-###### \`machine_image_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.machine_image_type\\"></a>
+###### \`machine_image_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.parameter.machine_image_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.MachineImageType\`](#aws_cdk.aws_eks.MachineImageType)
 - *Default:* MachineImageType.AMAZON_LINUX_2
@@ -11370,7 +11370,7 @@ Allow options to specify different machine image type.
 
 ---
 
-###### \`map_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.map_role\\"></a>
+###### \`map_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.parameter.map_role\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true if the cluster has kubectl enabled (which is the default).
@@ -11381,7 +11381,7 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 
 ---
 
-###### \`spot_interrupt_handler\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.spot_interrupt_handler\\"></a>
+###### \`spot_interrupt_handler\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.parameter.spot_interrupt_handler\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -11400,7 +11400,7 @@ def get_service_load_balancer_address(service_name: str,
                                       timeout: Duration = None)
 \`\`\`
 
-###### \`service_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.service_name\\"></a>
+###### \`service_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.service_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -11408,7 +11408,7 @@ The name of the service.
 
 ---
 
-###### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceLoadBalancerAddressOptions.namespace\\"></a>
+###### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceLoadBalancerAddressOptions.parameter.namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* 'default'
@@ -11417,7 +11417,7 @@ The namespace the service belongs to.
 
 ---
 
-###### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceLoadBalancerAddressOptions.timeout\\"></a>
+###### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceLoadBalancerAddressOptions.parameter.timeout\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -11452,7 +11452,7 @@ aws_eks.Cluster.from_cluster_attributes(scope: Construct,
                                         vpc: IVpc = None)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -11460,7 +11460,7 @@ the construct scope, in most cases 'this'.
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -11468,7 +11468,7 @@ the id or name to import as.
 
 ---
 
-###### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.cluster_name\\"></a>
+###### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -11476,7 +11476,7 @@ The physical name of the Cluster.
 
 ---
 
-###### \`cluster_certificate_authority_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.cluster_certificate_authority_data\\"></a>
+###### \`cluster_certificate_authority_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.cluster_certificate_authority_data\\"></a>
 
 - *Type:* \`str\`
 - *Default:* if not specified \`cluster.clusterCertificateAuthorityData\` will
@@ -11486,7 +11486,7 @@ The certificate-authority-data for your cluster.
 
 ---
 
-###### \`cluster_encryption_config_key_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.cluster_encryption_config_key_arn\\"></a>
+###### \`cluster_encryption_config_key_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.cluster_encryption_config_key_arn\\"></a>
 
 - *Type:* \`str\`
 - *Default:* if not specified \`cluster.clusterEncryptionConfigKeyArn\` will
@@ -11496,7 +11496,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ---
 
-###### \`cluster_endpoint\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.cluster_endpoint\\"></a>
+###### \`cluster_endpoint\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.cluster_endpoint\\"></a>
 
 - *Type:* \`str\`
 - *Default:* if not specified \`cluster.clusterEndpoint\` will throw an error.
@@ -11505,7 +11505,7 @@ The API Server endpoint URL.
 
 ---
 
-###### \`cluster_security_group_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.cluster_security_group_id\\"></a>
+###### \`cluster_security_group_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.cluster_security_group_id\\"></a>
 
 - *Type:* \`str\`
 - *Default:* if not specified \`cluster.clusterSecurityGroupId\` will throw an
@@ -11515,7 +11515,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 
 ---
 
-###### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.kubectl_environment\\"></a>
+###### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.kubectl_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* no additional variables
@@ -11524,7 +11524,7 @@ Environment variables to use when running \`kubectl\` against this cluster.
 
 ---
 
-###### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.kubectl_layer\\"></a>
+###### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.kubectl_layer\\"></a>
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 - *Default:* a layer bundled with this module.
@@ -11542,7 +11542,7 @@ The handler expects the layer to include the following executables:
 
 ---
 
-###### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.kubectl_memory\\"></a>
+###### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.kubectl_memory\\"></a>
 
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 - *Default:* Size.gibibytes(1)
@@ -11551,7 +11551,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-###### \`kubectl_private_subnet_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.kubectl_private_subnet_ids\\"></a>
+###### \`kubectl_private_subnet_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.kubectl_private_subnet_ids\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* k8s endpoint is expected to be accessible publicly
@@ -11563,7 +11563,7 @@ endpoint is expected to be accessible publicly.
 
 ---
 
-###### \`kubectl_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.kubectl_role_arn\\"></a>
+###### \`kubectl_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.kubectl_role_arn\\"></a>
 
 - *Type:* \`str\`
 - *Default:* if not specified, it not be possible to issue \`kubectl\` commands
@@ -11573,7 +11573,7 @@ An IAM role with cluster administrator and \\"system:masters\\" permissions.
 
 ---
 
-###### \`kubectl_security_group_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.kubectl_security_group_id\\"></a>
+###### \`kubectl_security_group_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.kubectl_security_group_id\\"></a>
 
 - *Type:* \`str\`
 - *Default:* k8s endpoint is expected to be accessible publicly
@@ -11585,7 +11585,7 @@ endpoint is expected to be accessible publicly.
 
 ---
 
-###### \`open_id_connect_provider\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.open_id_connect_provider\\"></a>
+###### \`open_id_connect_provider\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.open_id_connect_provider\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IOpenIdConnectProvider\`](#aws_cdk.aws_iam.IOpenIdConnectProvider)
 - *Default:* if not specified \`cluster.openIdConnectProvider\` and \`cluster.addServiceAccount\` will throw an error.
@@ -11597,7 +11597,7 @@ or create a new provider using \`new eks.OpenIdConnectProvider\`
 
 ---
 
-###### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.prune\\"></a>
+###### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.prune\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -11610,7 +11610,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ---
 
-###### \`security_group_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.security_group_ids\\"></a>
+###### \`security_group_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.security_group_ids\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* if not specified, no additional security groups will be
@@ -11620,7 +11620,7 @@ Additional security groups associated with this cluster.
 
 ---
 
-###### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.vpc\\"></a>
+###### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.parameter.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* if not specified \`cluster.vpc\` will throw an error
@@ -11631,7 +11631,7 @@ The VPC in which this Cluster was created.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`admin_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.admin_role\\"></a>
+##### \`admin_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.admin_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.Role\`](#aws_cdk.aws_iam.Role)
 
@@ -11641,7 +11641,7 @@ This role also has \`systems:master\` permissions.
 
 ---
 
-##### \`aws_auth\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.aws_auth\\"></a>
+##### \`aws_auth\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.aws_auth\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.AwsAuth\`](#aws_cdk.aws_eks.AwsAuth)
 
@@ -11649,7 +11649,7 @@ Lazily creates the AwsAuth resource, which manages AWS authentication mapping.
 
 ---
 
-##### \`cluster_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.cluster_arn\\"></a>
+##### \`cluster_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -11657,7 +11657,7 @@ The AWS generated ARN for the Cluster resource.
 
 ---
 
-##### \`cluster_certificate_authority_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.cluster_certificate_authority_data\\"></a>
+##### \`cluster_certificate_authority_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_certificate_authority_data\\"></a>
 
 - *Type:* \`str\`
 
@@ -11665,7 +11665,7 @@ The certificate-authority-data for your cluster.
 
 ---
 
-##### \`cluster_encryption_config_key_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.cluster_encryption_config_key_arn\\"></a>
+##### \`cluster_encryption_config_key_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_encryption_config_key_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -11673,7 +11673,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ---
 
-##### \`cluster_endpoint\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.cluster_endpoint\\"></a>
+##### \`cluster_endpoint\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_endpoint\\"></a>
 
 - *Type:* \`str\`
 
@@ -11683,7 +11683,7 @@ This is the URL inside the kubeconfig file to use with kubectl
 
 ---
 
-##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -11691,7 +11691,7 @@ The Name of the created EKS Cluster.
 
 ---
 
-##### \`cluster_open_id_connect_issuer\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.cluster_open_id_connect_issuer\\"></a>
+##### \`cluster_open_id_connect_issuer\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_open_id_connect_issuer\\"></a>
 
 - *Type:* \`str\`
 
@@ -11703,7 +11703,7 @@ stock \`CfnCluster\`), this is \`undefined\`.
 
 ---
 
-##### \`cluster_open_id_connect_issuer_url\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.cluster_open_id_connect_issuer_url\\"></a>
+##### \`cluster_open_id_connect_issuer_url\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_open_id_connect_issuer_url\\"></a>
 
 - *Type:* \`str\`
 
@@ -11715,7 +11715,7 @@ stock \`CfnCluster\`), this is \`undefined\`.
 
 ---
 
-##### \`cluster_security_group\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.cluster_security_group\\"></a>
+##### \`cluster_security_group\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_security_group\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 
@@ -11723,7 +11723,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 
 ---
 
-##### \`cluster_security_group_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.cluster_security_group_id\\"></a>
+##### \`cluster_security_group_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_security_group_id\\"></a>
 
 - *Type:* \`str\`
 
@@ -11731,7 +11731,7 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 
 ---
 
-##### \`connections\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.connections\\"></a>
+##### \`connections\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.connections\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.Connections\`](#aws_cdk.aws_ec2.Connections)
 
@@ -11739,7 +11739,7 @@ Manages connection rules (Security Group Rules) for the cluster.
 
 ---
 
-##### \`open_id_connect_provider\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.open_id_connect_provider\\"></a>
+##### \`open_id_connect_provider\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.open_id_connect_provider\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IOpenIdConnectProvider\`](#aws_cdk.aws_iam.IOpenIdConnectProvider)
 
@@ -11749,7 +11749,7 @@ A provider will only be defined if this property is accessed (lazy initializatio
 
 ---
 
-##### \`prune\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.prune\\"></a>
+##### \`prune\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.prune\\"></a>
 
 - *Type:* \`bool\`
 
@@ -11757,7 +11757,7 @@ Determines if Kubernetes resources can be pruned automatically.
 
 ---
 
-##### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.role\\"></a>
+##### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
@@ -11765,7 +11765,7 @@ IAM role assumed by the EKS Control Plane.
 
 ---
 
-##### \`vpc\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.vpc\\"></a>
+##### \`vpc\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 
@@ -11773,7 +11773,7 @@ The VPC in which this Cluster was created.
 
 ---
 
-##### \`default_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.default_capacity\\"></a>
+##### \`default_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.default_capacity\\"></a>
 
 - *Type:* [\`aws_cdk.aws_autoscaling.AutoScalingGroup\`](#aws_cdk.aws_autoscaling.AutoScalingGroup)
 
@@ -11784,7 +11784,7 @@ This will be \`undefined\` if the \`defaultCapacityType\` is not \`EC2\` or
 
 ---
 
-##### \`default_nodegroup\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.default_nodegroup\\"></a>
+##### \`default_nodegroup\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.default_nodegroup\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.Nodegroup\`](#aws_cdk.aws_eks.Nodegroup)
 
@@ -11795,7 +11795,7 @@ This will be \`undefined\` if the \`defaultCapacityType\` is \`EC2\` or
 
 ---
 
-##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.kubectl_environment\\"></a>
+##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.kubectl_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 
@@ -11803,7 +11803,7 @@ Custom environment variables when running \`kubectl\` against this cluster.
 
 ---
 
-##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.kubectl_layer\\"></a>
+##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.kubectl_layer\\"></a>
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 
@@ -11814,7 +11814,7 @@ undefined, a SAR app that contains this layer will be used.
 
 ---
 
-##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.kubectl_memory\\"></a>
+##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.kubectl_memory\\"></a>
 
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 
@@ -11822,7 +11822,7 @@ The amount of memory allocated to the kubectl provider's lambda function.
 
 ---
 
-##### \`kubectl_private_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.kubectl_private_subnets\\"></a>
+##### \`kubectl_private_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.kubectl_private_subnets\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.ISubnet\`](#aws_cdk.aws_ec2.ISubnet)]
 - *Default:* If not specified, the k8s endpoint is expected to be accessible
@@ -11832,7 +11832,7 @@ Subnets to host the \`kubectl\` compute resources.
 
 ---
 
-##### \`kubectl_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.kubectl_role\\"></a>
+##### \`kubectl_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.kubectl_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
@@ -11842,7 +11842,7 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 
 ---
 
-##### \`kubectl_security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.kubectl_security_group\\"></a>
+##### \`kubectl_security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.kubectl_security_group\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 - *Default:* If not specified, the k8s endpoint is expected to be accessible
@@ -11890,19 +11890,19 @@ aws_eks.FargateCluster(scope: Construct,
                        default_profile: FargateProfileOptions = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateCluster.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateCluster.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateCluster.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateCluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.version\\"></a>
+##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.version\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -11910,7 +11910,7 @@ The Kubernetes version to run in the cluster.
 
 ---
 
-##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.cluster_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name
@@ -11919,7 +11919,7 @@ Name for the cluster.
 
 ---
 
-##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.output_cluster_name\\"></a>
+##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.output_cluster_name\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -11928,7 +11928,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 
 ---
 
-##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.output_config_command\\"></a>
+##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.output_config_command\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -11940,7 +11940,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ---
 
-##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.role\\"></a>
+##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* A role is automatically created for you
@@ -11949,7 +11949,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 
 ---
 
-##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.security_group\\"></a>
+##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.security_group\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -11958,7 +11958,7 @@ Security Group to use for Control Plane ENIs.
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
@@ -11967,7 +11967,7 @@ The VPC in which to create the Cluster.
 
 ---
 
-##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.vpc_subnets\\"></a>
+##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.vpc_subnets\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
 - *Default:* All public and private subnets
@@ -11986,7 +11986,7 @@ vpcSubnets: [
 
 ---
 
-##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.cluster_handler_environment\\"></a>
+##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.cluster_handler_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
@@ -11995,7 +11995,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ---
 
-##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.core_dns_compute_type\\"></a>
+##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.core_dns_compute_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
@@ -12004,7 +12004,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 
 ---
 
-##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.endpoint_access\\"></a>
+##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.endpoint_access\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -12015,7 +12015,7 @@ Configure access to the Kubernetes API server endpoint..
 
 ---
 
-##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.kubectl_environment\\"></a>
+##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.kubectl_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
@@ -12026,7 +12026,7 @@ Only relevant for kubectl enabled clusters.
 
 ---
 
-##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.kubectl_layer\\"></a>
+##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.kubectl_layer\\"></a>
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -12053,7 +12053,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ---
 
-##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.kubectl_memory\\"></a>
+##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.kubectl_memory\\"></a>
 
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 - *Default:* Size.gibibytes(1)
@@ -12062,7 +12062,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.masters_role\\"></a>
+##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.masters_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -12074,7 +12074,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ---
 
-##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.output_masters_role_arn\\"></a>
+##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.output_masters_role_arn\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -12083,7 +12083,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ---
 
-##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.place_cluster_handler_in_vpc\\"></a>
+##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.place_cluster_handler_in_vpc\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -12092,7 +12092,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 
 ---
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.prune\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -12105,7 +12105,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ---
 
-##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.secrets_encryption_key\\"></a>
+##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.secrets_encryption_key\\"></a>
 
 - *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
@@ -12116,7 +12116,7 @@ KMS secret for envelope encryption for Kubernetes secrets.
 
 ---
 
-##### \`default_profile\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.default_profile\\"></a>
+##### \`default_profile\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.parameter.default_profile\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.FargateProfileOptions\`](#aws_cdk.aws_eks.FargateProfileOptions)
 - *Default:* A profile called \\"default\\" with 'default' and 'kube-system'
@@ -12168,19 +12168,19 @@ aws_eks.FargateProfile(scope: Construct,
                        cluster: Cluster)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.selectors\\"></a>
+##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.parameter.selectors\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_eks.Selector\`](#aws_cdk.aws_eks.Selector)]
 
@@ -12194,7 +12194,7 @@ At least one selector is required and you may specify up to five selectors.
 
 ---
 
-##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.fargate_profile_name\\"></a>
+##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.parameter.fargate_profile_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* generated
@@ -12203,7 +12203,7 @@ The name of the Fargate profile.
 
 ---
 
-##### \`pod_execution_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.pod_execution_role\\"></a>
+##### \`pod_execution_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.parameter.pod_execution_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role will be automatically created
@@ -12218,7 +12218,7 @@ ECR image repositories.
 
 ---
 
-##### \`subnet_selection\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.subnet_selection\\"></a>
+##### \`subnet_selection\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.parameter.subnet_selection\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* all private subnets of the VPC are selected.
@@ -12231,7 +12231,7 @@ on Fargate are not assigned public IP addresses, so only private subnets
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.parameter.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* all private subnets used by theEKS cluster
@@ -12243,7 +12243,7 @@ By default, all private subnets are selected. You can customize this using
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.parameter.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.Cluster\`](#aws_cdk.aws_eks.Cluster)
 
@@ -12257,7 +12257,7 @@ The EKS cluster to apply the Fargate profile to.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`fargate_profile_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.fargate_profile_arn\\"></a>
+##### \`fargate_profile_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.property.fargate_profile_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -12265,7 +12265,7 @@ The full Amazon Resource Name (ARN) of the Fargate profile.
 
 ---
 
-##### \`fargate_profile_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.fargate_profile_name\\"></a>
+##### \`fargate_profile_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.property.fargate_profile_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -12273,7 +12273,7 @@ The name of the Fargate profile.
 
 ---
 
-##### \`pod_execution_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.pod_execution_role\\"></a>
+##### \`pod_execution_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.property.pod_execution_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
@@ -12285,7 +12285,7 @@ ECR image repositories.
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.property.tags\\"></a>
 
 - *Type:* [\`aws_cdk.TagManager\`](#aws_cdk.TagManager)
 
@@ -12319,19 +12319,19 @@ aws_eks.HelmChart(scope: Construct,
                   cluster: ICluster)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChart.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChart.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChart.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChart.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.chart\\"></a>
+##### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.parameter.chart\\"></a>
 
 - *Type:* \`str\`
 
@@ -12339,7 +12339,7 @@ The name of the chart.
 
 ---
 
-##### \`create_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.create_namespace\\"></a>
+##### \`create_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.parameter.create_namespace\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -12348,7 +12348,7 @@ create namespace if not exist.
 
 ---
 
-##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.namespace\\"></a>
+##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.parameter.namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* default
@@ -12357,7 +12357,7 @@ The Kubernetes namespace scope of the requests.
 
 ---
 
-##### \`release\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.release\\"></a>
+##### \`release\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.parameter.release\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
@@ -12366,7 +12366,7 @@ The name of the release.
 
 ---
 
-##### \`repository\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.repository\\"></a>
+##### \`repository\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.parameter.repository\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -12377,7 +12377,7 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ---
 
-##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.timeout\\"></a>
+##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.parameter.timeout\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -12388,7 +12388,7 @@ Maximum 15 minutes.
 
 ---
 
-##### \`values\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.values\\"></a>
+##### \`values\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.parameter.values\\"></a>
 
 - *Type:* typing.Mapping[\`typing.Any\`]
 - *Default:* No values are provided to the chart.
@@ -12397,7 +12397,7 @@ The values to be used by the chart.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.parameter.version\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If this is not specified, the latest version is installed
@@ -12406,7 +12406,7 @@ The chart version to install.
 
 ---
 
-##### \`wait\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.wait\\"></a>
+##### \`wait\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.parameter.wait\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* Helm will not wait before marking release as successful
@@ -12415,7 +12415,7 @@ Whether or not Helm should wait until all Pods, PVCs, Services, and minimum numb
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.parameter.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -12430,7 +12430,7 @@ The EKS cluster to apply this configuration to.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`RESOURCE_TYPE\` <a name=\\"aws_cdk.aws_eks.HelmChart.RESOURCE_TYPE\\"></a>
+##### \`RESOURCE_TYPE\` <a name=\\"aws_cdk.aws_eks.HelmChart.property.RESOURCE_TYPE\\"></a>
 
 - *Type:* \`str\`
 
@@ -12461,19 +12461,19 @@ aws_eks.KubernetesManifest(scope: Construct,
                            overwrite: bool = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifest.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifest.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifest.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifest.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.parameter.prune\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* based on the prune option of the cluster, which is \`true\` unless
@@ -12499,7 +12499,7 @@ empty.
 
 ---
 
-##### \`skip_validation\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.skip_validation\\"></a>
+##### \`skip_validation\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.parameter.skip_validation\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -12508,7 +12508,7 @@ A flag to signify if the manifest validation should be skipped.
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.parameter.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -12518,7 +12518,7 @@ The EKS cluster to apply this manifest to.
 
 ---
 
-##### \`manifest\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.manifest\\"></a>
+##### \`manifest\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.parameter.manifest\\"></a>
 
 - *Type:* typing.List[typing.Mapping[\`typing.Any\`]]
 
@@ -12532,7 +12532,7 @@ deleted, the resources in the manifest will be deleted through \`kubectl delete\
 
 ---
 
-##### \`overwrite\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.overwrite\\"></a>
+##### \`overwrite\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.parameter.overwrite\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -12550,7 +12550,7 @@ in the cluster with the same name, the operation will fail.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`RESOURCE_TYPE\` <a name=\\"aws_cdk.aws_eks.KubernetesManifest.RESOURCE_TYPE\\"></a>
+##### \`RESOURCE_TYPE\` <a name=\\"aws_cdk.aws_eks.KubernetesManifest.property.RESOURCE_TYPE\\"></a>
 
 - *Type:* \`str\`
 
@@ -12579,19 +12579,19 @@ aws_eks.KubernetesObjectValue(scope: Construct,
                               timeout: Duration = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValue.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValue.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValue.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValue.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.parameter.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -12601,7 +12601,7 @@ The EKS cluster to fetch attributes from.
 
 ---
 
-##### \`json_path\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.json_path\\"></a>
+##### \`json_path\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.parameter.json_path\\"></a>
 
 - *Type:* \`str\`
 
@@ -12611,7 +12611,7 @@ JSONPath to the specific value.
 
 ---
 
-##### \`object_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.object_name\\"></a>
+##### \`object_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.parameter.object_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -12619,7 +12619,7 @@ The name of the object to query.
 
 ---
 
-##### \`object_type\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.object_type\\"></a>
+##### \`object_type\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.parameter.object_type\\"></a>
 
 - *Type:* \`str\`
 
@@ -12629,7 +12629,7 @@ The object type to query.
 
 ---
 
-##### \`object_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.object_namespace\\"></a>
+##### \`object_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.parameter.object_namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* 'default'
@@ -12638,7 +12638,7 @@ The namespace the object belongs to.
 
 ---
 
-##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.timeout\\"></a>
+##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.parameter.timeout\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -12651,7 +12651,7 @@ Timeout for waiting on a value.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`value\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValue.value\\"></a>
+##### \`value\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValue.property.value\\"></a>
 
 - *Type:* \`str\`
 
@@ -12661,7 +12661,7 @@ The value as a string token.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`RESOURCE_TYPE\` <a name=\\"aws_cdk.aws_eks.KubernetesObjectValue.RESOURCE_TYPE\\"></a>
+##### \`RESOURCE_TYPE\` <a name=\\"aws_cdk.aws_eks.KubernetesObjectValue.property.RESOURCE_TYPE\\"></a>
 
 - *Type:* \`str\`
 
@@ -12690,19 +12690,19 @@ aws_eks.KubernetesPatch(scope: Construct,
                         resource_namespace: str = None)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatch.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatch.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatch.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatch.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`apply_patch\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.apply_patch\\"></a>
+##### \`apply_patch\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.parameter.apply_patch\\"></a>
 
 - *Type:* typing.Mapping[\`typing.Any\`]
 
@@ -12710,7 +12710,7 @@ The JSON object to pass to \`kubectl patch\` when the resource is created/update
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.parameter.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -12720,7 +12720,7 @@ The cluster to apply the patch to.
 
 ---
 
-##### \`resource_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.resource_name\\"></a>
+##### \`resource_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.parameter.resource_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -12728,7 +12728,7 @@ The full name of the resource to patch (e.g. \`deployment/coredns\`).
 
 ---
 
-##### \`restore_patch\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.restore_patch\\"></a>
+##### \`restore_patch\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.parameter.restore_patch\\"></a>
 
 - *Type:* typing.Mapping[\`typing.Any\`]
 
@@ -12736,7 +12736,7 @@ The JSON object to pass to \`kubectl patch\` when the resource is removed.
 
 ---
 
-##### \`patch_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.patch_type\\"></a>
+##### \`patch_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.parameter.patch_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.PatchType\`](#aws_cdk.aws_eks.PatchType)
 - *Default:* PatchType.STRATEGIC
@@ -12747,7 +12747,7 @@ The default type used by \`kubectl patch\` is \\"strategic\\".
 
 ---
 
-##### \`resource_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.resource_namespace\\"></a>
+##### \`resource_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.parameter.resource_namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* \\"default\\"
@@ -12792,19 +12792,19 @@ aws_eks.Nodegroup(scope: Construct,
                   cluster: ICluster)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.ami_type\\"></a>
+##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.ami_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.NodegroupAmiType\`](#aws_cdk.aws_eks.NodegroupAmiType)
 - *Default:* auto-determined from the instanceTypes property.
@@ -12813,7 +12813,7 @@ The AMI type for your node group.
 
 ---
 
-##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.capacity_type\\"></a>
+##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.capacity_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.CapacityType\`](#aws_cdk.aws_eks.CapacityType)
 - *Default:* ON_DEMAND
@@ -12822,7 +12822,7 @@ The capacity type of the nodegroup.
 
 ---
 
-##### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.desired_size\\"></a>
+##### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.desired_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 2
@@ -12834,7 +12834,7 @@ the nodewgroup will initially create \`minSize\` instances.
 
 ---
 
-##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.disk_size\\"></a>
+##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.disk_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 20
@@ -12843,7 +12843,7 @@ The root device disk size (in GiB) for your node group instances.
 
 ---
 
-##### \`force_update\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.force_update\\"></a>
+##### \`force_update\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.force_update\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -12856,7 +12856,7 @@ running on the node.
 
 ---
 
-##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.instance_types\\"></a>
+##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.instance_types\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)]
 - *Default:* t3.medium will be used according to the cloudformation document.
@@ -12867,7 +12867,7 @@ The instance types to use for your node group.
 
 ---
 
-##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.labels\\"></a>
+##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.labels\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* None
@@ -12876,7 +12876,7 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 
 ---
 
-##### \`launch_template_spec\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.launch_template_spec\\"></a>
+##### \`launch_template_spec\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.launch_template_spec\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.LaunchTemplateSpec\`](#aws_cdk.aws_eks.LaunchTemplateSpec)
 - *Default:* no launch template
@@ -12887,7 +12887,7 @@ Launch template specification used for the nodegroup.
 
 ---
 
-##### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.max_size\\"></a>
+##### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.max_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* desiredSize
@@ -12898,7 +12898,7 @@ Managed node groups can support up to 100 nodes by default.
 
 ---
 
-##### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.min_size\\"></a>
+##### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.min_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 1
@@ -12909,7 +12909,7 @@ This number must be greater than zero.
 
 ---
 
-##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.nodegroup_name\\"></a>
+##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.nodegroup_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* resource ID
@@ -12918,7 +12918,7 @@ Name of the Nodegroup.
 
 ---
 
-##### \`node_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.node_role\\"></a>
+##### \`node_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.node_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* None. Auto-generated if not specified.
@@ -12932,7 +12932,7 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 
 ---
 
-##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.release_version\\"></a>
+##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.release_version\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
@@ -12941,7 +12941,7 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 
 ---
 
-##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.remote_access\\"></a>
+##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.remote_access\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.NodegroupRemoteAccess\`](#aws_cdk.aws_eks.NodegroupRemoteAccess)
 - *Default:* disabled
@@ -12954,7 +12954,7 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 
 ---
 
-##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.subnets\\"></a>
+##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.subnets\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* private subnets
@@ -12968,7 +12968,7 @@ the name of your cluster.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.tags\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* None
@@ -12981,7 +12981,7 @@ associated with the node group, such as the Amazon EC2 instances or subnets.
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.parameter.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -13002,19 +13002,19 @@ aws_eks.Nodegroup.from_nodegroup_name(scope: Construct,
                                       nodegroup_name: str)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-###### \`nodegroup_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.nodegroup_name\\"></a>
+###### \`nodegroup_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.parameter.nodegroup_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -13022,7 +13022,7 @@ aws_eks.Nodegroup.from_nodegroup_name(scope: Construct,
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.property.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -13030,7 +13030,7 @@ the Amazon EKS cluster resource.
 
 ---
 
-##### \`nodegroup_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.nodegroup_arn\\"></a>
+##### \`nodegroup_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.property.nodegroup_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -13038,7 +13038,7 @@ ARN of the nodegroup.
 
 ---
 
-##### \`nodegroup_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.nodegroup_name\\"></a>
+##### \`nodegroup_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.property.nodegroup_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -13046,7 +13046,7 @@ Nodegroup name.
 
 ---
 
-##### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.role\\"></a>
+##### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.property.role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
@@ -13078,7 +13078,7 @@ aws_eks.OpenIdConnectProvider(scope: Construct,
                               url: str)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.OpenIdConnectProvider.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.OpenIdConnectProvider.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -13086,7 +13086,7 @@ The definition scope.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.OpenIdConnectProvider.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.OpenIdConnectProvider.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -13094,7 +13094,7 @@ Construct ID.
 
 ---
 
-##### \`url\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.OpenIdConnectProviderProps.url\\"></a>
+##### \`url\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.OpenIdConnectProviderProps.parameter.url\\"></a>
 
 - *Type:* \`str\`
 
@@ -13133,19 +13133,19 @@ aws_eks.ServiceAccount(scope: Construct,
                        cluster: ICluster)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.name\\"></a>
+##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.parameter.name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If no name is given, it will use the id of the resource.
@@ -13154,7 +13154,7 @@ The name of the service account.
 
 ---
 
-##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.namespace\\"></a>
+##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.parameter.namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* \\"default\\"
@@ -13163,7 +13163,7 @@ The namespace of the service account.
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.parameter.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -13179,7 +13179,7 @@ The cluster to apply the patch to.
 def add_to_principal_policy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.parameter.statement\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.PolicyStatement\`](#aws_cdk.aws_iam.PolicyStatement)
 
@@ -13188,7 +13188,7 @@ def add_to_principal_policy(statement: PolicyStatement)
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`assume_role_action\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.assume_role_action\\"></a>
+##### \`assume_role_action\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.property.assume_role_action\\"></a>
 
 - *Type:* \`str\`
 
@@ -13196,7 +13196,7 @@ When this Principal is used in an AssumeRole policy, the action to use.
 
 ---
 
-##### \`grant_principal\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.grant_principal\\"></a>
+##### \`grant_principal\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.property.grant_principal\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IPrincipal\`](#aws_cdk.aws_iam.IPrincipal)
 
@@ -13204,7 +13204,7 @@ The principal to grant permissions to.
 
 ---
 
-##### \`policy_fragment\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.policy_fragment\\"></a>
+##### \`policy_fragment\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.property.policy_fragment\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.PrincipalPolicyFragment\`](#aws_cdk.aws_iam.PrincipalPolicyFragment)
 
@@ -13212,7 +13212,7 @@ Return the policy fragment that identifies this principal in a Policy.
 
 ---
 
-##### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.role\\"></a>
+##### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.property.role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
@@ -13220,7 +13220,7 @@ The role which is linked to the service account.
 
 ---
 
-##### \`service_account_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.service_account_name\\"></a>
+##### \`service_account_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.property.service_account_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -13228,7 +13228,7 @@ The name of the service account.
 
 ---
 
-##### \`service_account_namespace\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.service_account_namespace\\"></a>
+##### \`service_account_namespace\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.property.service_account_namespace\\"></a>
 
 - *Type:* \`str\`
 
@@ -13276,7 +13276,7 @@ aws_eks.AutoScalingGroupCapacityOptions(allow_all_outbound: bool = None,
                                         spot_interrupt_handler: bool = None)
 \`\`\`
 
-##### \`allow_all_outbound\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.allow_all_outbound\\"></a>
+##### \`allow_all_outbound\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.allow_all_outbound\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -13285,7 +13285,7 @@ Whether the instances can initiate connections to anywhere by default.
 
 ---
 
-##### \`associate_public_ip_address\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.associate_public_ip_address\\"></a>
+##### \`associate_public_ip_address\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.associate_public_ip_address\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* Use subnet setting.
@@ -13294,7 +13294,7 @@ Whether instances in the Auto Scaling Group should have public IP addresses asso
 
 ---
 
-##### \`auto_scaling_group_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.auto_scaling_group_name\\"></a>
+##### \`auto_scaling_group_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.auto_scaling_group_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Auto generated by CloudFormation
@@ -13305,7 +13305,7 @@ This name must be unique per Region per account.
 
 ---
 
-##### \`block_devices\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.block_devices\\"></a>
+##### \`block_devices\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.block_devices\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_autoscaling.BlockDevice\`](#aws_cdk.aws_autoscaling.BlockDevice)]
 - *Default:* Uses the block device mapping of the AMI
@@ -13321,7 +13321,7 @@ instance store volumes to attach to an instance when it is launched.
 
 ---
 
-##### \`cooldown\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.cooldown\\"></a>
+##### \`cooldown\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.cooldown\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -13330,7 +13330,7 @@ Default scaling cooldown for this AutoScalingGroup.
 
 ---
 
-##### \`desired_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.desired_capacity\\"></a>
+##### \`desired_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.desired_capacity\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* minCapacity, and leave unchanged during deployment
@@ -13344,7 +13344,7 @@ instances to this number. It is recommended to leave this value blank.
 
 ---
 
-##### \`group_metrics\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.group_metrics\\"></a>
+##### \`group_metrics\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.group_metrics\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_autoscaling.GroupMetrics\`](#aws_cdk.aws_autoscaling.GroupMetrics)]
 - *Default:* no group metrics will be reported
@@ -13356,7 +13356,7 @@ Group metrics are reported in a granularity of 1 minute at no additional charge.
 
 ---
 
-##### \`health_check\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.health_check\\"></a>
+##### \`health_check\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.health_check\\"></a>
 
 - *Type:* [\`aws_cdk.aws_autoscaling.HealthCheck\`](#aws_cdk.aws_autoscaling.HealthCheck)
 - *Default:* HealthCheck.ec2 with no grace period
@@ -13365,7 +13365,7 @@ Configuration for health checks.
 
 ---
 
-##### \`ignore_unmodified_size_properties\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.ignore_unmodified_size_properties\\"></a>
+##### \`ignore_unmodified_size_properties\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.ignore_unmodified_size_properties\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -13380,7 +13380,7 @@ on deployment.
 
 ---
 
-##### \`instance_monitoring\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.instance_monitoring\\"></a>
+##### \`instance_monitoring\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.instance_monitoring\\"></a>
 
 - *Type:* [\`aws_cdk.aws_autoscaling.Monitoring\`](#aws_cdk.aws_autoscaling.Monitoring)
 - *Default:* Monitoring.DETAILED
@@ -13394,7 +13394,7 @@ is charged a fee. When you disable detailed monitoring, CloudWatch generates met
 
 ---
 
-##### \`key_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.key_name\\"></a>
+##### \`key_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.key_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No SSH access will be possible.
@@ -13403,7 +13403,7 @@ Name of SSH keypair to grant access to instances.
 
 ---
 
-##### \`max_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.max_capacity\\"></a>
+##### \`max_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.max_capacity\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* desiredCapacity
@@ -13412,7 +13412,7 @@ Maximum number of instances in the fleet.
 
 ---
 
-##### \`max_instance_lifetime\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.max_instance_lifetime\\"></a>
+##### \`max_instance_lifetime\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.max_instance_lifetime\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* none
@@ -13430,7 +13430,7 @@ leave this property undefined.
 
 ---
 
-##### \`min_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.min_capacity\\"></a>
+##### \`min_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.min_capacity\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 1
@@ -13439,7 +13439,7 @@ Minimum number of instances in the fleet.
 
 ---
 
-##### \`new_instances_protected_from_scale_in\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.new_instances_protected_from_scale_in\\"></a>
+##### \`new_instances_protected_from_scale_in\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.new_instances_protected_from_scale_in\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -13457,7 +13457,7 @@ an ECS Capacity Provider with managed termination protection.
 
 ---
 
-##### \`notifications\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.notifications\\"></a>
+##### \`notifications\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.notifications\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_autoscaling.NotificationConfiguration\`](#aws_cdk.aws_autoscaling.NotificationConfiguration)]
 - *Default:* No fleet change notifications will be sent.
@@ -13468,7 +13468,7 @@ Configure autoscaling group to send notifications about fleet changes to an SNS 
 
 ---
 
-##### \`signals\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.signals\\"></a>
+##### \`signals\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.signals\\"></a>
 
 - *Type:* [\`aws_cdk.aws_autoscaling.Signals\`](#aws_cdk.aws_autoscaling.Signals)
 - *Default:* Do not wait for signals
@@ -13493,7 +13493,7 @@ https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services
 
 ---
 
-##### \`spot_price\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.spot_price\\"></a>
+##### \`spot_price\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.spot_price\\"></a>
 
 - *Type:* \`str\`
 - *Default:* none
@@ -13505,7 +13505,7 @@ launched when the price you specify exceeds the current Spot market price.
 
 ---
 
-##### \`update_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.update_policy\\"></a>
+##### \`update_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.update_policy\\"></a>
 
 - *Type:* [\`aws_cdk.aws_autoscaling.UpdatePolicy\`](#aws_cdk.aws_autoscaling.UpdatePolicy)
 - *Default:* \`UpdatePolicy.rollingUpdate()\` if using \`init\`, \`UpdatePolicy.none()\` otherwise
@@ -13520,7 +13520,7 @@ is done and only new instances are launched with the new config.
 
 ---
 
-##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.vpc_subnets\\"></a>
+##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.vpc_subnets\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* All Private subnets.
@@ -13529,7 +13529,7 @@ Where to place instances within the VPC.
 
 ---
 
-##### \`instance_type\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.instance_type\\"></a>
+##### \`instance_type\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.instance_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)
 
@@ -13537,7 +13537,7 @@ Instance type of the instances to start.
 
 ---
 
-##### \`bootstrap_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.bootstrap_enabled\\"></a>
+##### \`bootstrap_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.bootstrap_enabled\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -13549,7 +13549,7 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 
 ---
 
-##### \`bootstrap_options\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.bootstrap_options\\"></a>
+##### \`bootstrap_options\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.bootstrap_options\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.BootstrapOptions\`](#aws_cdk.aws_eks.BootstrapOptions)
 - *Default:* none
@@ -13558,7 +13558,7 @@ EKS node bootstrapping options.
 
 ---
 
-##### \`machine_image_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.machine_image_type\\"></a>
+##### \`machine_image_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.machine_image_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.MachineImageType\`](#aws_cdk.aws_eks.MachineImageType)
 - *Default:* MachineImageType.AMAZON_LINUX_2
@@ -13567,7 +13567,7 @@ Machine image type.
 
 ---
 
-##### \`map_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.map_role\\"></a>
+##### \`map_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.map_role\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true if the cluster has kubectl enabled (which is the default).
@@ -13578,7 +13578,7 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 
 ---
 
-##### \`spot_interrupt_handler\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.spot_interrupt_handler\\"></a>
+##### \`spot_interrupt_handler\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.spot_interrupt_handler\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -13605,7 +13605,7 @@ aws_eks.AutoScalingGroupOptions(bootstrap_enabled: bool = None,
                                 spot_interrupt_handler: bool = None)
 \`\`\`
 
-##### \`bootstrap_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.bootstrap_enabled\\"></a>
+##### \`bootstrap_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.property.bootstrap_enabled\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -13617,7 +13617,7 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 
 ---
 
-##### \`bootstrap_options\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.bootstrap_options\\"></a>
+##### \`bootstrap_options\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.property.bootstrap_options\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.BootstrapOptions\`](#aws_cdk.aws_eks.BootstrapOptions)
 - *Default:* default options
@@ -13626,7 +13626,7 @@ Allows options for node bootstrapping through EC2 user data.
 
 ---
 
-##### \`machine_image_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.machine_image_type\\"></a>
+##### \`machine_image_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.property.machine_image_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.MachineImageType\`](#aws_cdk.aws_eks.MachineImageType)
 - *Default:* MachineImageType.AMAZON_LINUX_2
@@ -13635,7 +13635,7 @@ Allow options to specify different machine image type.
 
 ---
 
-##### \`map_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.map_role\\"></a>
+##### \`map_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.property.map_role\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true if the cluster has kubectl enabled (which is the default).
@@ -13646,7 +13646,7 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 
 ---
 
-##### \`spot_interrupt_handler\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.spot_interrupt_handler\\"></a>
+##### \`spot_interrupt_handler\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.property.spot_interrupt_handler\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -13670,7 +13670,7 @@ aws_eks.AwsAuthMapping(groups: typing.List[str],
                        username: str = None)
 \`\`\`
 
-##### \`groups\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.groups\\"></a>
+##### \`groups\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.property.groups\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -13680,7 +13680,7 @@ A list of groups within Kubernetes to which the role is mapped.
 
 ---
 
-##### \`username\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.username\\"></a>
+##### \`username\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.property.username\\"></a>
 
 - *Type:* \`str\`
 - *Default:* By default, the user name is the ARN of the IAM role.
@@ -13701,7 +13701,7 @@ from aws_cdk import aws_eks
 aws_eks.AwsAuthProps(cluster: Cluster)
 \`\`\`
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthProps.property.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.Cluster\`](#aws_cdk.aws_eks.Cluster)
 
@@ -13729,7 +13729,7 @@ aws_eks.BootstrapOptions(additional_args: str = None,
                          use_max_pods: bool = None)
 \`\`\`
 
-##### \`additional_args\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.additional_args\\"></a>
+##### \`additional_args\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.additional_args\\"></a>
 
 - *Type:* \`str\`
 - *Default:* none
@@ -13740,7 +13740,7 @@ Additional command line arguments to pass to the \`/etc/eks/bootstrap.sh\` comma
 
 ---
 
-##### \`aws_api_retry_attempts\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.aws_api_retry_attempts\\"></a>
+##### \`aws_api_retry_attempts\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.aws_api_retry_attempts\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 3
@@ -13749,7 +13749,7 @@ Number of retry attempts for AWS API call (DescribeCluster).
 
 ---
 
-##### \`dns_cluster_ip\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.dns_cluster_ip\\"></a>
+##### \`dns_cluster_ip\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.dns_cluster_ip\\"></a>
 
 - *Type:* \`str\`
 - *Default:* 10.100.0.10 or 172.20.0.10 based on the IP
@@ -13759,7 +13759,7 @@ Overrides the IP address to use for DNS queries within the cluster.
 
 ---
 
-##### \`docker_config_json\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.docker_config_json\\"></a>
+##### \`docker_config_json\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.docker_config_json\\"></a>
 
 - *Type:* \`str\`
 - *Default:* none
@@ -13768,7 +13768,7 @@ The contents of the \`/etc/docker/daemon.json\` file. Useful if you want a custo
 
 ---
 
-##### \`enable_docker_bridge\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.enable_docker_bridge\\"></a>
+##### \`enable_docker_bridge\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.enable_docker_bridge\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -13777,7 +13777,7 @@ Restores the docker default bridge network.
 
 ---
 
-##### \`kubelet_extra_args\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.kubelet_extra_args\\"></a>
+##### \`kubelet_extra_args\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.kubelet_extra_args\\"></a>
 
 - *Type:* \`str\`
 - *Default:* none
@@ -13788,7 +13788,7 @@ Useful for adding labels or taints.
 
 ---
 
-##### \`use_max_pods\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.use_max_pods\\"></a>
+##### \`use_max_pods\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.use_max_pods\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -13816,7 +13816,7 @@ aws_eks.CfnAddonProps(addon_name: str,
                       tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`addon_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.addon_name\\"></a>
+##### \`addon_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.property.addon_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -13826,7 +13826,7 @@ aws_eks.CfnAddonProps(addon_name: str,
 
 ---
 
-##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -13836,7 +13836,7 @@ aws_eks.CfnAddonProps(addon_name: str,
 
 ---
 
-##### \`addon_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.addon_version\\"></a>
+##### \`addon_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.property.addon_version\\"></a>
 
 - *Type:* \`str\`
 
@@ -13846,7 +13846,7 @@ aws_eks.CfnAddonProps(addon_name: str,
 
 ---
 
-##### \`resolve_conflicts\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.resolve_conflicts\\"></a>
+##### \`resolve_conflicts\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.property.resolve_conflicts\\"></a>
 
 - *Type:* \`str\`
 
@@ -13856,7 +13856,7 @@ aws_eks.CfnAddonProps(addon_name: str,
 
 ---
 
-##### \`service_account_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.service_account_role_arn\\"></a>
+##### \`service_account_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.property.service_account_role_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -13866,7 +13866,7 @@ aws_eks.CfnAddonProps(addon_name: str,
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.property.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.CfnTag\`](#aws_cdk.CfnTag)]
 
@@ -13895,7 +13895,7 @@ aws_eks.CfnClusterProps(resources_vpc_config: typing.Union[ResourcesVpcConfigPro
                         version: str = None)
 \`\`\`
 
-##### \`resources_vpc_config\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.resources_vpc_config\\"></a>
+##### \`resources_vpc_config\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.property.resources_vpc_config\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -13905,7 +13905,7 @@ aws_eks.CfnClusterProps(resources_vpc_config: typing.Union[ResourcesVpcConfigPro
 
 ---
 
-##### \`role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.role_arn\\"></a>
+##### \`role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.property.role_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -13915,7 +13915,7 @@ aws_eks.CfnClusterProps(resources_vpc_config: typing.Union[ResourcesVpcConfigPro
 
 ---
 
-##### \`encryption_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.encryption_config\\"></a>
+##### \`encryption_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.property.encryption_config\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
@@ -13925,7 +13925,7 @@ aws_eks.CfnClusterProps(resources_vpc_config: typing.Union[ResourcesVpcConfigPro
 
 ---
 
-##### \`kubernetes_network_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.kubernetes_network_config\\"></a>
+##### \`kubernetes_network_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.property.kubernetes_network_config\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -13935,7 +13935,7 @@ aws_eks.CfnClusterProps(resources_vpc_config: typing.Union[ResourcesVpcConfigPro
 
 ---
 
-##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.name\\"></a>
+##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.property.name\\"></a>
 
 - *Type:* \`str\`
 
@@ -13945,7 +13945,7 @@ aws_eks.CfnClusterProps(resources_vpc_config: typing.Union[ResourcesVpcConfigPro
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.property.version\\"></a>
 
 - *Type:* \`str\`
 
@@ -13974,7 +13974,7 @@ aws_eks.CfnFargateProfileProps(cluster_name: str,
                                tags: typing.List[CfnTag] = None)
 \`\`\`
 
-##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -13984,7 +13984,7 @@ aws_eks.CfnFargateProfileProps(cluster_name: str,
 
 ---
 
-##### \`pod_execution_role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.pod_execution_role_arn\\"></a>
+##### \`pod_execution_role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.property.pod_execution_role_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -13994,7 +13994,7 @@ aws_eks.CfnFargateProfileProps(cluster_name: str,
 
 ---
 
-##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.selectors\\"></a>
+##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.property.selectors\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
@@ -14004,7 +14004,7 @@ aws_eks.CfnFargateProfileProps(cluster_name: str,
 
 ---
 
-##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.fargate_profile_name\\"></a>
+##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.property.fargate_profile_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -14014,7 +14014,7 @@ aws_eks.CfnFargateProfileProps(cluster_name: str,
 
 ---
 
-##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.subnets\\"></a>
+##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.property.subnets\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -14024,7 +14024,7 @@ aws_eks.CfnFargateProfileProps(cluster_name: str,
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.property.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.CfnTag\`](#aws_cdk.CfnTag)]
 
@@ -14064,7 +14064,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
                           version: str = None)
 \`\`\`
 
-##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -14074,7 +14074,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`node_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.node_role\\"></a>
+##### \`node_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.node_role\\"></a>
 
 - *Type:* \`str\`
 
@@ -14084,7 +14084,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`subnets\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.subnets\\"></a>
+##### \`subnets\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.subnets\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -14094,7 +14094,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.ami_type\\"></a>
+##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.ami_type\\"></a>
 
 - *Type:* \`str\`
 
@@ -14104,7 +14104,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.capacity_type\\"></a>
+##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.capacity_type\\"></a>
 
 - *Type:* \`str\`
 
@@ -14114,7 +14114,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.disk_size\\"></a>
+##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.disk_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -14124,7 +14124,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`force_update_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.force_update_enabled\\"></a>
+##### \`force_update_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.force_update_enabled\\"></a>
 
 - *Type:* typing.Union[\`bool\`, [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -14134,7 +14134,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.instance_types\\"></a>
+##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.instance_types\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -14144,7 +14144,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.labels\\"></a>
+##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.labels\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -14154,7 +14154,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`launch_template\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.launch_template\\"></a>
+##### \`launch_template\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.launch_template\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -14164,7 +14164,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.nodegroup_name\\"></a>
+##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.nodegroup_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -14174,7 +14174,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.release_version\\"></a>
+##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.release_version\\"></a>
 
 - *Type:* \`str\`
 
@@ -14184,7 +14184,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.remote_access\\"></a>
+##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.remote_access\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -14194,7 +14194,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`scaling_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.scaling_config\\"></a>
+##### \`scaling_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.scaling_config\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -14204,7 +14204,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.tags\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -14214,7 +14214,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`taints\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.taints\\"></a>
+##### \`taints\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.taints\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.TaintProperty\`](#aws_cdk.aws_eks.CfnNodegroup.TaintProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
@@ -14224,7 +14224,7 @@ aws_eks.CfnNodegroupProps(cluster_name: str,
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.version\\"></a>
 
 - *Type:* \`str\`
 
@@ -14260,7 +14260,7 @@ aws_eks.ClusterAttributes(cluster_name: str,
                           vpc: IVpc = None)
 \`\`\`
 
-##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -14268,7 +14268,7 @@ The physical name of the Cluster.
 
 ---
 
-##### \`cluster_certificate_authority_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.cluster_certificate_authority_data\\"></a>
+##### \`cluster_certificate_authority_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.cluster_certificate_authority_data\\"></a>
 
 - *Type:* \`str\`
 - *Default:* if not specified \`cluster.clusterCertificateAuthorityData\` will
@@ -14278,7 +14278,7 @@ The certificate-authority-data for your cluster.
 
 ---
 
-##### \`cluster_encryption_config_key_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.cluster_encryption_config_key_arn\\"></a>
+##### \`cluster_encryption_config_key_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.cluster_encryption_config_key_arn\\"></a>
 
 - *Type:* \`str\`
 - *Default:* if not specified \`cluster.clusterEncryptionConfigKeyArn\` will
@@ -14288,7 +14288,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ---
 
-##### \`cluster_endpoint\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.cluster_endpoint\\"></a>
+##### \`cluster_endpoint\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.cluster_endpoint\\"></a>
 
 - *Type:* \`str\`
 - *Default:* if not specified \`cluster.clusterEndpoint\` will throw an error.
@@ -14297,7 +14297,7 @@ The API Server endpoint URL.
 
 ---
 
-##### \`cluster_security_group_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.cluster_security_group_id\\"></a>
+##### \`cluster_security_group_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.cluster_security_group_id\\"></a>
 
 - *Type:* \`str\`
 - *Default:* if not specified \`cluster.clusterSecurityGroupId\` will throw an
@@ -14307,7 +14307,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 
 ---
 
-##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.kubectl_environment\\"></a>
+##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.kubectl_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* no additional variables
@@ -14316,7 +14316,7 @@ Environment variables to use when running \`kubectl\` against this cluster.
 
 ---
 
-##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.kubectl_layer\\"></a>
+##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.kubectl_layer\\"></a>
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 - *Default:* a layer bundled with this module.
@@ -14334,7 +14334,7 @@ The handler expects the layer to include the following executables:
 
 ---
 
-##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.kubectl_memory\\"></a>
+##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.kubectl_memory\\"></a>
 
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 - *Default:* Size.gibibytes(1)
@@ -14343,7 +14343,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-##### \`kubectl_private_subnet_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.kubectl_private_subnet_ids\\"></a>
+##### \`kubectl_private_subnet_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.kubectl_private_subnet_ids\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* k8s endpoint is expected to be accessible publicly
@@ -14355,7 +14355,7 @@ endpoint is expected to be accessible publicly.
 
 ---
 
-##### \`kubectl_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.kubectl_role_arn\\"></a>
+##### \`kubectl_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.kubectl_role_arn\\"></a>
 
 - *Type:* \`str\`
 - *Default:* if not specified, it not be possible to issue \`kubectl\` commands
@@ -14365,7 +14365,7 @@ An IAM role with cluster administrator and \\"system:masters\\" permissions.
 
 ---
 
-##### \`kubectl_security_group_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.kubectl_security_group_id\\"></a>
+##### \`kubectl_security_group_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.kubectl_security_group_id\\"></a>
 
 - *Type:* \`str\`
 - *Default:* k8s endpoint is expected to be accessible publicly
@@ -14377,7 +14377,7 @@ endpoint is expected to be accessible publicly.
 
 ---
 
-##### \`open_id_connect_provider\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.open_id_connect_provider\\"></a>
+##### \`open_id_connect_provider\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.open_id_connect_provider\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IOpenIdConnectProvider\`](#aws_cdk.aws_iam.IOpenIdConnectProvider)
 - *Default:* if not specified \`cluster.openIdConnectProvider\` and \`cluster.addServiceAccount\` will throw an error.
@@ -14389,7 +14389,7 @@ or create a new provider using \`new eks.OpenIdConnectProvider\`
 
 ---
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.prune\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -14402,7 +14402,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ---
 
-##### \`security_group_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.security_group_ids\\"></a>
+##### \`security_group_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.security_group_ids\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* if not specified, no additional security groups will be
@@ -14412,7 +14412,7 @@ Additional security groups associated with this cluster.
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* if not specified \`cluster.vpc\` will throw an error
@@ -14451,7 +14451,7 @@ aws_eks.ClusterOptions(version: KubernetesVersion,
                        secrets_encryption_key: IKey = None)
 \`\`\`
 
-##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.version\\"></a>
+##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.version\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -14459,7 +14459,7 @@ The Kubernetes version to run in the cluster.
 
 ---
 
-##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name
@@ -14468,7 +14468,7 @@ Name for the cluster.
 
 ---
 
-##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.output_cluster_name\\"></a>
+##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.output_cluster_name\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -14477,7 +14477,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 
 ---
 
-##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.output_config_command\\"></a>
+##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.output_config_command\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -14489,7 +14489,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ---
 
-##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.role\\"></a>
+##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* A role is automatically created for you
@@ -14498,7 +14498,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 
 ---
 
-##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.security_group\\"></a>
+##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.security_group\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -14507,7 +14507,7 @@ Security Group to use for Control Plane ENIs.
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
@@ -14516,7 +14516,7 @@ The VPC in which to create the Cluster.
 
 ---
 
-##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.vpc_subnets\\"></a>
+##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.vpc_subnets\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
 - *Default:* All public and private subnets
@@ -14535,7 +14535,7 @@ vpcSubnets: [
 
 ---
 
-##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.cluster_handler_environment\\"></a>
+##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.cluster_handler_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
@@ -14544,7 +14544,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ---
 
-##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.core_dns_compute_type\\"></a>
+##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.core_dns_compute_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
@@ -14553,7 +14553,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 
 ---
 
-##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.endpoint_access\\"></a>
+##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.endpoint_access\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -14564,7 +14564,7 @@ Configure access to the Kubernetes API server endpoint..
 
 ---
 
-##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.kubectl_environment\\"></a>
+##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.kubectl_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
@@ -14575,7 +14575,7 @@ Only relevant for kubectl enabled clusters.
 
 ---
 
-##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.kubectl_layer\\"></a>
+##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.kubectl_layer\\"></a>
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -14602,7 +14602,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ---
 
-##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.kubectl_memory\\"></a>
+##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.kubectl_memory\\"></a>
 
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 - *Default:* Size.gibibytes(1)
@@ -14611,7 +14611,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.masters_role\\"></a>
+##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.masters_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -14623,7 +14623,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ---
 
-##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.output_masters_role_arn\\"></a>
+##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.output_masters_role_arn\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -14632,7 +14632,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ---
 
-##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.place_cluster_handler_in_vpc\\"></a>
+##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.place_cluster_handler_in_vpc\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -14641,7 +14641,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 
 ---
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.prune\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -14654,7 +14654,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ---
 
-##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.secrets_encryption_key\\"></a>
+##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.secrets_encryption_key\\"></a>
 
 - *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
@@ -14698,7 +14698,7 @@ aws_eks.ClusterProps(version: KubernetesVersion,
                      default_capacity_type: DefaultCapacityType = None)
 \`\`\`
 
-##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.version\\"></a>
+##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.version\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -14706,7 +14706,7 @@ The Kubernetes version to run in the cluster.
 
 ---
 
-##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name
@@ -14715,7 +14715,7 @@ Name for the cluster.
 
 ---
 
-##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.output_cluster_name\\"></a>
+##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.output_cluster_name\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -14724,7 +14724,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 
 ---
 
-##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.output_config_command\\"></a>
+##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.output_config_command\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -14736,7 +14736,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ---
 
-##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.role\\"></a>
+##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* A role is automatically created for you
@@ -14745,7 +14745,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 
 ---
 
-##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.security_group\\"></a>
+##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.security_group\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -14754,7 +14754,7 @@ Security Group to use for Control Plane ENIs.
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
@@ -14763,7 +14763,7 @@ The VPC in which to create the Cluster.
 
 ---
 
-##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.vpc_subnets\\"></a>
+##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.vpc_subnets\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
 - *Default:* All public and private subnets
@@ -14782,7 +14782,7 @@ vpcSubnets: [
 
 ---
 
-##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.cluster_handler_environment\\"></a>
+##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.cluster_handler_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
@@ -14791,7 +14791,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ---
 
-##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.core_dns_compute_type\\"></a>
+##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.core_dns_compute_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
@@ -14800,7 +14800,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 
 ---
 
-##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.endpoint_access\\"></a>
+##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.endpoint_access\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -14811,7 +14811,7 @@ Configure access to the Kubernetes API server endpoint..
 
 ---
 
-##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.kubectl_environment\\"></a>
+##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.kubectl_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
@@ -14822,7 +14822,7 @@ Only relevant for kubectl enabled clusters.
 
 ---
 
-##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.kubectl_layer\\"></a>
+##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.kubectl_layer\\"></a>
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -14849,7 +14849,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ---
 
-##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.kubectl_memory\\"></a>
+##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.kubectl_memory\\"></a>
 
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 - *Default:* Size.gibibytes(1)
@@ -14858,7 +14858,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.masters_role\\"></a>
+##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.masters_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -14870,7 +14870,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ---
 
-##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.output_masters_role_arn\\"></a>
+##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.output_masters_role_arn\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -14879,7 +14879,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ---
 
-##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.place_cluster_handler_in_vpc\\"></a>
+##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.place_cluster_handler_in_vpc\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -14888,7 +14888,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 
 ---
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.prune\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -14901,7 +14901,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ---
 
-##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.secrets_encryption_key\\"></a>
+##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.secrets_encryption_key\\"></a>
 
 - *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
@@ -14912,7 +14912,7 @@ KMS secret for envelope encryption for Kubernetes secrets.
 
 ---
 
-##### \`default_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.default_capacity\\"></a>
+##### \`default_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.default_capacity\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 2
@@ -14927,7 +14927,7 @@ to \`0\` is you wish to avoid the initial capacity allocation.
 
 ---
 
-##### \`default_capacity_instance\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.default_capacity_instance\\"></a>
+##### \`default_capacity_instance\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.default_capacity_instance\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)
 - *Default:* m5.large
@@ -14939,7 +14939,7 @@ into account if \`defaultCapacity\` is > 0.
 
 ---
 
-##### \`default_capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.default_capacity_type\\"></a>
+##### \`default_capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.default_capacity_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.DefaultCapacityType\`](#aws_cdk.aws_eks.DefaultCapacityType)
 - *Default:* NODEGROUP
@@ -14967,7 +14967,7 @@ aws_eks.CommonClusterOptions(version: KubernetesVersion,
                              vpc_subnets: typing.List[SubnetSelection] = None)
 \`\`\`
 
-##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.version\\"></a>
+##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.version\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -14975,7 +14975,7 @@ The Kubernetes version to run in the cluster.
 
 ---
 
-##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name
@@ -14984,7 +14984,7 @@ Name for the cluster.
 
 ---
 
-##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.output_cluster_name\\"></a>
+##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.output_cluster_name\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -14993,7 +14993,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 
 ---
 
-##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.output_config_command\\"></a>
+##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.output_config_command\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -15005,7 +15005,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ---
 
-##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.role\\"></a>
+##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* A role is automatically created for you
@@ -15014,7 +15014,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 
 ---
 
-##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.security_group\\"></a>
+##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.security_group\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -15023,7 +15023,7 @@ Security Group to use for Control Plane ENIs.
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
@@ -15032,7 +15032,7 @@ The VPC in which to create the Cluster.
 
 ---
 
-##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.vpc_subnets\\"></a>
+##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.vpc_subnets\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
 - *Default:* All public and private subnets
@@ -15065,7 +15065,7 @@ aws_eks.EksOptimizedImageProps(cpu_arch: CpuArch = None,
                                node_type: NodeType = None)
 \`\`\`
 
-##### \`cpu_arch\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.cpu_arch\\"></a>
+##### \`cpu_arch\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.property.cpu_arch\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.CpuArch\`](#aws_cdk.aws_eks.CpuArch)
 - *Default:* CpuArch.X86_64
@@ -15074,7 +15074,7 @@ What cpu architecture to retrieve the image for (arm64 or x86_64).
 
 ---
 
-##### \`kubernetes_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.kubernetes_version\\"></a>
+##### \`kubernetes_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.property.kubernetes_version\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The latest version
@@ -15083,7 +15083,7 @@ The Kubernetes version to use.
 
 ---
 
-##### \`node_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.node_type\\"></a>
+##### \`node_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.property.node_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.NodeType\`](#aws_cdk.aws_eks.NodeType)
 - *Default:* NodeType.STANDARD
@@ -15105,7 +15105,7 @@ aws_eks.CfnCluster.EncryptionConfigProperty(provider: typing.Union[ProviderPrope
                                             resources: typing.List[str] = None)
 \`\`\`
 
-##### \`provider\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty.provider\\"></a>
+##### \`provider\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty.property.provider\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.ProviderProperty\`](#aws_cdk.aws_eks.CfnCluster.ProviderProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -15115,7 +15115,7 @@ aws_eks.CfnCluster.EncryptionConfigProperty(provider: typing.Union[ProviderPrope
 
 ---
 
-##### \`resources\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty.resources\\"></a>
+##### \`resources\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty.property.resources\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -15156,7 +15156,7 @@ aws_eks.FargateClusterProps(version: KubernetesVersion,
                             default_profile: FargateProfileOptions = None)
 \`\`\`
 
-##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.version\\"></a>
+##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.version\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -15164,7 +15164,7 @@ The Kubernetes version to run in the cluster.
 
 ---
 
-##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name
@@ -15173,7 +15173,7 @@ Name for the cluster.
 
 ---
 
-##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.output_cluster_name\\"></a>
+##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.output_cluster_name\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -15182,7 +15182,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 
 ---
 
-##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.output_config_command\\"></a>
+##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.output_config_command\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -15194,7 +15194,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ---
 
-##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.role\\"></a>
+##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* A role is automatically created for you
@@ -15203,7 +15203,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 
 ---
 
-##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.security_group\\"></a>
+##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.security_group\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -15212,7 +15212,7 @@ Security Group to use for Control Plane ENIs.
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
@@ -15221,7 +15221,7 @@ The VPC in which to create the Cluster.
 
 ---
 
-##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.vpc_subnets\\"></a>
+##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.vpc_subnets\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
 - *Default:* All public and private subnets
@@ -15240,7 +15240,7 @@ vpcSubnets: [
 
 ---
 
-##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.cluster_handler_environment\\"></a>
+##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.cluster_handler_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
@@ -15249,7 +15249,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ---
 
-##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.core_dns_compute_type\\"></a>
+##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.core_dns_compute_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
@@ -15258,7 +15258,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 
 ---
 
-##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.endpoint_access\\"></a>
+##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.endpoint_access\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -15269,7 +15269,7 @@ Configure access to the Kubernetes API server endpoint..
 
 ---
 
-##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.kubectl_environment\\"></a>
+##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.kubectl_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
@@ -15280,7 +15280,7 @@ Only relevant for kubectl enabled clusters.
 
 ---
 
-##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.kubectl_layer\\"></a>
+##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.kubectl_layer\\"></a>
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -15307,7 +15307,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ---
 
-##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.kubectl_memory\\"></a>
+##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.kubectl_memory\\"></a>
 
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 - *Default:* Size.gibibytes(1)
@@ -15316,7 +15316,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.masters_role\\"></a>
+##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.masters_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -15328,7 +15328,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ---
 
-##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.output_masters_role_arn\\"></a>
+##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.output_masters_role_arn\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -15337,7 +15337,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ---
 
-##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.place_cluster_handler_in_vpc\\"></a>
+##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.place_cluster_handler_in_vpc\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -15346,7 +15346,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 
 ---
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.prune\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -15359,7 +15359,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ---
 
-##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.secrets_encryption_key\\"></a>
+##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.secrets_encryption_key\\"></a>
 
 - *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
@@ -15370,7 +15370,7 @@ KMS secret for envelope encryption for Kubernetes secrets.
 
 ---
 
-##### \`default_profile\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.default_profile\\"></a>
+##### \`default_profile\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.default_profile\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.FargateProfileOptions\`](#aws_cdk.aws_eks.FargateProfileOptions)
 - *Default:* A profile called \\"default\\" with 'default' and 'kube-system'
@@ -15396,7 +15396,7 @@ aws_eks.FargateProfileOptions(selectors: typing.List[Selector],
                               vpc: IVpc = None)
 \`\`\`
 
-##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.selectors\\"></a>
+##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.property.selectors\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_eks.Selector\`](#aws_cdk.aws_eks.Selector)]
 
@@ -15410,7 +15410,7 @@ At least one selector is required and you may specify up to five selectors.
 
 ---
 
-##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.fargate_profile_name\\"></a>
+##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.property.fargate_profile_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* generated
@@ -15419,7 +15419,7 @@ The name of the Fargate profile.
 
 ---
 
-##### \`pod_execution_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.pod_execution_role\\"></a>
+##### \`pod_execution_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.property.pod_execution_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role will be automatically created
@@ -15434,7 +15434,7 @@ ECR image repositories.
 
 ---
 
-##### \`subnet_selection\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.subnet_selection\\"></a>
+##### \`subnet_selection\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.property.subnet_selection\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* all private subnets of the VPC are selected.
@@ -15447,7 +15447,7 @@ on Fargate are not assigned public IP addresses, so only private subnets
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.property.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* all private subnets used by theEKS cluster
@@ -15476,7 +15476,7 @@ aws_eks.FargateProfileProps(selectors: typing.List[Selector],
                             cluster: Cluster)
 \`\`\`
 
-##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.selectors\\"></a>
+##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.property.selectors\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_eks.Selector\`](#aws_cdk.aws_eks.Selector)]
 
@@ -15490,7 +15490,7 @@ At least one selector is required and you may specify up to five selectors.
 
 ---
 
-##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.fargate_profile_name\\"></a>
+##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.property.fargate_profile_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* generated
@@ -15499,7 +15499,7 @@ The name of the Fargate profile.
 
 ---
 
-##### \`pod_execution_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.pod_execution_role\\"></a>
+##### \`pod_execution_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.property.pod_execution_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role will be automatically created
@@ -15514,7 +15514,7 @@ ECR image repositories.
 
 ---
 
-##### \`subnet_selection\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.subnet_selection\\"></a>
+##### \`subnet_selection\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.property.subnet_selection\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* all private subnets of the VPC are selected.
@@ -15527,7 +15527,7 @@ on Fargate are not assigned public IP addresses, so only private subnets
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.property.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* all private subnets used by theEKS cluster
@@ -15539,7 +15539,7 @@ By default, all private subnets are selected. You can customize this using
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.property.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.Cluster\`](#aws_cdk.aws_eks.Cluster)
 
@@ -15569,7 +15569,7 @@ aws_eks.HelmChartOptions(chart: str,
                          wait: bool = None)
 \`\`\`
 
-##### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.chart\\"></a>
+##### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.chart\\"></a>
 
 - *Type:* \`str\`
 
@@ -15577,7 +15577,7 @@ The name of the chart.
 
 ---
 
-##### \`create_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.create_namespace\\"></a>
+##### \`create_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.create_namespace\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -15586,7 +15586,7 @@ create namespace if not exist.
 
 ---
 
-##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.namespace\\"></a>
+##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* default
@@ -15595,7 +15595,7 @@ The Kubernetes namespace scope of the requests.
 
 ---
 
-##### \`release\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.release\\"></a>
+##### \`release\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.release\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
@@ -15604,7 +15604,7 @@ The name of the release.
 
 ---
 
-##### \`repository\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.repository\\"></a>
+##### \`repository\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.repository\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -15615,7 +15615,7 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ---
 
-##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.timeout\\"></a>
+##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.timeout\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -15626,7 +15626,7 @@ Maximum 15 minutes.
 
 ---
 
-##### \`values\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.values\\"></a>
+##### \`values\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.values\\"></a>
 
 - *Type:* typing.Mapping[\`typing.Any\`]
 - *Default:* No values are provided to the chart.
@@ -15635,7 +15635,7 @@ The values to be used by the chart.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.version\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If this is not specified, the latest version is installed
@@ -15644,7 +15644,7 @@ The chart version to install.
 
 ---
 
-##### \`wait\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.wait\\"></a>
+##### \`wait\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.wait\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* Helm will not wait before marking release as successful
@@ -15674,7 +15674,7 @@ aws_eks.HelmChartProps(chart: str,
                        cluster: ICluster)
 \`\`\`
 
-##### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.chart\\"></a>
+##### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.chart\\"></a>
 
 - *Type:* \`str\`
 
@@ -15682,7 +15682,7 @@ The name of the chart.
 
 ---
 
-##### \`create_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.create_namespace\\"></a>
+##### \`create_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.create_namespace\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -15691,7 +15691,7 @@ create namespace if not exist.
 
 ---
 
-##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.namespace\\"></a>
+##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* default
@@ -15700,7 +15700,7 @@ The Kubernetes namespace scope of the requests.
 
 ---
 
-##### \`release\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.release\\"></a>
+##### \`release\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.release\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
@@ -15709,7 +15709,7 @@ The name of the release.
 
 ---
 
-##### \`repository\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.repository\\"></a>
+##### \`repository\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.repository\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -15720,7 +15720,7 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ---
 
-##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.timeout\\"></a>
+##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.timeout\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -15731,7 +15731,7 @@ Maximum 15 minutes.
 
 ---
 
-##### \`values\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.values\\"></a>
+##### \`values\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.values\\"></a>
 
 - *Type:* typing.Mapping[\`typing.Any\`]
 - *Default:* No values are provided to the chart.
@@ -15740,7 +15740,7 @@ The values to be used by the chart.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.version\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If this is not specified, the latest version is installed
@@ -15749,7 +15749,7 @@ The chart version to install.
 
 ---
 
-##### \`wait\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.wait\\"></a>
+##### \`wait\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.wait\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* Helm will not wait before marking release as successful
@@ -15758,7 +15758,7 @@ Whether or not Helm should wait until all Pods, PVCs, Services, and minimum numb
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -15781,7 +15781,7 @@ aws_eks.KubernetesManifestOptions(prune: bool = None,
                                   skip_validation: bool = None)
 \`\`\`
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestOptions.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestOptions.property.prune\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* based on the prune option of the cluster, which is \`true\` unless
@@ -15807,7 +15807,7 @@ empty.
 
 ---
 
-##### \`skip_validation\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestOptions.skip_validation\\"></a>
+##### \`skip_validation\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestOptions.property.skip_validation\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -15832,7 +15832,7 @@ aws_eks.KubernetesManifestProps(prune: bool = None,
                                 overwrite: bool = None)
 \`\`\`
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.property.prune\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* based on the prune option of the cluster, which is \`true\` unless
@@ -15858,7 +15858,7 @@ empty.
 
 ---
 
-##### \`skip_validation\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.skip_validation\\"></a>
+##### \`skip_validation\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.property.skip_validation\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -15867,7 +15867,7 @@ A flag to signify if the manifest validation should be skipped.
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.property.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -15877,7 +15877,7 @@ The EKS cluster to apply this manifest to.
 
 ---
 
-##### \`manifest\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.manifest\\"></a>
+##### \`manifest\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.property.manifest\\"></a>
 
 - *Type:* typing.List[typing.Mapping[\`typing.Any\`]]
 
@@ -15891,7 +15891,7 @@ deleted, the resources in the manifest will be deleted through \`kubectl delete\
 
 ---
 
-##### \`overwrite\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.overwrite\\"></a>
+##### \`overwrite\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.property.overwrite\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -15916,7 +15916,7 @@ from aws_cdk import aws_eks
 aws_eks.CfnCluster.KubernetesNetworkConfigProperty(service_ipv4_cidr: str = None)
 \`\`\`
 
-##### \`service_ipv4_cidr\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty.service_ipv4_cidr\\"></a>
+##### \`service_ipv4_cidr\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty.property.service_ipv4_cidr\\"></a>
 
 - *Type:* \`str\`
 
@@ -15943,7 +15943,7 @@ aws_eks.KubernetesObjectValueProps(cluster: ICluster,
                                    timeout: Duration = None)
 \`\`\`
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.property.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -15953,7 +15953,7 @@ The EKS cluster to fetch attributes from.
 
 ---
 
-##### \`json_path\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.json_path\\"></a>
+##### \`json_path\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.property.json_path\\"></a>
 
 - *Type:* \`str\`
 
@@ -15963,7 +15963,7 @@ JSONPath to the specific value.
 
 ---
 
-##### \`object_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.object_name\\"></a>
+##### \`object_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.property.object_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -15971,7 +15971,7 @@ The name of the object to query.
 
 ---
 
-##### \`object_type\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.object_type\\"></a>
+##### \`object_type\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.property.object_type\\"></a>
 
 - *Type:* \`str\`
 
@@ -15981,7 +15981,7 @@ The object type to query.
 
 ---
 
-##### \`object_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.object_namespace\\"></a>
+##### \`object_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.property.object_namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* 'default'
@@ -15990,7 +15990,7 @@ The namespace the object belongs to.
 
 ---
 
-##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.timeout\\"></a>
+##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.property.timeout\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -16016,7 +16016,7 @@ aws_eks.KubernetesPatchProps(apply_patch: typing.Mapping[typing.Any],
                              resource_namespace: str = None)
 \`\`\`
 
-##### \`apply_patch\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.apply_patch\\"></a>
+##### \`apply_patch\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.property.apply_patch\\"></a>
 
 - *Type:* typing.Mapping[\`typing.Any\`]
 
@@ -16024,7 +16024,7 @@ The JSON object to pass to \`kubectl patch\` when the resource is created/update
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.property.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -16034,7 +16034,7 @@ The cluster to apply the patch to.
 
 ---
 
-##### \`resource_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.resource_name\\"></a>
+##### \`resource_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.property.resource_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -16042,7 +16042,7 @@ The full name of the resource to patch (e.g. \`deployment/coredns\`).
 
 ---
 
-##### \`restore_patch\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.restore_patch\\"></a>
+##### \`restore_patch\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.property.restore_patch\\"></a>
 
 - *Type:* typing.Mapping[\`typing.Any\`]
 
@@ -16050,7 +16050,7 @@ The JSON object to pass to \`kubectl patch\` when the resource is removed.
 
 ---
 
-##### \`patch_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.patch_type\\"></a>
+##### \`patch_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.property.patch_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.PatchType\`](#aws_cdk.aws_eks.PatchType)
 - *Default:* PatchType.STRATEGIC
@@ -16061,7 +16061,7 @@ The default type used by \`kubectl patch\` is \\"strategic\\".
 
 ---
 
-##### \`resource_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.resource_namespace\\"></a>
+##### \`resource_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.property.resource_namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* \\"default\\"
@@ -16083,7 +16083,7 @@ aws_eks.CfnFargateProfile.LabelProperty(key: str,
                                         value: str)
 \`\`\`
 
-##### \`key\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.LabelProperty.key\\"></a>
+##### \`key\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.LabelProperty.property.key\\"></a>
 
 - *Type:* \`str\`
 
@@ -16093,7 +16093,7 @@ aws_eks.CfnFargateProfile.LabelProperty(key: str,
 
 ---
 
-##### \`value\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.LabelProperty.value\\"></a>
+##### \`value\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.LabelProperty.property.value\\"></a>
 
 - *Type:* \`str\`
 
@@ -16116,7 +16116,7 @@ aws_eks.LaunchTemplateSpec(id: str,
                            version: str = None)
 \`\`\`
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.LaunchTemplateSpec.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.LaunchTemplateSpec.property.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -16124,7 +16124,7 @@ The Launch template ID.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.LaunchTemplateSpec.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.LaunchTemplateSpec.property.version\\"></a>
 
 - *Type:* \`str\`
 - *Default:* the default version of the launch template
@@ -16147,7 +16147,7 @@ aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty(id: str = None,
                                                          version: str = None)
 \`\`\`
 
-##### \`id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.id\\"></a>
+##### \`id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -16157,7 +16157,7 @@ aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty(id: str = None,
 
 ---
 
-##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.name\\"></a>
+##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.name\\"></a>
 
 - *Type:* \`str\`
 
@@ -16167,7 +16167,7 @@ aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty(id: str = None,
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.version\\"></a>
 
 - *Type:* \`str\`
 
@@ -16204,7 +16204,7 @@ aws_eks.NodegroupOptions(ami_type: NodegroupAmiType = None,
                          tags: typing.Mapping[str] = None)
 \`\`\`
 
-##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.ami_type\\"></a>
+##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.ami_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.NodegroupAmiType\`](#aws_cdk.aws_eks.NodegroupAmiType)
 - *Default:* auto-determined from the instanceTypes property.
@@ -16213,7 +16213,7 @@ The AMI type for your node group.
 
 ---
 
-##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.capacity_type\\"></a>
+##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.capacity_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.CapacityType\`](#aws_cdk.aws_eks.CapacityType)
 - *Default:* ON_DEMAND
@@ -16222,7 +16222,7 @@ The capacity type of the nodegroup.
 
 ---
 
-##### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.desired_size\\"></a>
+##### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.desired_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 2
@@ -16234,7 +16234,7 @@ the nodewgroup will initially create \`minSize\` instances.
 
 ---
 
-##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.disk_size\\"></a>
+##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.disk_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 20
@@ -16243,7 +16243,7 @@ The root device disk size (in GiB) for your node group instances.
 
 ---
 
-##### \`force_update\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.force_update\\"></a>
+##### \`force_update\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.force_update\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -16256,7 +16256,7 @@ running on the node.
 
 ---
 
-##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.instance_types\\"></a>
+##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.instance_types\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)]
 - *Default:* t3.medium will be used according to the cloudformation document.
@@ -16267,7 +16267,7 @@ The instance types to use for your node group.
 
 ---
 
-##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.labels\\"></a>
+##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.labels\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* None
@@ -16276,7 +16276,7 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 
 ---
 
-##### \`launch_template_spec\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.launch_template_spec\\"></a>
+##### \`launch_template_spec\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.launch_template_spec\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.LaunchTemplateSpec\`](#aws_cdk.aws_eks.LaunchTemplateSpec)
 - *Default:* no launch template
@@ -16287,7 +16287,7 @@ Launch template specification used for the nodegroup.
 
 ---
 
-##### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.max_size\\"></a>
+##### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.max_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* desiredSize
@@ -16298,7 +16298,7 @@ Managed node groups can support up to 100 nodes by default.
 
 ---
 
-##### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.min_size\\"></a>
+##### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.min_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 1
@@ -16309,7 +16309,7 @@ This number must be greater than zero.
 
 ---
 
-##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.nodegroup_name\\"></a>
+##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.nodegroup_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* resource ID
@@ -16318,7 +16318,7 @@ Name of the Nodegroup.
 
 ---
 
-##### \`node_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.node_role\\"></a>
+##### \`node_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.node_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* None. Auto-generated if not specified.
@@ -16332,7 +16332,7 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 
 ---
 
-##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.release_version\\"></a>
+##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.release_version\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
@@ -16341,7 +16341,7 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 
 ---
 
-##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.remote_access\\"></a>
+##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.remote_access\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.NodegroupRemoteAccess\`](#aws_cdk.aws_eks.NodegroupRemoteAccess)
 - *Default:* disabled
@@ -16354,7 +16354,7 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 
 ---
 
-##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.subnets\\"></a>
+##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.subnets\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* private subnets
@@ -16368,7 +16368,7 @@ the name of your cluster.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.tags\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* None
@@ -16409,7 +16409,7 @@ aws_eks.NodegroupProps(ami_type: NodegroupAmiType = None,
                        cluster: ICluster)
 \`\`\`
 
-##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.ami_type\\"></a>
+##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.ami_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.NodegroupAmiType\`](#aws_cdk.aws_eks.NodegroupAmiType)
 - *Default:* auto-determined from the instanceTypes property.
@@ -16418,7 +16418,7 @@ The AMI type for your node group.
 
 ---
 
-##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.capacity_type\\"></a>
+##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.capacity_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.CapacityType\`](#aws_cdk.aws_eks.CapacityType)
 - *Default:* ON_DEMAND
@@ -16427,7 +16427,7 @@ The capacity type of the nodegroup.
 
 ---
 
-##### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.desired_size\\"></a>
+##### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.desired_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 2
@@ -16439,7 +16439,7 @@ the nodewgroup will initially create \`minSize\` instances.
 
 ---
 
-##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.disk_size\\"></a>
+##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.disk_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 20
@@ -16448,7 +16448,7 @@ The root device disk size (in GiB) for your node group instances.
 
 ---
 
-##### \`force_update\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.force_update\\"></a>
+##### \`force_update\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.force_update\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -16461,7 +16461,7 @@ running on the node.
 
 ---
 
-##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.instance_types\\"></a>
+##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.instance_types\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)]
 - *Default:* t3.medium will be used according to the cloudformation document.
@@ -16472,7 +16472,7 @@ The instance types to use for your node group.
 
 ---
 
-##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.labels\\"></a>
+##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.labels\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* None
@@ -16481,7 +16481,7 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 
 ---
 
-##### \`launch_template_spec\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.launch_template_spec\\"></a>
+##### \`launch_template_spec\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.launch_template_spec\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.LaunchTemplateSpec\`](#aws_cdk.aws_eks.LaunchTemplateSpec)
 - *Default:* no launch template
@@ -16492,7 +16492,7 @@ Launch template specification used for the nodegroup.
 
 ---
 
-##### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.max_size\\"></a>
+##### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.max_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* desiredSize
@@ -16503,7 +16503,7 @@ Managed node groups can support up to 100 nodes by default.
 
 ---
 
-##### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.min_size\\"></a>
+##### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.min_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 1
@@ -16514,7 +16514,7 @@ This number must be greater than zero.
 
 ---
 
-##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.nodegroup_name\\"></a>
+##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.nodegroup_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* resource ID
@@ -16523,7 +16523,7 @@ Name of the Nodegroup.
 
 ---
 
-##### \`node_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.node_role\\"></a>
+##### \`node_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.node_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* None. Auto-generated if not specified.
@@ -16537,7 +16537,7 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 
 ---
 
-##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.release_version\\"></a>
+##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.release_version\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
@@ -16546,7 +16546,7 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 
 ---
 
-##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.remote_access\\"></a>
+##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.remote_access\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.NodegroupRemoteAccess\`](#aws_cdk.aws_eks.NodegroupRemoteAccess)
 - *Default:* disabled
@@ -16559,7 +16559,7 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 
 ---
 
-##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.subnets\\"></a>
+##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.subnets\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* private subnets
@@ -16573,7 +16573,7 @@ the name of your cluster.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.tags\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* None
@@ -16586,7 +16586,7 @@ associated with the node group, such as the Amazon EC2 instances or subnets.
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -16609,7 +16609,7 @@ aws_eks.NodegroupRemoteAccess(ssh_key_name: str,
                               source_security_groups: typing.List[ISecurityGroup] = None)
 \`\`\`
 
-##### \`ssh_key_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.NodegroupRemoteAccess.ssh_key_name\\"></a>
+##### \`ssh_key_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.NodegroupRemoteAccess.property.ssh_key_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -16617,7 +16617,7 @@ The Amazon EC2 SSH key that provides access for SSH communication with the worke
 
 ---
 
-##### \`source_security_groups\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupRemoteAccess.source_security_groups\\"></a>
+##### \`source_security_groups\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupRemoteAccess.property.source_security_groups\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)]
 - *Default:* port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
@@ -16642,7 +16642,7 @@ from aws_cdk import aws_eks
 aws_eks.OpenIdConnectProviderProps(url: str)
 \`\`\`
 
-##### \`url\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.OpenIdConnectProviderProps.url\\"></a>
+##### \`url\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.OpenIdConnectProviderProps.property.url\\"></a>
 
 - *Type:* \`str\`
 
@@ -16671,7 +16671,7 @@ from aws_cdk import aws_eks
 aws_eks.CfnCluster.ProviderProperty(key_arn: str = None)
 \`\`\`
 
-##### \`key_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.ProviderProperty.key_arn\\"></a>
+##### \`key_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.ProviderProperty.property.key_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -16694,7 +16694,7 @@ aws_eks.CfnNodegroup.RemoteAccessProperty(ec2_ssh_key: str,
                                           source_security_groups: typing.List[str] = None)
 \`\`\`
 
-##### \`ec2_ssh_key\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty.ec2_ssh_key\\"></a>
+##### \`ec2_ssh_key\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty.property.ec2_ssh_key\\"></a>
 
 - *Type:* \`str\`
 
@@ -16704,7 +16704,7 @@ aws_eks.CfnNodegroup.RemoteAccessProperty(ec2_ssh_key: str,
 
 ---
 
-##### \`source_security_groups\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty.source_security_groups\\"></a>
+##### \`source_security_groups\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty.property.source_security_groups\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -16727,7 +16727,7 @@ aws_eks.CfnCluster.ResourcesVpcConfigProperty(subnet_ids: typing.List[str],
                                               security_group_ids: typing.List[str] = None)
 \`\`\`
 
-##### \`subnet_ids\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty.subnet_ids\\"></a>
+##### \`subnet_ids\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty.property.subnet_ids\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -16737,7 +16737,7 @@ aws_eks.CfnCluster.ResourcesVpcConfigProperty(subnet_ids: typing.List[str],
 
 ---
 
-##### \`security_group_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty.security_group_ids\\"></a>
+##### \`security_group_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty.property.security_group_ids\\"></a>
 
 - *Type:* typing.List[\`str\`]
 
@@ -16761,7 +16761,7 @@ aws_eks.CfnNodegroup.ScalingConfigProperty(desired_size: typing.Union[int, float
                                            min_size: typing.Union[int, float] = None)
 \`\`\`
 
-##### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty.desired_size\\"></a>
+##### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty.property.desired_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -16771,7 +16771,7 @@ aws_eks.CfnNodegroup.ScalingConfigProperty(desired_size: typing.Union[int, float
 
 ---
 
-##### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty.max_size\\"></a>
+##### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty.property.max_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -16781,7 +16781,7 @@ aws_eks.CfnNodegroup.ScalingConfigProperty(desired_size: typing.Union[int, float
 
 ---
 
-##### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty.min_size\\"></a>
+##### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty.property.min_size\\"></a>
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -16804,7 +16804,7 @@ aws_eks.Selector(namespace: str,
                  labels: typing.Mapping[str] = None)
 \`\`\`
 
-##### \`namespace\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Selector.namespace\\"></a>
+##### \`namespace\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Selector.property.namespace\\"></a>
 
 - *Type:* \`str\`
 
@@ -16816,7 +16816,7 @@ to target multiple namespaces.
 
 ---
 
-##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Selector.labels\\"></a>
+##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Selector.property.labels\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* all pods within the namespace will be selected.
@@ -16842,7 +16842,7 @@ aws_eks.CfnFargateProfile.SelectorProperty(namespace: str,
                                            labels: typing.Union[IResolvable, typing.List[typing.Union[LabelProperty, IResolvable]]] = None)
 \`\`\`
 
-##### \`namespace\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty.namespace\\"></a>
+##### \`namespace\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty.property.namespace\\"></a>
 
 - *Type:* \`str\`
 
@@ -16852,7 +16852,7 @@ aws_eks.CfnFargateProfile.SelectorProperty(namespace: str,
 
 ---
 
-##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty.labels\\"></a>
+##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty.property.labels\\"></a>
 
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnFargateProfile.LabelProperty\`](#aws_cdk.aws_eks.CfnFargateProfile.LabelProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
@@ -16875,7 +16875,7 @@ aws_eks.ServiceAccountOptions(name: str = None,
                               namespace: str = None)
 \`\`\`
 
-##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.name\\"></a>
+##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.property.name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If no name is given, it will use the id of the resource.
@@ -16884,7 +16884,7 @@ The name of the service account.
 
 ---
 
-##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.namespace\\"></a>
+##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.property.namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* \\"default\\"
@@ -16907,7 +16907,7 @@ aws_eks.ServiceAccountProps(name: str = None,
                             cluster: ICluster)
 \`\`\`
 
-##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.name\\"></a>
+##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.property.name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If no name is given, it will use the id of the resource.
@@ -16916,7 +16916,7 @@ The name of the service account.
 
 ---
 
-##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.namespace\\"></a>
+##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.property.namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* \\"default\\"
@@ -16925,7 +16925,7 @@ The namespace of the service account.
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.property.cluster\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -16946,7 +16946,7 @@ aws_eks.ServiceLoadBalancerAddressOptions(namespace: str = None,
                                           timeout: Duration = None)
 \`\`\`
 
-##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceLoadBalancerAddressOptions.namespace\\"></a>
+##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceLoadBalancerAddressOptions.property.namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* 'default'
@@ -16955,7 +16955,7 @@ The namespace the service belongs to.
 
 ---
 
-##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceLoadBalancerAddressOptions.timeout\\"></a>
+##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceLoadBalancerAddressOptions.property.timeout\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -16978,7 +16978,7 @@ aws_eks.CfnNodegroup.TaintProperty(effect: str = None,
                                    value: str = None)
 \`\`\`
 
-##### \`effect\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.TaintProperty.effect\\"></a>
+##### \`effect\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.TaintProperty.property.effect\\"></a>
 
 - *Type:* \`str\`
 
@@ -16988,7 +16988,7 @@ aws_eks.CfnNodegroup.TaintProperty(effect: str = None,
 
 ---
 
-##### \`key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.TaintProperty.key\\"></a>
+##### \`key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.TaintProperty.property.key\\"></a>
 
 - *Type:* \`str\`
 
@@ -16998,7 +16998,7 @@ aws_eks.CfnNodegroup.TaintProperty(effect: str = None,
 
 ---
 
-##### \`value\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.TaintProperty.value\\"></a>
+##### \`value\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.TaintProperty.property.value\\"></a>
 
 - *Type:* \`str\`
 
@@ -17026,7 +17026,7 @@ aws_eks.EksOptimizedImage(cpu_arch: CpuArch = None,
                           node_type: NodeType = None)
 \`\`\`
 
-##### \`cpu_arch\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.cpu_arch\\"></a>
+##### \`cpu_arch\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.parameter.cpu_arch\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.CpuArch\`](#aws_cdk.aws_eks.CpuArch)
 - *Default:* CpuArch.X86_64
@@ -17035,7 +17035,7 @@ What cpu architecture to retrieve the image for (arm64 or x86_64).
 
 ---
 
-##### \`kubernetes_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.kubernetes_version\\"></a>
+##### \`kubernetes_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.parameter.kubernetes_version\\"></a>
 
 - *Type:* \`str\`
 - *Default:* The latest version
@@ -17044,7 +17044,7 @@ The Kubernetes version to use.
 
 ---
 
-##### \`node_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.node_type\\"></a>
+##### \`node_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.parameter.node_type\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.NodeType\`](#aws_cdk.aws_eks.NodeType)
 - *Default:* NodeType.STANDARD
@@ -17061,7 +17061,7 @@ What instance type to retrieve the image for (standard or GPU-optimized).
 def get_image(scope: Construct)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImage.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImage.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -17082,7 +17082,7 @@ Endpoint access characteristics.
 def only_from(cidr: str)
 \`\`\`
 
-###### \`cidr\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.EndpointAccess.cidr\\"></a>
+###### \`cidr\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.EndpointAccess.parameter.cidr\\"></a>
 
 - *Type:* \`str\`
 
@@ -17094,7 +17094,7 @@ CIDR blocks.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`PRIVATE\` <a name=\\"aws_cdk.aws_eks.EndpointAccess.PRIVATE\\"></a>
+##### \`PRIVATE\` <a name=\\"aws_cdk.aws_eks.EndpointAccess.property.PRIVATE\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 
@@ -17104,7 +17104,7 @@ Worker node traffic to the endpoint will stay within your VPC.
 
 ---
 
-##### \`PUBLIC\` <a name=\\"aws_cdk.aws_eks.EndpointAccess.PUBLIC\\"></a>
+##### \`PUBLIC\` <a name=\\"aws_cdk.aws_eks.EndpointAccess.property.PUBLIC\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 
@@ -17119,7 +17119,7 @@ access the public endpoint from.
 
 ---
 
-##### \`PUBLIC_AND_PRIVATE\` <a name=\\"aws_cdk.aws_eks.EndpointAccess.PUBLIC_AND_PRIVATE\\"></a>
+##### \`PUBLIC_AND_PRIVATE\` <a name=\\"aws_cdk.aws_eks.EndpointAccess.property.PUBLIC_AND_PRIVATE\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 
@@ -17149,7 +17149,7 @@ from aws_cdk import aws_eks
 aws_eks.KubernetesVersion.of(version: str)
 \`\`\`
 
-###### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesVersion.version\\"></a>
+###### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesVersion.parameter.version\\"></a>
 
 - *Type:* \`str\`
 
@@ -17159,7 +17159,7 @@ custom version number.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesVersion.version\\"></a>
+##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.version\\"></a>
 
 - *Type:* \`str\`
 
@@ -17169,7 +17169,7 @@ cluster version number.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`V1_14\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.V1_14\\"></a>
+##### \`V1_14\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_14\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -17177,7 +17177,7 @@ Kubernetes version 1.14.
 
 ---
 
-##### \`V1_15\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.V1_15\\"></a>
+##### \`V1_15\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_15\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -17185,7 +17185,7 @@ Kubernetes version 1.15.
 
 ---
 
-##### \`V1_16\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.V1_16\\"></a>
+##### \`V1_16\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_16\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -17193,7 +17193,7 @@ Kubernetes version 1.16.
 
 ---
 
-##### \`V1_17\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.V1_17\\"></a>
+##### \`V1_17\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_17\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -17201,7 +17201,7 @@ Kubernetes version 1.17.
 
 ---
 
-##### \`V1_18\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.V1_18\\"></a>
+##### \`V1_18\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_18\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -17209,7 +17209,7 @@ Kubernetes version 1.18.
 
 ---
 
-##### \`V1_19\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.V1_19\\"></a>
+##### \`V1_19\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_19\\"></a>
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -17236,7 +17236,7 @@ def add_cdk8s_chart(id: str,
                     chart: Construct)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -17244,7 +17244,7 @@ logical id of this chart.
 
 ---
 
-###### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.chart\\"></a>
+###### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.parameter.chart\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -17267,7 +17267,7 @@ def add_helm_chart(id: str,
                    wait: bool = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -17275,7 +17275,7 @@ logical id of this chart.
 
 ---
 
-###### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.chart\\"></a>
+###### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.chart\\"></a>
 
 - *Type:* \`str\`
 
@@ -17283,7 +17283,7 @@ The name of the chart.
 
 ---
 
-###### \`create_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.create_namespace\\"></a>
+###### \`create_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.create_namespace\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -17292,7 +17292,7 @@ create namespace if not exist.
 
 ---
 
-###### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.namespace\\"></a>
+###### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* default
@@ -17301,7 +17301,7 @@ The Kubernetes namespace scope of the requests.
 
 ---
 
-###### \`release\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.release\\"></a>
+###### \`release\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.release\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
@@ -17310,7 +17310,7 @@ The name of the release.
 
 ---
 
-###### \`repository\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.repository\\"></a>
+###### \`repository\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.repository\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -17321,7 +17321,7 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ---
 
-###### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.timeout\\"></a>
+###### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.timeout\\"></a>
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -17332,7 +17332,7 @@ Maximum 15 minutes.
 
 ---
 
-###### \`values\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.values\\"></a>
+###### \`values\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.values\\"></a>
 
 - *Type:* typing.Mapping[\`typing.Any\`]
 - *Default:* No values are provided to the chart.
@@ -17341,7 +17341,7 @@ The values to be used by the chart.
 
 ---
 
-###### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.version\\"></a>
+###### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.version\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If this is not specified, the latest version is installed
@@ -17350,7 +17350,7 @@ The chart version to install.
 
 ---
 
-###### \`wait\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.wait\\"></a>
+###### \`wait\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.parameter.wait\\"></a>
 
 - *Type:* \`bool\`
 - *Default:* Helm will not wait before marking release as successful
@@ -17366,7 +17366,7 @@ def add_manifest(id: str,
                  manifest: typing.Mapping[typing.Any])
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -17374,7 +17374,7 @@ logical id of this manifest.
 
 ---
 
-###### \`manifest\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.manifest\\"></a>
+###### \`manifest\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.parameter.manifest\\"></a>
 
 - *Type:* typing.Mapping[\`typing.Any\`]
 
@@ -17390,7 +17390,7 @@ def add_service_account(id: str,
                         namespace: str = None)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -17398,7 +17398,7 @@ logical id of service account.
 
 ---
 
-###### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.name\\"></a>
+###### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.parameter.name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* If no name is given, it will use the id of the resource.
@@ -17407,7 +17407,7 @@ The name of the service account.
 
 ---
 
-###### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.namespace\\"></a>
+###### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.parameter.namespace\\"></a>
 
 - *Type:* \`str\`
 - *Default:* \\"default\\"
@@ -17418,7 +17418,7 @@ The namespace of the service account.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.node\\"></a>
+##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.node\\"></a>
 
 - *Type:* [\`constructs.Node\`](#constructs.Node)
 
@@ -17426,7 +17426,7 @@ The tree node.
 
 ---
 
-##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.env\\"></a>
+##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.env\\"></a>
 
 - *Type:* [\`aws_cdk.ResourceEnvironment\`](#aws_cdk.ResourceEnvironment)
 
@@ -17441,7 +17441,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.stack\\"></a>
+##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.stack\\"></a>
 
 - *Type:* [\`aws_cdk.Stack\`](#aws_cdk.Stack)
 
@@ -17449,13 +17449,13 @@ The stack in which this resource is defined.
 
 ---
 
-##### \`connections\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.connections\\"></a>
+##### \`connections\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.connections\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.Connections\`](#aws_cdk.aws_ec2.Connections)
 
 ---
 
-##### \`cluster_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.cluster_arn\\"></a>
+##### \`cluster_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -17463,7 +17463,7 @@ The unique ARN assigned to the service by AWS in the form of arn:aws:eks:.
 
 ---
 
-##### \`cluster_certificate_authority_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.cluster_certificate_authority_data\\"></a>
+##### \`cluster_certificate_authority_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_certificate_authority_data\\"></a>
 
 - *Type:* \`str\`
 
@@ -17471,7 +17471,7 @@ The certificate-authority-data for your cluster.
 
 ---
 
-##### \`cluster_encryption_config_key_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.cluster_encryption_config_key_arn\\"></a>
+##### \`cluster_encryption_config_key_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_encryption_config_key_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -17479,7 +17479,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ---
 
-##### \`cluster_endpoint\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.cluster_endpoint\\"></a>
+##### \`cluster_endpoint\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_endpoint\\"></a>
 
 - *Type:* \`str\`
 
@@ -17487,7 +17487,7 @@ The API Server endpoint URL.
 
 ---
 
-##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.cluster_name\\"></a>
+##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -17495,7 +17495,7 @@ The physical name of the Cluster.
 
 ---
 
-##### \`cluster_security_group\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.cluster_security_group\\"></a>
+##### \`cluster_security_group\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_security_group\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 
@@ -17503,7 +17503,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 
 ---
 
-##### \`cluster_security_group_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.cluster_security_group_id\\"></a>
+##### \`cluster_security_group_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_security_group_id\\"></a>
 
 - *Type:* \`str\`
 
@@ -17511,7 +17511,7 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 
 ---
 
-##### \`open_id_connect_provider\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.open_id_connect_provider\\"></a>
+##### \`open_id_connect_provider\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.open_id_connect_provider\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IOpenIdConnectProvider\`](#aws_cdk.aws_iam.IOpenIdConnectProvider)
 
@@ -17519,7 +17519,7 @@ The Open ID Connect Provider of the cluster used to configure Service Accounts.
 
 ---
 
-##### \`prune\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.prune\\"></a>
+##### \`prune\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.prune\\"></a>
 
 - *Type:* \`bool\`
 
@@ -17532,7 +17532,7 @@ apply\` operation with the \`--prune\` switch.
 
 ---
 
-##### \`vpc\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.vpc\\"></a>
+##### \`vpc\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.vpc\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 
@@ -17540,7 +17540,7 @@ The VPC in which this Cluster was created.
 
 ---
 
-##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.kubectl_environment\\"></a>
+##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.kubectl_environment\\"></a>
 
 - *Type:* typing.Mapping[\`str\`]
 
@@ -17548,7 +17548,7 @@ Custom environment variables when running \`kubectl\` against this cluster.
 
 ---
 
-##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.kubectl_layer\\"></a>
+##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.kubectl_layer\\"></a>
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 
@@ -17558,7 +17558,7 @@ If not defined, a default layer will be used.
 
 ---
 
-##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.kubectl_memory\\"></a>
+##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.kubectl_memory\\"></a>
 
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 
@@ -17566,7 +17566,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-##### \`kubectl_private_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.kubectl_private_subnets\\"></a>
+##### \`kubectl_private_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.kubectl_private_subnets\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.ISubnet\`](#aws_cdk.aws_ec2.ISubnet)]
 
@@ -17577,7 +17577,7 @@ publicly.
 
 ---
 
-##### \`kubectl_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.kubectl_role\\"></a>
+##### \`kubectl_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.kubectl_role\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
@@ -17587,7 +17587,7 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 
 ---
 
-##### \`kubectl_security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.kubectl_security_group\\"></a>
+##### \`kubectl_security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.kubectl_security_group\\"></a>
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 
@@ -17609,7 +17609,7 @@ NodeGroup interface.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.INodegroup.node\\"></a>
+##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.INodegroup.property.node\\"></a>
 
 - *Type:* [\`constructs.Node\`](#constructs.Node)
 
@@ -17617,7 +17617,7 @@ The tree node.
 
 ---
 
-##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.INodegroup.env\\"></a>
+##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.INodegroup.property.env\\"></a>
 
 - *Type:* [\`aws_cdk.ResourceEnvironment\`](#aws_cdk.ResourceEnvironment)
 
@@ -17632,7 +17632,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.INodegroup.stack\\"></a>
+##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.INodegroup.property.stack\\"></a>
 
 - *Type:* [\`aws_cdk.Stack\`](#aws_cdk.Stack)
 
@@ -17640,7 +17640,7 @@ The stack in which this resource is defined.
 
 ---
 
-##### \`nodegroup_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.INodegroup.nodegroup_name\\"></a>
+##### \`nodegroup_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.INodegroup.property.nodegroup_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -17939,7 +17939,7 @@ import { CfnPublicRepository } from '@aws-cdk/aws-ecr'
 new CfnPublicRepository(scope: Construct, id: string, props?: CfnPublicRepositoryProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.parameter.scope\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Construct\`](#@aws-cdk/core.Construct)
 
@@ -17947,7 +17947,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -17955,7 +17955,7 @@ scoped id of the resource.
 
 ---
 
-##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.props\\"></a>
+##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.CfnPublicRepositoryProps\`](#@aws-cdk/aws-ecr.CfnPublicRepositoryProps)
 
@@ -17971,7 +17971,7 @@ resource properties.
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.parameter.inspector\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TreeInspector\`](#@aws-cdk/core.TreeInspector)
 
@@ -17982,13 +17982,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.attrArn\\"></a>
+##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.attrArn\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.tags\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TagManager\`](#@aws-cdk/core.TagManager)
 
@@ -17998,7 +17998,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repositoryCatalogData\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.repositoryCatalogData\\"></a>
+##### \`repositoryCatalogData\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryCatalogData\\"></a>
 
 - *Type:* \`any\`
 
@@ -18008,7 +18008,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.repositoryPolicyText\\"></a>
+##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryPolicyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -18018,7 +18018,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -18030,7 +18030,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`string\`
 
@@ -18054,7 +18054,7 @@ import { CfnRegistryPolicy } from '@aws-cdk/aws-ecr'
 new CfnRegistryPolicy(scope: Construct, id: string, props: CfnRegistryPolicyProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.parameter.scope\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Construct\`](#@aws-cdk/core.Construct)
 
@@ -18062,7 +18062,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -18070,7 +18070,7 @@ scoped id of the resource.
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.CfnRegistryPolicyProps\`](#@aws-cdk/aws-ecr.CfnRegistryPolicyProps)
 
@@ -18086,7 +18086,7 @@ resource properties.
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.parameter.inspector\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TreeInspector\`](#@aws-cdk/core.TreeInspector)
 
@@ -18097,13 +18097,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.attrRegistryId\\"></a>
+##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.attrRegistryId\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.policyText\\"></a>
+##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.policyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -18115,7 +18115,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`string\`
 
@@ -18139,7 +18139,7 @@ import { CfnReplicationConfiguration } from '@aws-cdk/aws-ecr'
 new CfnReplicationConfiguration(scope: Construct, id: string, props: CfnReplicationConfigurationProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.parameter.scope\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Construct\`](#@aws-cdk/core.Construct)
 
@@ -18147,7 +18147,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -18155,7 +18155,7 @@ scoped id of the resource.
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.CfnReplicationConfigurationProps\`](#@aws-cdk/aws-ecr.CfnReplicationConfigurationProps)
 
@@ -18171,7 +18171,7 @@ resource properties.
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.parameter.inspector\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TreeInspector\`](#@aws-cdk/core.TreeInspector)
 
@@ -18182,13 +18182,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.attrRegistryId\\"></a>
+##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.attrRegistryId\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.replicationConfiguration\\"></a>
+##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.replicationConfiguration\\"></a>
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
 
@@ -18200,7 +18200,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`string\`
 
@@ -18224,7 +18224,7 @@ import { CfnRepository } from '@aws-cdk/aws-ecr'
 new CfnRepository(scope: Construct, id: string, props?: CfnRepositoryProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.parameter.scope\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Construct\`](#@aws-cdk/core.Construct)
 
@@ -18232,7 +18232,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -18240,7 +18240,7 @@ scoped id of the resource.
 
 ---
 
-##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.props\\"></a>
+##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.CfnRepositoryProps\`](#@aws-cdk/aws-ecr.CfnRepositoryProps)
 
@@ -18256,7 +18256,7 @@ resource properties.
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.parameter.inspector\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TreeInspector\`](#@aws-cdk/core.TreeInspector)
 
@@ -18267,19 +18267,19 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.attrArn\\"></a>
+##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.attrArn\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`attrRepositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.attrRepositoryUri\\"></a>
+##### \`attrRepositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.attrRepositoryUri\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.tags\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TagManager\`](#@aws-cdk/core.TagManager)
 
@@ -18289,7 +18289,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`encryptionConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.encryptionConfiguration\\"></a>
+##### \`encryptionConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.encryptionConfiguration\\"></a>
 
 - *Type:* \`any\`
 
@@ -18299,7 +18299,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`imageScanningConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.imageScanningConfiguration\\"></a>
+##### \`imageScanningConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.imageScanningConfiguration\\"></a>
 
 - *Type:* \`any\`
 
@@ -18309,7 +18309,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.repositoryPolicyText\\"></a>
+##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.repositoryPolicyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -18319,7 +18319,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.imageTagMutability\\"></a>
+##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.imageTagMutability\\"></a>
 
 - *Type:* \`string\`
 
@@ -18329,7 +18329,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.lifecyclePolicy\\"></a>
+##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.lifecyclePolicy\\"></a>
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty\`](#@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty)
 
@@ -18339,7 +18339,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -18351,7 +18351,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRepository.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`string\`
 
@@ -18371,19 +18371,19 @@ import { Repository } from '@aws-cdk/aws-ecr'
 new Repository(scope: Construct, id: string, props?: RepositoryProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.props\\"></a>
+##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.RepositoryProps\`](#@aws-cdk/aws-ecr.RepositoryProps)
 
@@ -18397,7 +18397,7 @@ new Repository(scope: Construct, id: string, props?: RepositoryProps)
 public addLifecycleRule(rule: LifecycleRule)
 \`\`\`
 
-###### \`rule\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.rule\\"></a>
+###### \`rule\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.rule\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.LifecycleRule\`](#@aws-cdk/aws-ecr.LifecycleRule)
 
@@ -18409,7 +18409,7 @@ public addLifecycleRule(rule: LifecycleRule)
 public addToResourcePolicy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.statement\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.PolicyStatement\`](#@aws-cdk/aws-iam.PolicyStatement)
 
@@ -18425,19 +18425,19 @@ import { Repository } from '@aws-cdk/aws-ecr'
 Repository.arnForLocalRepository(repositoryName: string, scope: IConstruct, account?: string)
 \`\`\`
 
-###### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.repositoryName\\"></a>
+###### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.IConstruct\`](#constructs.IConstruct)
 
 ---
 
-###### \`account\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.account\\"></a>
+###### \`account\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.account\\"></a>
 
 - *Type:* \`string\`
 
@@ -18451,19 +18451,19 @@ import { Repository } from '@aws-cdk/aws-ecr'
 Repository.fromRepositoryArn(scope: Construct, id: string, repositoryArn: string)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.repositoryArn\\"></a>
+###### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.repositoryArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -18477,19 +18477,19 @@ import { Repository } from '@aws-cdk/aws-ecr'
 Repository.fromRepositoryAttributes(scope: Construct, id: string, attrs: RepositoryAttributes)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`attrs\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.attrs\\"></a>
+###### \`attrs\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.attrs\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.RepositoryAttributes\`](#@aws-cdk/aws-ecr.RepositoryAttributes)
 
@@ -18503,19 +18503,19 @@ import { Repository } from '@aws-cdk/aws-ecr'
 Repository.fromRepositoryName(scope: Construct, id: string, repositoryName: string)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.repositoryName\\"></a>
+###### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -18523,7 +18523,7 @@ Repository.fromRepositoryName(scope: Construct, id: string, repositoryName: stri
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.repositoryArn\\"></a>
+##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.property.repositoryArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -18531,7 +18531,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -18556,19 +18556,19 @@ import { RepositoryBase } from '@aws-cdk/aws-ecr'
 new RepositoryBase(scope: Construct, id: string, props?: ResourceProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.props\\"></a>
+##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/core.ResourceProps\`](#@aws-cdk/core.ResourceProps)
 
@@ -18582,7 +18582,7 @@ new RepositoryBase(scope: Construct, id: string, props?: ResourceProps)
 public addToResourcePolicy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.statement\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.PolicyStatement\`](#@aws-cdk/aws-iam.PolicyStatement)
 
@@ -18594,13 +18594,13 @@ public addToResourcePolicy(statement: PolicyStatement)
 public grant(grantee: IGrantable, actions: string)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
 ---
 
-###### \`actions\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.actions\\"></a>
+###### \`actions\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.actions\\"></a>
 
 - *Type:* \`string\`
 
@@ -18612,7 +18612,7 @@ public grant(grantee: IGrantable, actions: string)
 public grantPull(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -18624,7 +18624,7 @@ public grantPull(grantee: IGrantable)
 public grantPullPush(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -18636,7 +18636,7 @@ public grantPullPush(grantee: IGrantable)
 public onCloudTrailEvent(id: string, options?: OnEventOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -18644,7 +18644,7 @@ The id of the rule.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.OnEventOptions\`](#@aws-cdk/aws-events.OnEventOptions)
 
@@ -18658,7 +18658,7 @@ Options for adding the rule.
 public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -18666,7 +18666,7 @@ The id of the rule.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions\`](#@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions)
 
@@ -18680,13 +18680,13 @@ Options for adding the rule.
 public onEvent(id: string, options?: OnEventOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.OnEventOptions\`](#@aws-cdk/aws-events.OnEventOptions)
 
@@ -18698,7 +18698,7 @@ public onEvent(id: string, options?: OnEventOptions)
 public onImageScanCompleted(id: string, options?: OnImageScanCompletedOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -18706,7 +18706,7 @@ The id of the rule.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.OnImageScanCompletedOptions\`](#@aws-cdk/aws-ecr.OnImageScanCompletedOptions)
 
@@ -18720,7 +18720,7 @@ Options for adding the rule.
 public repositoryUriForDigest(digest?: string)
 \`\`\`
 
-###### \`digest\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.digest\\"></a>
+###### \`digest\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.digest\\"></a>
 
 - *Type:* \`string\`
 
@@ -18734,7 +18734,7 @@ Optional image digest.
 public repositoryUriForTag(tag?: string)
 \`\`\`
 
-###### \`tag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.tag\\"></a>
+###### \`tag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.tag\\"></a>
 
 - *Type:* \`string\`
 
@@ -18745,7 +18745,7 @@ Optional image tag.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.repositoryArn\\"></a>
+##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -18753,7 +18753,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -18761,7 +18761,7 @@ The name of the repository.
 
 ---
 
-##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.repositoryUri\\"></a>
+##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryUri\\"></a>
 
 - *Type:* \`string\`
 
@@ -18788,7 +18788,7 @@ import { CfnPublicRepositoryProps } from '@aws-cdk/aws-ecr'
 const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 \`\`\`
 
-##### \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryCatalogData\\"></a>
+##### \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 - *Type:* \`any\`
 
@@ -18798,7 +18798,7 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ---
 
-##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -18808,7 +18808,7 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ---
 
-##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryPolicyText\\"></a>
+##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -18818,7 +18818,7 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
 
@@ -18842,7 +18842,7 @@ import { CfnRegistryPolicyProps } from '@aws-cdk/aws-ecr'
 const cfnRegistryPolicyProps: CfnRegistryPolicyProps = { ... }
 \`\`\`
 
-##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicyProps.policyText\\"></a>
+##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicyProps.property.policyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -18866,7 +18866,7 @@ import { CfnReplicationConfigurationProps } from '@aws-cdk/aws-ecr'
 const cfnReplicationConfigurationProps: CfnReplicationConfigurationProps = { ... }
 \`\`\`
 
-##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfigurationProps.replicationConfiguration\\"></a>
+##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfigurationProps.property.replicationConfiguration\\"></a>
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
 
@@ -18890,7 +18890,7 @@ import { CfnRepositoryProps } from '@aws-cdk/aws-ecr'
 const cfnRepositoryProps: CfnRepositoryProps = { ... }
 \`\`\`
 
-##### \`encryptionConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.encryptionConfiguration\\"></a>
+##### \`encryptionConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.encryptionConfiguration\\"></a>
 
 - *Type:* \`any\`
 
@@ -18900,7 +18900,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ---
 
-##### \`imageScanningConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.imageScanningConfiguration\\"></a>
+##### \`imageScanningConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.imageScanningConfiguration\\"></a>
 
 - *Type:* \`any\`
 
@@ -18910,7 +18910,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ---
 
-##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.imageTagMutability\\"></a>
+##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.imageTagMutability\\"></a>
 
 - *Type:* \`string\`
 
@@ -18920,7 +18920,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ---
 
-##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.lifecyclePolicy\\"></a>
+##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.lifecyclePolicy\\"></a>
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty\`](#@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty)
 
@@ -18930,7 +18930,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ---
 
-##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -18940,7 +18940,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ---
 
-##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.repositoryPolicyText\\"></a>
+##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.repositoryPolicyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -18950,7 +18950,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.tags\\"></a>
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
 
@@ -18972,7 +18972,7 @@ import { LifecyclePolicyProperty } from '@aws-cdk/aws-ecr'
 const lifecyclePolicyProperty: LifecyclePolicyProperty = { ... }
 \`\`\`
 
-##### \`lifecyclePolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.lifecyclePolicyText\\"></a>
+##### \`lifecyclePolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.property.lifecyclePolicyText\\"></a>
 
 - *Type:* \`string\`
 
@@ -18982,7 +18982,7 @@ const lifecyclePolicyProperty: LifecyclePolicyProperty = { ... }
 
 ---
 
-##### \`registryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.registryId\\"></a>
+##### \`registryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.property.registryId\\"></a>
 
 - *Type:* \`string\`
 
@@ -19004,7 +19004,7 @@ import { LifecycleRule } from '@aws-cdk/aws-ecr'
 const lifecycleRule: LifecycleRule = { ... }
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.description\\"></a>
 
 - *Type:* \`string\`
 - *Default:* No description
@@ -19013,7 +19013,7 @@ Describes the purpose of the rule.
 
 ---
 
-##### \`maxImageAge\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.maxImageAge\\"></a>
+##### \`maxImageAge\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.maxImageAge\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Duration\`](#@aws-cdk/core.Duration)
 
@@ -19023,7 +19023,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-##### \`maxImageCount\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.maxImageCount\\"></a>
+##### \`maxImageCount\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.maxImageCount\\"></a>
 
 - *Type:* \`number\`
 
@@ -19033,7 +19033,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-##### \`rulePriority\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.rulePriority\\"></a>
+##### \`rulePriority\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.rulePriority\\"></a>
 
 - *Type:* \`number\`
 - *Default:* Automatically assigned
@@ -19051,7 +19051,7 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
-##### \`tagPrefixList\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.tagPrefixList\\"></a>
+##### \`tagPrefixList\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.tagPrefixList\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -19061,7 +19061,7 @@ Only if tagStatus == TagStatus.Tagged
 
 ---
 
-##### \`tagStatus\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.tagStatus\\"></a>
+##### \`tagStatus\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.tagStatus\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.TagStatus\`](#@aws-cdk/aws-ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -19085,7 +19085,7 @@ import { OnCloudTrailImagePushedOptions } from '@aws-cdk/aws-ecr'
 const onCloudTrailImagePushedOptions: OnCloudTrailImagePushedOptions = { ... }
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
 - *Type:* \`string\`
 - *Default:* No description
@@ -19094,7 +19094,7 @@ A description of the rule's purpose.
 
 ---
 
-##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.eventPattern\\"></a>
+##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.eventPattern\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.EventPattern\`](#@aws-cdk/aws-events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -19109,7 +19109,7 @@ on top of that filtering.
 
 ---
 
-##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.ruleName\\"></a>
+##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.ruleName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -19118,7 +19118,7 @@ A name for the rule.
 
 ---
 
-##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.target\\"></a>
+##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.IRuleTarget\`](#@aws-cdk/aws-events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -19127,7 +19127,7 @@ The target to register for the event.
 
 ---
 
-##### \`imageTag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.imageTag\\"></a>
+##### \`imageTag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.imageTag\\"></a>
 
 - *Type:* \`string\`
 - *Default:* Watch changes to all tags
@@ -19148,7 +19148,7 @@ import { OnImageScanCompletedOptions } from '@aws-cdk/aws-ecr'
 const onImageScanCompletedOptions: OnImageScanCompletedOptions = { ... }
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
 - *Type:* \`string\`
 - *Default:* No description
@@ -19157,7 +19157,7 @@ A description of the rule's purpose.
 
 ---
 
-##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.eventPattern\\"></a>
+##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.eventPattern\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.EventPattern\`](#@aws-cdk/aws-events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -19172,7 +19172,7 @@ on top of that filtering.
 
 ---
 
-##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.ruleName\\"></a>
+##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.ruleName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -19181,7 +19181,7 @@ A name for the rule.
 
 ---
 
-##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.target\\"></a>
+##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.IRuleTarget\`](#@aws-cdk/aws-events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -19190,7 +19190,7 @@ The target to register for the event.
 
 ---
 
-##### \`imageTags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.imageTags\\"></a>
+##### \`imageTags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.imageTags\\"></a>
 
 - *Type:* \`string\`[]
 - *Default:* Watch the changes to the repository with all image tags
@@ -19213,7 +19213,7 @@ import { ReplicationConfigurationProperty } from '@aws-cdk/aws-ecr'
 const replicationConfigurationProperty: ReplicationConfigurationProperty = { ... }
 \`\`\`
 
-##### \`rules\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.rules\\"></a>
+##### \`rules\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty)[]
 
@@ -19235,7 +19235,7 @@ import { ReplicationDestinationProperty } from '@aws-cdk/aws-ecr'
 const replicationDestinationProperty: ReplicationDestinationProperty = { ... }
 \`\`\`
 
-##### \`region\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.region\\"></a>
+##### \`region\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
 - *Type:* \`string\`
 
@@ -19245,7 +19245,7 @@ const replicationDestinationProperty: ReplicationDestinationProperty = { ... }
 
 ---
 
-##### \`registryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.registryId\\"></a>
+##### \`registryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registryId\\"></a>
 
 - *Type:* \`string\`
 
@@ -19267,7 +19267,7 @@ import { ReplicationRuleProperty } from '@aws-cdk/aws-ecr'
 const replicationRuleProperty: ReplicationRuleProperty = { ... }
 \`\`\`
 
-##### \`destinations\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty.destinations\\"></a>
+##### \`destinations\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)[]
 
@@ -19287,13 +19287,13 @@ import { RepositoryAttributes } from '@aws-cdk/aws-ecr'
 const repositoryAttributes: RepositoryAttributes = { ... }
 \`\`\`
 
-##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.repositoryArn\\"></a>
+##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.property.repositoryArn\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -19309,7 +19309,7 @@ import { RepositoryProps } from '@aws-cdk/aws-ecr'
 const repositoryProps: RepositoryProps = { ... }
 \`\`\`
 
-##### \`imageScanOnPush\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.imageScanOnPush\\"></a>
+##### \`imageScanOnPush\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.imageScanOnPush\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -19318,7 +19318,7 @@ Enable the scan on push when creating the repository.
 
 ---
 
-##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.imageTagMutability\\"></a>
+##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.imageTagMutability\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.TagMutability\`](#@aws-cdk/aws-ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -19329,7 +19329,7 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ---
 
-##### \`lifecycleRegistryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.lifecycleRegistryId\\"></a>
+##### \`lifecycleRegistryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.lifecycleRegistryId\\"></a>
 
 - *Type:* \`string\`
 - *Default:* The default registry is assumed.
@@ -19340,7 +19340,7 @@ The AWS account ID associated with the registry that contains the repository.
 
 ---
 
-##### \`lifecycleRules\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.lifecycleRules\\"></a>
+##### \`lifecycleRules\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.lifecycleRules\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.LifecycleRule\`](#@aws-cdk/aws-ecr.LifecycleRule)[]
 - *Default:* No life cycle rules
@@ -19349,7 +19349,7 @@ Life cycle rules to apply to this registry.
 
 ---
 
-##### \`removalPolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.removalPolicy\\"></a>
+##### \`removalPolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.removalPolicy\\"></a>
 
 - *Type:* [\`@aws-cdk/core.RemovalPolicy\`](#@aws-cdk/core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
@@ -19358,7 +19358,7 @@ Determine what happens to the repository when the resource/stack is deleted.
 
 ---
 
-##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* Automatically generated name.
@@ -19386,7 +19386,7 @@ import { AuthorizationToken } from '@aws-cdk/aws-ecr'
 AuthorizationToken.grantRead(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -19411,7 +19411,7 @@ import { PublicGalleryAuthorizationToken } from '@aws-cdk/aws-ecr'
 PublicGalleryAuthorizationToken.grantRead(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.PublicGalleryAuthorizationToken.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.PublicGalleryAuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -19437,7 +19437,7 @@ Represents an ECR repository.
 public addToResourcePolicy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.statement\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.PolicyStatement\`](#@aws-cdk/aws-iam.PolicyStatement)
 
@@ -19449,13 +19449,13 @@ public addToResourcePolicy(statement: PolicyStatement)
 public grant(grantee: IGrantable, actions: string)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
 ---
 
-###### \`actions\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.actions\\"></a>
+###### \`actions\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.actions\\"></a>
 
 - *Type:* \`string\`
 
@@ -19467,7 +19467,7 @@ public grant(grantee: IGrantable, actions: string)
 public grantPull(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -19479,7 +19479,7 @@ public grantPull(grantee: IGrantable)
 public grantPullPush(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -19491,7 +19491,7 @@ public grantPullPush(grantee: IGrantable)
 public onCloudTrailEvent(id: string, options?: OnEventOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -19499,7 +19499,7 @@ The id of the rule.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.OnEventOptions\`](#@aws-cdk/aws-events.OnEventOptions)
 
@@ -19513,7 +19513,7 @@ Options for adding the rule.
 public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -19521,7 +19521,7 @@ The id of the rule.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions\`](#@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions)
 
@@ -19535,13 +19535,13 @@ Options for adding the rule.
 public onEvent(id: string, options?: OnEventOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.OnEventOptions\`](#@aws-cdk/aws-events.OnEventOptions)
 
@@ -19553,7 +19553,7 @@ public onEvent(id: string, options?: OnEventOptions)
 public onImageScanCompleted(id: string, options?: OnImageScanCompletedOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -19561,7 +19561,7 @@ The id of the rule.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.OnImageScanCompletedOptions\`](#@aws-cdk/aws-ecr.OnImageScanCompletedOptions)
 
@@ -19575,7 +19575,7 @@ Options for adding the rule.
 public repositoryUriForDigest(digest?: string)
 \`\`\`
 
-###### \`digest\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.digest\\"></a>
+###### \`digest\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.digest\\"></a>
 
 - *Type:* \`string\`
 
@@ -19589,7 +19589,7 @@ Image digest to use (tools usually default to the image with the \\"latest\\" ta
 public repositoryUriForTag(tag?: string)
 \`\`\`
 
-###### \`tag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.tag\\"></a>
+###### \`tag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.tag\\"></a>
 
 - *Type:* \`string\`
 
@@ -19599,7 +19599,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`node\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.node\\"></a>
+##### \`node\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.node\\"></a>
 
 - *Type:* [\`@aws-cdk/core.ConstructNode\`](#@aws-cdk/core.ConstructNode)
 
@@ -19607,7 +19607,7 @@ The construct tree node for this construct.
 
 ---
 
-##### \`env\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.env\\"></a>
+##### \`env\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.env\\"></a>
 
 - *Type:* [\`@aws-cdk/core.ResourceEnvironment\`](#@aws-cdk/core.ResourceEnvironment)
 
@@ -19622,7 +19622,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-##### \`stack\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.stack\\"></a>
+##### \`stack\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.stack\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Stack\`](#@aws-cdk/core.Stack)
 
@@ -19630,7 +19630,7 @@ The stack in which this resource is defined.
 
 ---
 
-##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.repositoryArn\\"></a>
+##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -19638,7 +19638,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -19646,7 +19646,7 @@ The name of the repository.
 
 ---
 
-##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.repositoryUri\\"></a>
+##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryUri\\"></a>
 
 - *Type:* \`string\`
 
@@ -19821,7 +19821,7 @@ import { CfnPublicRepository } from '@aws-cdk/aws-ecr'
 new CfnPublicRepository(scope: Construct, id: string, props?: CfnPublicRepositoryProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.parameter.scope\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Construct\`](#@aws-cdk/core.Construct)
 
@@ -19829,7 +19829,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -19837,7 +19837,7 @@ scoped id of the resource.
 
 ---
 
-##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.props\\"></a>
+##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.CfnPublicRepositoryProps\`](#@aws-cdk/aws-ecr.CfnPublicRepositoryProps)
 
@@ -19853,7 +19853,7 @@ resource properties.
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.parameter.inspector\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TreeInspector\`](#@aws-cdk/core.TreeInspector)
 
@@ -19864,13 +19864,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.attrArn\\"></a>
+##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.attrArn\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.tags\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TagManager\`](#@aws-cdk/core.TagManager)
 
@@ -19880,7 +19880,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repositoryCatalogData\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.repositoryCatalogData\\"></a>
+##### \`repositoryCatalogData\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryCatalogData\\"></a>
 
 - *Type:* \`any\`
 
@@ -19890,7 +19890,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.repositoryPolicyText\\"></a>
+##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryPolicyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -19900,7 +19900,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -19912,7 +19912,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`string\`
 
@@ -19936,7 +19936,7 @@ import { CfnRegistryPolicy } from '@aws-cdk/aws-ecr'
 new CfnRegistryPolicy(scope: Construct, id: string, props: CfnRegistryPolicyProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.parameter.scope\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Construct\`](#@aws-cdk/core.Construct)
 
@@ -19944,7 +19944,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -19952,7 +19952,7 @@ scoped id of the resource.
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.CfnRegistryPolicyProps\`](#@aws-cdk/aws-ecr.CfnRegistryPolicyProps)
 
@@ -19968,7 +19968,7 @@ resource properties.
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.parameter.inspector\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TreeInspector\`](#@aws-cdk/core.TreeInspector)
 
@@ -19979,13 +19979,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.attrRegistryId\\"></a>
+##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.attrRegistryId\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.policyText\\"></a>
+##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.policyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -19997,7 +19997,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`string\`
 
@@ -20021,7 +20021,7 @@ import { CfnReplicationConfiguration } from '@aws-cdk/aws-ecr'
 new CfnReplicationConfiguration(scope: Construct, id: string, props: CfnReplicationConfigurationProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.parameter.scope\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Construct\`](#@aws-cdk/core.Construct)
 
@@ -20029,7 +20029,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -20037,7 +20037,7 @@ scoped id of the resource.
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.CfnReplicationConfigurationProps\`](#@aws-cdk/aws-ecr.CfnReplicationConfigurationProps)
 
@@ -20053,7 +20053,7 @@ resource properties.
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.parameter.inspector\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TreeInspector\`](#@aws-cdk/core.TreeInspector)
 
@@ -20064,13 +20064,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.attrRegistryId\\"></a>
+##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.attrRegistryId\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.replicationConfiguration\\"></a>
+##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.replicationConfiguration\\"></a>
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
 
@@ -20082,7 +20082,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`string\`
 
@@ -20106,7 +20106,7 @@ import { CfnRepository } from '@aws-cdk/aws-ecr'
 new CfnRepository(scope: Construct, id: string, props?: CfnRepositoryProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.parameter.scope\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Construct\`](#@aws-cdk/core.Construct)
 
@@ -20114,7 +20114,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -20122,7 +20122,7 @@ scoped id of the resource.
 
 ---
 
-##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.props\\"></a>
+##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.CfnRepositoryProps\`](#@aws-cdk/aws-ecr.CfnRepositoryProps)
 
@@ -20138,7 +20138,7 @@ resource properties.
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.parameter.inspector\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TreeInspector\`](#@aws-cdk/core.TreeInspector)
 
@@ -20149,19 +20149,19 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.attrArn\\"></a>
+##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.attrArn\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`attrRepositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.attrRepositoryUri\\"></a>
+##### \`attrRepositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.attrRepositoryUri\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.tags\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TagManager\`](#@aws-cdk/core.TagManager)
 
@@ -20171,7 +20171,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`encryptionConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.encryptionConfiguration\\"></a>
+##### \`encryptionConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.encryptionConfiguration\\"></a>
 
 - *Type:* \`any\`
 
@@ -20181,7 +20181,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`imageScanningConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.imageScanningConfiguration\\"></a>
+##### \`imageScanningConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.imageScanningConfiguration\\"></a>
 
 - *Type:* \`any\`
 
@@ -20191,7 +20191,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.repositoryPolicyText\\"></a>
+##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.repositoryPolicyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -20201,7 +20201,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.imageTagMutability\\"></a>
+##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.imageTagMutability\\"></a>
 
 - *Type:* \`string\`
 
@@ -20211,7 +20211,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.lifecyclePolicy\\"></a>
+##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.lifecyclePolicy\\"></a>
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty\`](#@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty)
 
@@ -20221,7 +20221,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -20233,7 +20233,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRepository.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`string\`
 
@@ -20253,19 +20253,19 @@ import { Repository } from '@aws-cdk/aws-ecr'
 new Repository(scope: Construct, id: string, props?: RepositoryProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.props\\"></a>
+##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.RepositoryProps\`](#@aws-cdk/aws-ecr.RepositoryProps)
 
@@ -20279,7 +20279,7 @@ new Repository(scope: Construct, id: string, props?: RepositoryProps)
 public addLifecycleRule(rule: LifecycleRule)
 \`\`\`
 
-###### \`rule\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.rule\\"></a>
+###### \`rule\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.rule\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.LifecycleRule\`](#@aws-cdk/aws-ecr.LifecycleRule)
 
@@ -20291,7 +20291,7 @@ public addLifecycleRule(rule: LifecycleRule)
 public addToResourcePolicy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.statement\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.PolicyStatement\`](#@aws-cdk/aws-iam.PolicyStatement)
 
@@ -20307,19 +20307,19 @@ import { Repository } from '@aws-cdk/aws-ecr'
 Repository.arnForLocalRepository(repositoryName: string, scope: IConstruct, account?: string)
 \`\`\`
 
-###### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.repositoryName\\"></a>
+###### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.IConstruct\`](#constructs.IConstruct)
 
 ---
 
-###### \`account\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.account\\"></a>
+###### \`account\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.account\\"></a>
 
 - *Type:* \`string\`
 
@@ -20333,19 +20333,19 @@ import { Repository } from '@aws-cdk/aws-ecr'
 Repository.fromRepositoryArn(scope: Construct, id: string, repositoryArn: string)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.repositoryArn\\"></a>
+###### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.repositoryArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -20359,19 +20359,19 @@ import { Repository } from '@aws-cdk/aws-ecr'
 Repository.fromRepositoryAttributes(scope: Construct, id: string, attrs: RepositoryAttributes)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`attrs\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.attrs\\"></a>
+###### \`attrs\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.attrs\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.RepositoryAttributes\`](#@aws-cdk/aws-ecr.RepositoryAttributes)
 
@@ -20385,19 +20385,19 @@ import { Repository } from '@aws-cdk/aws-ecr'
 Repository.fromRepositoryName(scope: Construct, id: string, repositoryName: string)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.repositoryName\\"></a>
+###### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.parameter.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -20405,7 +20405,7 @@ Repository.fromRepositoryName(scope: Construct, id: string, repositoryName: stri
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.repositoryArn\\"></a>
+##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.property.repositoryArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -20413,7 +20413,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -20438,19 +20438,19 @@ import { RepositoryBase } from '@aws-cdk/aws-ecr'
 new RepositoryBase(scope: Construct, id: string, props?: ResourceProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.props\\"></a>
+##### \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/core.ResourceProps\`](#@aws-cdk/core.ResourceProps)
 
@@ -20464,7 +20464,7 @@ new RepositoryBase(scope: Construct, id: string, props?: ResourceProps)
 public addToResourcePolicy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.statement\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.PolicyStatement\`](#@aws-cdk/aws-iam.PolicyStatement)
 
@@ -20476,13 +20476,13 @@ public addToResourcePolicy(statement: PolicyStatement)
 public grant(grantee: IGrantable, actions: string)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
 ---
 
-###### \`actions\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.actions\\"></a>
+###### \`actions\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.actions\\"></a>
 
 - *Type:* \`string\`
 
@@ -20494,7 +20494,7 @@ public grant(grantee: IGrantable, actions: string)
 public grantPull(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -20506,7 +20506,7 @@ public grantPull(grantee: IGrantable)
 public grantPullPush(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -20518,7 +20518,7 @@ public grantPullPush(grantee: IGrantable)
 public onCloudTrailEvent(id: string, options?: OnEventOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -20526,7 +20526,7 @@ The id of the rule.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.OnEventOptions\`](#@aws-cdk/aws-events.OnEventOptions)
 
@@ -20540,7 +20540,7 @@ Options for adding the rule.
 public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -20548,7 +20548,7 @@ The id of the rule.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions\`](#@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions)
 
@@ -20562,13 +20562,13 @@ Options for adding the rule.
 public onEvent(id: string, options?: OnEventOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.OnEventOptions\`](#@aws-cdk/aws-events.OnEventOptions)
 
@@ -20580,7 +20580,7 @@ public onEvent(id: string, options?: OnEventOptions)
 public onImageScanCompleted(id: string, options?: OnImageScanCompletedOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -20588,7 +20588,7 @@ The id of the rule.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.OnImageScanCompletedOptions\`](#@aws-cdk/aws-ecr.OnImageScanCompletedOptions)
 
@@ -20602,7 +20602,7 @@ Options for adding the rule.
 public repositoryUriForDigest(digest?: string)
 \`\`\`
 
-###### \`digest\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.digest\\"></a>
+###### \`digest\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.digest\\"></a>
 
 - *Type:* \`string\`
 
@@ -20616,7 +20616,7 @@ Optional image digest.
 public repositoryUriForTag(tag?: string)
 \`\`\`
 
-###### \`tag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.tag\\"></a>
+###### \`tag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.parameter.tag\\"></a>
 
 - *Type:* \`string\`
 
@@ -20627,7 +20627,7 @@ Optional image tag.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.repositoryArn\\"></a>
+##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -20635,7 +20635,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -20643,7 +20643,7 @@ The name of the repository.
 
 ---
 
-##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.repositoryUri\\"></a>
+##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryUri\\"></a>
 
 - *Type:* \`string\`
 
@@ -20670,7 +20670,7 @@ import { CfnPublicRepositoryProps } from '@aws-cdk/aws-ecr'
 const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 \`\`\`
 
-##### \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryCatalogData\\"></a>
+##### \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 - *Type:* \`any\`
 
@@ -20680,7 +20680,7 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ---
 
-##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -20690,7 +20690,7 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ---
 
-##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryPolicyText\\"></a>
+##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -20700,7 +20700,7 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
 
@@ -20724,7 +20724,7 @@ import { CfnRegistryPolicyProps } from '@aws-cdk/aws-ecr'
 const cfnRegistryPolicyProps: CfnRegistryPolicyProps = { ... }
 \`\`\`
 
-##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicyProps.policyText\\"></a>
+##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicyProps.property.policyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -20748,7 +20748,7 @@ import { CfnReplicationConfigurationProps } from '@aws-cdk/aws-ecr'
 const cfnReplicationConfigurationProps: CfnReplicationConfigurationProps = { ... }
 \`\`\`
 
-##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfigurationProps.replicationConfiguration\\"></a>
+##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfigurationProps.property.replicationConfiguration\\"></a>
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
 
@@ -20772,7 +20772,7 @@ import { CfnRepositoryProps } from '@aws-cdk/aws-ecr'
 const cfnRepositoryProps: CfnRepositoryProps = { ... }
 \`\`\`
 
-##### \`encryptionConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.encryptionConfiguration\\"></a>
+##### \`encryptionConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.encryptionConfiguration\\"></a>
 
 - *Type:* \`any\`
 
@@ -20782,7 +20782,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ---
 
-##### \`imageScanningConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.imageScanningConfiguration\\"></a>
+##### \`imageScanningConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.imageScanningConfiguration\\"></a>
 
 - *Type:* \`any\`
 
@@ -20792,7 +20792,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ---
 
-##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.imageTagMutability\\"></a>
+##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.imageTagMutability\\"></a>
 
 - *Type:* \`string\`
 
@@ -20802,7 +20802,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ---
 
-##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.lifecyclePolicy\\"></a>
+##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.lifecyclePolicy\\"></a>
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty\`](#@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty)
 
@@ -20812,7 +20812,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ---
 
-##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -20822,7 +20822,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ---
 
-##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.repositoryPolicyText\\"></a>
+##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.repositoryPolicyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -20832,7 +20832,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.tags\\"></a>
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
 
@@ -20854,7 +20854,7 @@ import { LifecyclePolicyProperty } from '@aws-cdk/aws-ecr'
 const lifecyclePolicyProperty: LifecyclePolicyProperty = { ... }
 \`\`\`
 
-##### \`lifecyclePolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.lifecyclePolicyText\\"></a>
+##### \`lifecyclePolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.property.lifecyclePolicyText\\"></a>
 
 - *Type:* \`string\`
 
@@ -20864,7 +20864,7 @@ const lifecyclePolicyProperty: LifecyclePolicyProperty = { ... }
 
 ---
 
-##### \`registryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.registryId\\"></a>
+##### \`registryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.property.registryId\\"></a>
 
 - *Type:* \`string\`
 
@@ -20886,7 +20886,7 @@ import { LifecycleRule } from '@aws-cdk/aws-ecr'
 const lifecycleRule: LifecycleRule = { ... }
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.description\\"></a>
 
 - *Type:* \`string\`
 - *Default:* No description
@@ -20895,7 +20895,7 @@ Describes the purpose of the rule.
 
 ---
 
-##### \`maxImageAge\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.maxImageAge\\"></a>
+##### \`maxImageAge\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.maxImageAge\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Duration\`](#@aws-cdk/core.Duration)
 
@@ -20905,7 +20905,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-##### \`maxImageCount\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.maxImageCount\\"></a>
+##### \`maxImageCount\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.maxImageCount\\"></a>
 
 - *Type:* \`number\`
 
@@ -20915,7 +20915,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ---
 
-##### \`rulePriority\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.rulePriority\\"></a>
+##### \`rulePriority\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.rulePriority\\"></a>
 
 - *Type:* \`number\`
 - *Default:* Automatically assigned
@@ -20933,7 +20933,7 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
-##### \`tagPrefixList\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.tagPrefixList\\"></a>
+##### \`tagPrefixList\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.tagPrefixList\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -20943,7 +20943,7 @@ Only if tagStatus == TagStatus.Tagged
 
 ---
 
-##### \`tagStatus\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.tagStatus\\"></a>
+##### \`tagStatus\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.tagStatus\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.TagStatus\`](#@aws-cdk/aws-ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -20967,7 +20967,7 @@ import { OnCloudTrailImagePushedOptions } from '@aws-cdk/aws-ecr'
 const onCloudTrailImagePushedOptions: OnCloudTrailImagePushedOptions = { ... }
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
 - *Type:* \`string\`
 - *Default:* No description
@@ -20976,7 +20976,7 @@ A description of the rule's purpose.
 
 ---
 
-##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.eventPattern\\"></a>
+##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.eventPattern\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.EventPattern\`](#@aws-cdk/aws-events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -20991,7 +20991,7 @@ on top of that filtering.
 
 ---
 
-##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.ruleName\\"></a>
+##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.ruleName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -21000,7 +21000,7 @@ A name for the rule.
 
 ---
 
-##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.target\\"></a>
+##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.IRuleTarget\`](#@aws-cdk/aws-events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -21009,7 +21009,7 @@ The target to register for the event.
 
 ---
 
-##### \`imageTag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.imageTag\\"></a>
+##### \`imageTag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.imageTag\\"></a>
 
 - *Type:* \`string\`
 - *Default:* Watch changes to all tags
@@ -21030,7 +21030,7 @@ import { OnImageScanCompletedOptions } from '@aws-cdk/aws-ecr'
 const onImageScanCompletedOptions: OnImageScanCompletedOptions = { ... }
 \`\`\`
 
-##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.description\\"></a>
+##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
 - *Type:* \`string\`
 - *Default:* No description
@@ -21039,7 +21039,7 @@ A description of the rule's purpose.
 
 ---
 
-##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.eventPattern\\"></a>
+##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.eventPattern\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.EventPattern\`](#@aws-cdk/aws-events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -21054,7 +21054,7 @@ on top of that filtering.
 
 ---
 
-##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.ruleName\\"></a>
+##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.ruleName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -21063,7 +21063,7 @@ A name for the rule.
 
 ---
 
-##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.target\\"></a>
+##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.IRuleTarget\`](#@aws-cdk/aws-events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -21072,7 +21072,7 @@ The target to register for the event.
 
 ---
 
-##### \`imageTags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.imageTags\\"></a>
+##### \`imageTags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.imageTags\\"></a>
 
 - *Type:* \`string\`[]
 - *Default:* Watch the changes to the repository with all image tags
@@ -21095,7 +21095,7 @@ import { ReplicationConfigurationProperty } from '@aws-cdk/aws-ecr'
 const replicationConfigurationProperty: ReplicationConfigurationProperty = { ... }
 \`\`\`
 
-##### \`rules\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.rules\\"></a>
+##### \`rules\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty)[]
 
@@ -21117,7 +21117,7 @@ import { ReplicationDestinationProperty } from '@aws-cdk/aws-ecr'
 const replicationDestinationProperty: ReplicationDestinationProperty = { ... }
 \`\`\`
 
-##### \`region\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.region\\"></a>
+##### \`region\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
 - *Type:* \`string\`
 
@@ -21127,7 +21127,7 @@ const replicationDestinationProperty: ReplicationDestinationProperty = { ... }
 
 ---
 
-##### \`registryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.registryId\\"></a>
+##### \`registryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registryId\\"></a>
 
 - *Type:* \`string\`
 
@@ -21149,7 +21149,7 @@ import { ReplicationRuleProperty } from '@aws-cdk/aws-ecr'
 const replicationRuleProperty: ReplicationRuleProperty = { ... }
 \`\`\`
 
-##### \`destinations\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty.destinations\\"></a>
+##### \`destinations\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)[]
 
@@ -21169,13 +21169,13 @@ import { RepositoryAttributes } from '@aws-cdk/aws-ecr'
 const repositoryAttributes: RepositoryAttributes = { ... }
 \`\`\`
 
-##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.repositoryArn\\"></a>
+##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.property.repositoryArn\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -21191,7 +21191,7 @@ import { RepositoryProps } from '@aws-cdk/aws-ecr'
 const repositoryProps: RepositoryProps = { ... }
 \`\`\`
 
-##### \`imageScanOnPush\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.imageScanOnPush\\"></a>
+##### \`imageScanOnPush\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.imageScanOnPush\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -21200,7 +21200,7 @@ Enable the scan on push when creating the repository.
 
 ---
 
-##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.imageTagMutability\\"></a>
+##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.imageTagMutability\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.TagMutability\`](#@aws-cdk/aws-ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -21211,7 +21211,7 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ---
 
-##### \`lifecycleRegistryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.lifecycleRegistryId\\"></a>
+##### \`lifecycleRegistryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.lifecycleRegistryId\\"></a>
 
 - *Type:* \`string\`
 - *Default:* The default registry is assumed.
@@ -21222,7 +21222,7 @@ The AWS account ID associated with the registry that contains the repository.
 
 ---
 
-##### \`lifecycleRules\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.lifecycleRules\\"></a>
+##### \`lifecycleRules\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.lifecycleRules\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.LifecycleRule\`](#@aws-cdk/aws-ecr.LifecycleRule)[]
 - *Default:* No life cycle rules
@@ -21231,7 +21231,7 @@ Life cycle rules to apply to this registry.
 
 ---
 
-##### \`removalPolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.removalPolicy\\"></a>
+##### \`removalPolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.removalPolicy\\"></a>
 
 - *Type:* [\`@aws-cdk/core.RemovalPolicy\`](#@aws-cdk/core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
@@ -21240,7 +21240,7 @@ Determine what happens to the repository when the resource/stack is deleted.
 
 ---
 
-##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* Automatically generated name.
@@ -21268,7 +21268,7 @@ import { AuthorizationToken } from '@aws-cdk/aws-ecr'
 AuthorizationToken.grantRead(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -21293,7 +21293,7 @@ import { PublicGalleryAuthorizationToken } from '@aws-cdk/aws-ecr'
 PublicGalleryAuthorizationToken.grantRead(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.PublicGalleryAuthorizationToken.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.PublicGalleryAuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -21319,7 +21319,7 @@ Represents an ECR repository.
 public addToResourcePolicy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.statement\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.PolicyStatement\`](#@aws-cdk/aws-iam.PolicyStatement)
 
@@ -21331,13 +21331,13 @@ public addToResourcePolicy(statement: PolicyStatement)
 public grant(grantee: IGrantable, actions: string)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
 ---
 
-###### \`actions\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.actions\\"></a>
+###### \`actions\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.actions\\"></a>
 
 - *Type:* \`string\`
 
@@ -21349,7 +21349,7 @@ public grant(grantee: IGrantable, actions: string)
 public grantPull(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -21361,7 +21361,7 @@ public grantPull(grantee: IGrantable)
 public grantPullPush(grantee: IGrantable)
 \`\`\`
 
-###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.grantee\\"></a>
+###### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -21373,7 +21373,7 @@ public grantPullPush(grantee: IGrantable)
 public onCloudTrailEvent(id: string, options?: OnEventOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -21381,7 +21381,7 @@ The id of the rule.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.OnEventOptions\`](#@aws-cdk/aws-events.OnEventOptions)
 
@@ -21395,7 +21395,7 @@ Options for adding the rule.
 public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -21403,7 +21403,7 @@ The id of the rule.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions\`](#@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions)
 
@@ -21417,13 +21417,13 @@ Options for adding the rule.
 public onEvent(id: string, options?: OnEventOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.OnEventOptions\`](#@aws-cdk/aws-events.OnEventOptions)
 
@@ -21435,7 +21435,7 @@ public onEvent(id: string, options?: OnEventOptions)
 public onImageScanCompleted(id: string, options?: OnImageScanCompletedOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -21443,7 +21443,7 @@ The id of the rule.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.OnImageScanCompletedOptions\`](#@aws-cdk/aws-ecr.OnImageScanCompletedOptions)
 
@@ -21457,7 +21457,7 @@ Options for adding the rule.
 public repositoryUriForDigest(digest?: string)
 \`\`\`
 
-###### \`digest\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.digest\\"></a>
+###### \`digest\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.digest\\"></a>
 
 - *Type:* \`string\`
 
@@ -21471,7 +21471,7 @@ Image digest to use (tools usually default to the image with the \\"latest\\" ta
 public repositoryUriForTag(tag?: string)
 \`\`\`
 
-###### \`tag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.tag\\"></a>
+###### \`tag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.tag\\"></a>
 
 - *Type:* \`string\`
 
@@ -21481,7 +21481,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`node\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.node\\"></a>
+##### \`node\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.node\\"></a>
 
 - *Type:* [\`@aws-cdk/core.ConstructNode\`](#@aws-cdk/core.ConstructNode)
 
@@ -21489,7 +21489,7 @@ The construct tree node for this construct.
 
 ---
 
-##### \`env\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.env\\"></a>
+##### \`env\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.env\\"></a>
 
 - *Type:* [\`@aws-cdk/core.ResourceEnvironment\`](#@aws-cdk/core.ResourceEnvironment)
 
@@ -21504,7 +21504,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-##### \`stack\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.stack\\"></a>
+##### \`stack\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.stack\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Stack\`](#@aws-cdk/core.Stack)
 
@@ -21512,7 +21512,7 @@ The stack in which this resource is defined.
 
 ---
 
-##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.repositoryArn\\"></a>
+##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -21520,7 +21520,7 @@ The ARN of the repository.
 
 ---
 
-##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.repositoryName\\"></a>
+##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -21528,7 +21528,7 @@ The name of the repository.
 
 ---
 
-##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.repositoryUri\\"></a>
+##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryUri\\"></a>
 
 - *Type:* \`string\`
 
@@ -22815,19 +22815,19 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.AwsAuth(scope: Construct, id: string, props: AwsAuthProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.AwsAuthProps\`](#aws-cdk-lib.aws_eks.AwsAuthProps)
 
@@ -22841,7 +22841,7 @@ new aws_eks.AwsAuth(scope: Construct, id: string, props: AwsAuthProps)
 public addAccount(accountId: string)
 \`\`\`
 
-###### \`accountId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.accountId\\"></a>
+###### \`accountId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.parameter.accountId\\"></a>
 
 - *Type:* \`string\`
 
@@ -22855,7 +22855,7 @@ account number.
 public addMastersRole(role: IRole, username?: string)
 \`\`\`
 
-###### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.role\\"></a>
+###### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.parameter.role\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
@@ -22863,7 +22863,7 @@ The IAM role to add.
 
 ---
 
-###### \`username\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.username\\"></a>
+###### \`username\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.parameter.username\\"></a>
 
 - *Type:* \`string\`
 
@@ -22877,7 +22877,7 @@ Optional user (defaults to the role ARN).
 public addRoleMapping(role: IRole, mapping: AwsAuthMapping)
 \`\`\`
 
-###### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.role\\"></a>
+###### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.parameter.role\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
@@ -22885,7 +22885,7 @@ The IAM role to map.
 
 ---
 
-###### \`mapping\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.mapping\\"></a>
+###### \`mapping\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.parameter.mapping\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.AwsAuthMapping\`](#aws-cdk-lib.aws_eks.AwsAuthMapping)
 
@@ -22899,7 +22899,7 @@ Mapping to k8s user name and groups.
 public addUserMapping(user: IUser, mapping: AwsAuthMapping)
 \`\`\`
 
-###### \`user\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.user\\"></a>
+###### \`user\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.parameter.user\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IUser\`](#aws-cdk-lib.aws_iam.IUser)
 
@@ -22907,7 +22907,7 @@ The IAM user to map.
 
 ---
 
-###### \`mapping\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.mapping\\"></a>
+###### \`mapping\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuth.parameter.mapping\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.AwsAuthMapping\`](#aws-cdk-lib.aws_eks.AwsAuthMapping)
 
@@ -22934,7 +22934,7 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.CfnAddon(scope: Construct, id: string, props: CfnAddonProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -22942,7 +22942,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -22950,7 +22950,7 @@ scoped id of the resource.
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnAddonProps\`](#aws-cdk-lib.aws_eks.CfnAddonProps)
 
@@ -22966,7 +22966,7 @@ resource properties.
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.parameter.inspector\\"></a>
 
 - *Type:* [\`aws-cdk-lib.TreeInspector\`](#aws-cdk-lib.TreeInspector)
 
@@ -22977,13 +22977,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.attrArn\\"></a>
+##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.attrArn\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.tags\\"></a>
 
 - *Type:* [\`aws-cdk-lib.TagManager\`](#aws-cdk-lib.TagManager)
 
@@ -22993,7 +22993,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`addonName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.addonName\\"></a>
+##### \`addonName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.addonName\\"></a>
 
 - *Type:* \`string\`
 
@@ -23003,7 +23003,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.clusterName\\"></a>
+##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 
@@ -23013,7 +23013,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`addonVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.addonVersion\\"></a>
+##### \`addonVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.addonVersion\\"></a>
 
 - *Type:* \`string\`
 
@@ -23023,7 +23023,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.resolveConflicts\\"></a>
+##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.resolveConflicts\\"></a>
 
 - *Type:* \`string\`
 
@@ -23033,7 +23033,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.serviceAccountRoleArn\\"></a>
+##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.serviceAccountRoleArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -23045,7 +23045,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`string\`
 
@@ -23069,7 +23069,7 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.CfnCluster(scope: Construct, id: string, props: CfnClusterProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -23077,7 +23077,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -23085,7 +23085,7 @@ scoped id of the resource.
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnClusterProps\`](#aws-cdk-lib.aws_eks.CfnClusterProps)
 
@@ -23101,7 +23101,7 @@ resource properties.
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.parameter.inspector\\"></a>
 
 - *Type:* [\`aws-cdk-lib.TreeInspector\`](#aws-cdk-lib.TreeInspector)
 
@@ -23112,43 +23112,43 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.attrArn\\"></a>
+##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrArn\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`attrCertificateAuthorityData\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.attrCertificateAuthorityData\\"></a>
+##### \`attrCertificateAuthorityData\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrCertificateAuthorityData\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`attrClusterSecurityGroupId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.attrClusterSecurityGroupId\\"></a>
+##### \`attrClusterSecurityGroupId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrClusterSecurityGroupId\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`attrEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.attrEncryptionConfigKeyArn\\"></a>
+##### \`attrEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrEncryptionConfigKeyArn\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`attrEndpoint\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.attrEndpoint\\"></a>
+##### \`attrEndpoint\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrEndpoint\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`attrOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.attrOpenIdConnectIssuerUrl\\"></a>
+##### \`attrOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrOpenIdConnectIssuerUrl\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.resourcesVpcConfig\\"></a>
+##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.resourcesVpcConfig\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -23158,7 +23158,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`roleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.roleArn\\"></a>
+##### \`roleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.roleArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -23168,7 +23168,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.encryptionConfig\\"></a>
+##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.encryptionConfig\\"></a>
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
@@ -23178,7 +23178,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.kubernetesNetworkConfig\\"></a>
+##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.kubernetesNetworkConfig\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -23188,7 +23188,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.name\\"></a>
+##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.name\\"></a>
 
 - *Type:* \`string\`
 
@@ -23198,7 +23198,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.version\\"></a>
 
 - *Type:* \`string\`
 
@@ -23210,7 +23210,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`string\`
 
@@ -23234,7 +23234,7 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.CfnFargateProfile(scope: Construct, id: string, props: CfnFargateProfileProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -23242,7 +23242,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -23250,7 +23250,7 @@ scoped id of the resource.
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnFargateProfileProps\`](#aws-cdk-lib.aws_eks.CfnFargateProfileProps)
 
@@ -23266,7 +23266,7 @@ resource properties.
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.parameter.inspector\\"></a>
 
 - *Type:* [\`aws-cdk-lib.TreeInspector\`](#aws-cdk-lib.TreeInspector)
 
@@ -23277,13 +23277,13 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.attrArn\\"></a>
+##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.attrArn\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.tags\\"></a>
 
 - *Type:* [\`aws-cdk-lib.TagManager\`](#aws-cdk-lib.TagManager)
 
@@ -23293,7 +23293,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.clusterName\\"></a>
+##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 
@@ -23303,7 +23303,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.podExecutionRoleArn\\"></a>
+##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.podExecutionRoleArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -23313,7 +23313,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.selectors\\"></a>
+##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.selectors\\"></a>
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
@@ -23323,7 +23323,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.fargateProfileName\\"></a>
+##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.fargateProfileName\\"></a>
 
 - *Type:* \`string\`
 
@@ -23333,7 +23333,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.subnets\\"></a>
+##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.subnets\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -23345,7 +23345,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`string\`
 
@@ -23369,7 +23369,7 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.CfnNodegroup(scope: Construct, id: string, props: CfnNodegroupProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -23377,7 +23377,7 @@ scope in which this resource is defined.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -23385,7 +23385,7 @@ scoped id of the resource.
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroupProps\`](#aws-cdk-lib.aws_eks.CfnNodegroupProps)
 
@@ -23401,7 +23401,7 @@ resource properties.
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-###### \`inspector\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.inspector\\"></a>
+###### \`inspector\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.parameter.inspector\\"></a>
 
 - *Type:* [\`aws-cdk-lib.TreeInspector\`](#aws-cdk-lib.TreeInspector)
 
@@ -23412,25 +23412,25 @@ tree inspector to collect and process attributes.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.attrArn\\"></a>
+##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.attrArn\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`attrClusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.attrClusterName\\"></a>
+##### \`attrClusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.attrClusterName\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`attrNodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.attrNodegroupName\\"></a>
+##### \`attrNodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.attrNodegroupName\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.tags\\"></a>
 
 - *Type:* [\`aws-cdk-lib.TagManager\`](#aws-cdk-lib.TagManager)
 
@@ -23440,7 +23440,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.clusterName\\"></a>
+##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 
@@ -23450,7 +23450,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`labels\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.labels\\"></a>
+##### \`labels\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.labels\\"></a>
 
 - *Type:* \`any\`
 
@@ -23460,7 +23460,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`nodeRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.nodeRole\\"></a>
+##### \`nodeRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.nodeRole\\"></a>
 
 - *Type:* \`string\`
 
@@ -23470,7 +23470,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`subnets\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.subnets\\"></a>
+##### \`subnets\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.subnets\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -23480,7 +23480,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.amiType\\"></a>
+##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.amiType\\"></a>
 
 - *Type:* \`string\`
 
@@ -23490,7 +23490,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.capacityType\\"></a>
+##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.capacityType\\"></a>
 
 - *Type:* \`string\`
 
@@ -23500,7 +23500,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.diskSize\\"></a>
+##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.diskSize\\"></a>
 
 - *Type:* \`number\`
 
@@ -23510,7 +23510,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.forceUpdateEnabled\\"></a>
+##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.forceUpdateEnabled\\"></a>
 
 - *Type:* \`boolean\` | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -23520,7 +23520,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.instanceTypes\\"></a>
+##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.instanceTypes\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -23530,7 +23530,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.launchTemplate\\"></a>
+##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.launchTemplate\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -23540,7 +23540,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.nodegroupName\\"></a>
+##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.nodegroupName\\"></a>
 
 - *Type:* \`string\`
 
@@ -23550,7 +23550,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.releaseVersion\\"></a>
+##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.releaseVersion\\"></a>
 
 - *Type:* \`string\`
 
@@ -23560,7 +23560,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.remoteAccess\\"></a>
+##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.remoteAccess\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -23570,7 +23570,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.scalingConfig\\"></a>
+##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.scalingConfig\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -23580,7 +23580,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`taints\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.taints\\"></a>
+##### \`taints\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.taints\\"></a>
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
@@ -23590,7 +23590,7 @@ tree inspector to collect and process attributes.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.version\\"></a>
 
 - *Type:* \`string\`
 
@@ -23602,7 +23602,7 @@ tree inspector to collect and process attributes.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.CFN_RESOURCE_TYPE_NAME\\"></a>
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
 - *Type:* \`string\`
 
@@ -23627,7 +23627,7 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.Cluster(scope: Construct, id: string, props: ClusterProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -23635,7 +23635,7 @@ a Construct, most likely a cdk.Stack created.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -23643,7 +23643,7 @@ the id of the Construct to create.
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ClusterProps\`](#aws-cdk-lib.aws_eks.ClusterProps)
 
@@ -23659,13 +23659,13 @@ properties in the IClusterProps interface.
 public addAutoScalingGroupCapacity(id: string, options: AutoScalingGroupCapacityOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`options\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.options\\"></a>
+###### \`options\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.options\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions\`](#aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions)
 
@@ -23677,7 +23677,7 @@ public addAutoScalingGroupCapacity(id: string, options: AutoScalingGroupCapacity
 public addCdk8sChart(id: string, chart: Construct)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -23685,7 +23685,7 @@ logical id of this chart.
 
 ---
 
-###### \`chart\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.chart\\"></a>
+###### \`chart\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.chart\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -23699,7 +23699,7 @@ the cdk8s chart.
 public addFargateProfile(id: string, options: FargateProfileOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -23707,7 +23707,7 @@ the id of this profile.
 
 ---
 
-###### \`options\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.options\\"></a>
+###### \`options\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.options\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.FargateProfileOptions\`](#aws-cdk-lib.aws_eks.FargateProfileOptions)
 
@@ -23721,7 +23721,7 @@ profile options.
 public addHelmChart(id: string, options: HelmChartOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -23729,7 +23729,7 @@ logical id of this chart.
 
 ---
 
-###### \`options\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.options\\"></a>
+###### \`options\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.options\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.HelmChartOptions\`](#aws-cdk-lib.aws_eks.HelmChartOptions)
 
@@ -23743,7 +23743,7 @@ options of this chart.
 public addManifest(id: string, manifest: {[ key: string ]: any})
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -23751,7 +23751,7 @@ logical id of this manifest.
 
 ---
 
-###### \`manifest\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.manifest\\"></a>
+###### \`manifest\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.manifest\\"></a>
 
 - *Type:* {[ key: string ]: \`any\`}
 
@@ -23765,7 +23765,7 @@ a list of Kubernetes resource specifications.
 public addNodegroupCapacity(id: string, options?: NodegroupOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -23773,7 +23773,7 @@ The ID of the nodegroup.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.options\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupOptions\`](#aws-cdk-lib.aws_eks.NodegroupOptions)
 
@@ -23787,13 +23787,13 @@ options for creating a new nodegroup.
 public addServiceAccount(id: string, options?: ServiceAccountOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.options\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ServiceAccountOptions\`](#aws-cdk-lib.aws_eks.ServiceAccountOptions)
 
@@ -23805,7 +23805,7 @@ public addServiceAccount(id: string, options?: ServiceAccountOptions)
 public connectAutoScalingGroupCapacity(autoScalingGroup: AutoScalingGroup, options: AutoScalingGroupOptions)
 \`\`\`
 
-###### \`autoScalingGroup\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.autoScalingGroup\\"></a>
+###### \`autoScalingGroup\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.autoScalingGroup\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.AutoScalingGroup\`](#aws-cdk-lib.aws_autoscaling.AutoScalingGroup)
 
@@ -23813,7 +23813,7 @@ public connectAutoScalingGroupCapacity(autoScalingGroup: AutoScalingGroup, optio
 
 ---
 
-###### \`options\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.options\\"></a>
+###### \`options\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.options\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.AutoScalingGroupOptions\`](#aws-cdk-lib.aws_eks.AutoScalingGroupOptions)
 
@@ -23827,7 +23827,7 @@ options for adding auto scaling groups, like customizing the bootstrap script.
 public getServiceLoadBalancerAddress(serviceName: string, options?: ServiceLoadBalancerAddressOptions)
 \`\`\`
 
-###### \`serviceName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.serviceName\\"></a>
+###### \`serviceName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.serviceName\\"></a>
 
 - *Type:* \`string\`
 
@@ -23835,7 +23835,7 @@ The name of the service.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.options\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ServiceLoadBalancerAddressOptions\`](#aws-cdk-lib.aws_eks.ServiceLoadBalancerAddressOptions)
 
@@ -23853,7 +23853,7 @@ import { aws_eks } from 'aws-cdk-lib'
 aws_eks.Cluster.fromClusterAttributes(scope: Construct, id: string, attrs: ClusterAttributes)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -23861,7 +23861,7 @@ the construct scope, in most cases 'this'.
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -23869,7 +23869,7 @@ the id or name to import as.
 
 ---
 
-###### \`attrs\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.attrs\\"></a>
+###### \`attrs\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.parameter.attrs\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ClusterAttributes\`](#aws-cdk-lib.aws_eks.ClusterAttributes)
 
@@ -23879,7 +23879,7 @@ the cluster properties to use for importing information.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`adminRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.adminRole\\"></a>
+##### \`adminRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.adminRole\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.Role\`](#aws-cdk-lib.aws_iam.Role)
 
@@ -23889,7 +23889,7 @@ This role also has \`systems:master\` permissions.
 
 ---
 
-##### \`awsAuth\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.awsAuth\\"></a>
+##### \`awsAuth\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.awsAuth\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.AwsAuth\`](#aws-cdk-lib.aws_eks.AwsAuth)
 
@@ -23897,7 +23897,7 @@ Lazily creates the AwsAuth resource, which manages AWS authentication mapping.
 
 ---
 
-##### \`clusterArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.clusterArn\\"></a>
+##### \`clusterArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -23905,7 +23905,7 @@ The AWS generated ARN for the Cluster resource.
 
 ---
 
-##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.clusterCertificateAuthorityData\\"></a>
+##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterCertificateAuthorityData\\"></a>
 
 - *Type:* \`string\`
 
@@ -23913,7 +23913,7 @@ The certificate-authority-data for your cluster.
 
 ---
 
-##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.clusterEncryptionConfigKeyArn\\"></a>
+##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterEncryptionConfigKeyArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -23921,7 +23921,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ---
 
-##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.clusterEndpoint\\"></a>
+##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterEndpoint\\"></a>
 
 - *Type:* \`string\`
 
@@ -23931,7 +23931,7 @@ This is the URL inside the kubeconfig file to use with kubectl
 
 ---
 
-##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.clusterName\\"></a>
+##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 
@@ -23939,7 +23939,7 @@ The Name of the created EKS Cluster.
 
 ---
 
-##### \`clusterOpenIdConnectIssuer\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.clusterOpenIdConnectIssuer\\"></a>
+##### \`clusterOpenIdConnectIssuer\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterOpenIdConnectIssuer\\"></a>
 
 - *Type:* \`string\`
 
@@ -23951,7 +23951,7 @@ stock \`CfnCluster\`), this is \`undefined\`.
 
 ---
 
-##### \`clusterOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.clusterOpenIdConnectIssuerUrl\\"></a>
+##### \`clusterOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterOpenIdConnectIssuerUrl\\"></a>
 
 - *Type:* \`string\`
 
@@ -23963,7 +23963,7 @@ stock \`CfnCluster\`), this is \`undefined\`.
 
 ---
 
-##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.clusterSecurityGroup\\"></a>
+##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterSecurityGroup\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 
@@ -23971,7 +23971,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 
 ---
 
-##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.clusterSecurityGroupId\\"></a>
+##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterSecurityGroupId\\"></a>
 
 - *Type:* \`string\`
 
@@ -23979,7 +23979,7 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 
 ---
 
-##### \`connections\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.connections\\"></a>
+##### \`connections\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.connections\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.Connections\`](#aws-cdk-lib.aws_ec2.Connections)
 
@@ -23987,7 +23987,7 @@ Manages connection rules (Security Group Rules) for the cluster.
 
 ---
 
-##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.openIdConnectProvider\\"></a>
+##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.openIdConnectProvider\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IOpenIdConnectProvider\`](#aws-cdk-lib.aws_iam.IOpenIdConnectProvider)
 
@@ -23997,7 +23997,7 @@ A provider will only be defined if this property is accessed (lazy initializatio
 
 ---
 
-##### \`prune\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.prune\\"></a>
+##### \`prune\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.prune\\"></a>
 
 - *Type:* \`boolean\`
 
@@ -24005,7 +24005,7 @@ Determines if Kubernetes resources can be pruned automatically.
 
 ---
 
-##### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.role\\"></a>
+##### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.role\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
@@ -24013,7 +24013,7 @@ IAM role assumed by the EKS Control Plane.
 
 ---
 
-##### \`vpc\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.vpc\\"></a>
+##### \`vpc\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.vpc\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 
@@ -24021,7 +24021,7 @@ The VPC in which this Cluster was created.
 
 ---
 
-##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.defaultCapacity\\"></a>
+##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.defaultCapacity\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.AutoScalingGroup\`](#aws-cdk-lib.aws_autoscaling.AutoScalingGroup)
 
@@ -24032,7 +24032,7 @@ This will be \`undefined\` if the \`defaultCapacityType\` is not \`EC2\` or
 
 ---
 
-##### \`defaultNodegroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.defaultNodegroup\\"></a>
+##### \`defaultNodegroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.defaultNodegroup\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.Nodegroup\`](#aws-cdk-lib.aws_eks.Nodegroup)
 
@@ -24043,7 +24043,7 @@ This will be \`undefined\` if the \`defaultCapacityType\` is \`EC2\` or
 
 ---
 
-##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.kubectlEnvironment\\"></a>
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlEnvironment\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 
@@ -24051,7 +24051,7 @@ Custom environment variables when running \`kubectl\` against this cluster.
 
 ---
 
-##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.kubectlLayer\\"></a>
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlLayer\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
 
@@ -24062,7 +24062,7 @@ undefined, a SAR app that contains this layer will be used.
 
 ---
 
-##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.kubectlMemory\\"></a>
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlMemory\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
 
@@ -24070,7 +24070,7 @@ The amount of memory allocated to the kubectl provider's lambda function.
 
 ---
 
-##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.kubectlPrivateSubnets\\"></a>
+##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlPrivateSubnets\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISubnet\`](#aws-cdk-lib.aws_ec2.ISubnet)[]
 - *Default:* If not specified, the k8s endpoint is expected to be accessible
@@ -24080,7 +24080,7 @@ Subnets to host the \`kubectl\` compute resources.
 
 ---
 
-##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.kubectlRole\\"></a>
+##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlRole\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
@@ -24090,7 +24090,7 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 
 ---
 
-##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.kubectlSecurityGroup\\"></a>
+##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlSecurityGroup\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 - *Default:* If not specified, the k8s endpoint is expected to be accessible
@@ -24117,19 +24117,19 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.FargateCluster(scope: Construct, id: string, props: FargateClusterProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateCluster.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateCluster.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateCluster.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateCluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateCluster.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateCluster.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.FargateClusterProps\`](#aws-cdk-lib.aws_eks.FargateClusterProps)
 
@@ -24170,19 +24170,19 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.FargateProfile(scope: Construct, id: string, props: FargateProfileProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.FargateProfileProps\`](#aws-cdk-lib.aws_eks.FargateProfileProps)
 
@@ -24192,7 +24192,7 @@ new aws_eks.FargateProfile(scope: Construct, id: string, props: FargateProfilePr
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`fargateProfileArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.fargateProfileArn\\"></a>
+##### \`fargateProfileArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.property.fargateProfileArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -24200,7 +24200,7 @@ The full Amazon Resource Name (ARN) of the Fargate profile.
 
 ---
 
-##### \`fargateProfileName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.fargateProfileName\\"></a>
+##### \`fargateProfileName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.property.fargateProfileName\\"></a>
 
 - *Type:* \`string\`
 
@@ -24208,7 +24208,7 @@ The name of the Fargate profile.
 
 ---
 
-##### \`podExecutionRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.podExecutionRole\\"></a>
+##### \`podExecutionRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.property.podExecutionRole\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
@@ -24220,7 +24220,7 @@ ECR image repositories.
 
 ---
 
-##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.tags\\"></a>
+##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.property.tags\\"></a>
 
 - *Type:* [\`aws-cdk-lib.TagManager\`](#aws-cdk-lib.TagManager)
 
@@ -24243,19 +24243,19 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.HelmChart(scope: Construct, id: string, props: HelmChartProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChart.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChart.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChart.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChart.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChart.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChart.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.HelmChartProps\`](#aws-cdk-lib.aws_eks.HelmChartProps)
 
@@ -24266,7 +24266,7 @@ new aws_eks.HelmChart(scope: Construct, id: string, props: HelmChartProps)
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`RESOURCE_TYPE\` <a name=\\"aws-cdk-lib.aws_eks.HelmChart.RESOURCE_TYPE\\"></a>
+##### \`RESOURCE_TYPE\` <a name=\\"aws-cdk-lib.aws_eks.HelmChart.property.RESOURCE_TYPE\\"></a>
 
 - *Type:* \`string\`
 
@@ -24291,19 +24291,19 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.KubernetesManifest(scope: Construct, id: string, props: KubernetesManifestProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifest.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifest.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifest.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifest.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifest.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifest.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesManifestProps\`](#aws-cdk-lib.aws_eks.KubernetesManifestProps)
 
@@ -24314,7 +24314,7 @@ new aws_eks.KubernetesManifest(scope: Construct, id: string, props: KubernetesMa
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`RESOURCE_TYPE\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifest.RESOURCE_TYPE\\"></a>
+##### \`RESOURCE_TYPE\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifest.property.RESOURCE_TYPE\\"></a>
 
 - *Type:* \`string\`
 
@@ -24336,19 +24336,19 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.KubernetesObjectValue(scope: Construct, id: string, props: KubernetesObjectValueProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesObjectValueProps\`](#aws-cdk-lib.aws_eks.KubernetesObjectValueProps)
 
@@ -24358,7 +24358,7 @@ new aws_eks.KubernetesObjectValue(scope: Construct, id: string, props: Kubernete
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`value\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.value\\"></a>
+##### \`value\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.property.value\\"></a>
 
 - *Type:* \`string\`
 
@@ -24368,7 +24368,7 @@ The value as a string token.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`RESOURCE_TYPE\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.RESOURCE_TYPE\\"></a>
+##### \`RESOURCE_TYPE\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.property.RESOURCE_TYPE\\"></a>
 
 - *Type:* \`string\`
 
@@ -24390,19 +24390,19 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.KubernetesPatch(scope: Construct, id: string, props: KubernetesPatchProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatch.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatch.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatch.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatch.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatch.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatch.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesPatchProps\`](#aws-cdk-lib.aws_eks.KubernetesPatchProps)
 
@@ -24426,19 +24426,19 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.Nodegroup(scope: Construct, id: string, props: NodegroupProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupProps\`](#aws-cdk-lib.aws_eks.NodegroupProps)
 
@@ -24455,19 +24455,19 @@ import { aws_eks } from 'aws-cdk-lib'
 aws_eks.Nodegroup.fromNodegroupName(scope: Construct, id: string, nodegroupName: string)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-###### \`nodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.nodegroupName\\"></a>
+###### \`nodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.parameter.nodegroupName\\"></a>
 
 - *Type:* \`string\`
 
@@ -24475,7 +24475,7 @@ aws_eks.Nodegroup.fromNodegroupName(scope: Construct, id: string, nodegroupName:
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.property.cluster\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
@@ -24483,7 +24483,7 @@ the Amazon EKS cluster resource.
 
 ---
 
-##### \`nodegroupArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.nodegroupArn\\"></a>
+##### \`nodegroupArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.property.nodegroupArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -24491,7 +24491,7 @@ ARN of the nodegroup.
 
 ---
 
-##### \`nodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.nodegroupName\\"></a>
+##### \`nodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.property.nodegroupName\\"></a>
 
 - *Type:* \`string\`
 
@@ -24499,7 +24499,7 @@ Nodegroup name.
 
 ---
 
-##### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.role\\"></a>
+##### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.property.role\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
@@ -24529,7 +24529,7 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.OpenIdConnectProvider(scope: Construct, id: string, props: OpenIdConnectProviderProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.OpenIdConnectProvider.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.OpenIdConnectProvider.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -24537,7 +24537,7 @@ The definition scope.
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.OpenIdConnectProvider.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.OpenIdConnectProvider.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -24545,7 +24545,7 @@ Construct ID.
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.OpenIdConnectProvider.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.OpenIdConnectProvider.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.OpenIdConnectProviderProps\`](#aws-cdk-lib.aws_eks.OpenIdConnectProviderProps)
 
@@ -24571,19 +24571,19 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.ServiceAccount(scope: Construct, id: string, props: ServiceAccountProps)
 \`\`\`
 
-##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.scope\\"></a>
+##### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
 ---
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.props\\"></a>
+##### \`props\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ServiceAccountProps\`](#aws-cdk-lib.aws_eks.ServiceAccountProps)
 
@@ -24597,7 +24597,7 @@ new aws_eks.ServiceAccount(scope: Construct, id: string, props: ServiceAccountPr
 public addToPrincipalPolicy(statement: PolicyStatement)
 \`\`\`
 
-###### \`statement\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.statement\\"></a>
+###### \`statement\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.parameter.statement\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.PolicyStatement\`](#aws-cdk-lib.aws_iam.PolicyStatement)
 
@@ -24606,7 +24606,7 @@ public addToPrincipalPolicy(statement: PolicyStatement)
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`assumeRoleAction\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.assumeRoleAction\\"></a>
+##### \`assumeRoleAction\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.assumeRoleAction\\"></a>
 
 - *Type:* \`string\`
 
@@ -24614,7 +24614,7 @@ When this Principal is used in an AssumeRole policy, the action to use.
 
 ---
 
-##### \`grantPrincipal\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.grantPrincipal\\"></a>
+##### \`grantPrincipal\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.grantPrincipal\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IPrincipal\`](#aws-cdk-lib.aws_iam.IPrincipal)
 
@@ -24622,7 +24622,7 @@ The principal to grant permissions to.
 
 ---
 
-##### \`policyFragment\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.policyFragment\\"></a>
+##### \`policyFragment\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.policyFragment\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.PrincipalPolicyFragment\`](#aws-cdk-lib.aws_iam.PrincipalPolicyFragment)
 
@@ -24630,7 +24630,7 @@ Return the policy fragment that identifies this principal in a Policy.
 
 ---
 
-##### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.role\\"></a>
+##### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.role\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
@@ -24638,7 +24638,7 @@ The role which is linked to the service account.
 
 ---
 
-##### \`serviceAccountName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.serviceAccountName\\"></a>
+##### \`serviceAccountName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.serviceAccountName\\"></a>
 
 - *Type:* \`string\`
 
@@ -24646,7 +24646,7 @@ The name of the service account.
 
 ---
 
-##### \`serviceAccountNamespace\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.serviceAccountNamespace\\"></a>
+##### \`serviceAccountNamespace\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.serviceAccountNamespace\\"></a>
 
 - *Type:* \`string\`
 
@@ -24669,7 +24669,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const autoScalingGroupCapacityOptions: aws_eks.AutoScalingGroupCapacityOptions = { ... }
 \`\`\`
 
-##### \`allowAllOutbound\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.allowAllOutbound\\"></a>
+##### \`allowAllOutbound\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.allowAllOutbound\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -24678,7 +24678,7 @@ Whether the instances can initiate connections to anywhere by default.
 
 ---
 
-##### \`associatePublicIpAddress\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.associatePublicIpAddress\\"></a>
+##### \`associatePublicIpAddress\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.associatePublicIpAddress\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* Use subnet setting.
@@ -24687,7 +24687,7 @@ Whether instances in the Auto Scaling Group should have public IP addresses asso
 
 ---
 
-##### \`autoScalingGroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.autoScalingGroupName\\"></a>
+##### \`autoScalingGroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.autoScalingGroupName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* Auto generated by CloudFormation
@@ -24698,7 +24698,7 @@ This name must be unique per Region per account.
 
 ---
 
-##### \`blockDevices\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.blockDevices\\"></a>
+##### \`blockDevices\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.blockDevices\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.BlockDevice\`](#aws-cdk-lib.aws_autoscaling.BlockDevice)[]
 - *Default:* Uses the block device mapping of the AMI
@@ -24714,7 +24714,7 @@ instance store volumes to attach to an instance when it is launched.
 
 ---
 
-##### \`cooldown\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.cooldown\\"></a>
+##### \`cooldown\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.cooldown\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
 - *Default:* Duration.minutes(5)
@@ -24723,7 +24723,7 @@ Default scaling cooldown for this AutoScalingGroup.
 
 ---
 
-##### \`desiredCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.desiredCapacity\\"></a>
+##### \`desiredCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.desiredCapacity\\"></a>
 
 - *Type:* \`number\`
 - *Default:* minCapacity, and leave unchanged during deployment
@@ -24737,7 +24737,7 @@ instances to this number. It is recommended to leave this value blank.
 
 ---
 
-##### \`groupMetrics\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.groupMetrics\\"></a>
+##### \`groupMetrics\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.groupMetrics\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.GroupMetrics\`](#aws-cdk-lib.aws_autoscaling.GroupMetrics)[]
 - *Default:* no group metrics will be reported
@@ -24749,7 +24749,7 @@ Group metrics are reported in a granularity of 1 minute at no additional charge.
 
 ---
 
-##### \`healthCheck\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.healthCheck\\"></a>
+##### \`healthCheck\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.healthCheck\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.HealthCheck\`](#aws-cdk-lib.aws_autoscaling.HealthCheck)
 - *Default:* HealthCheck.ec2 with no grace period
@@ -24758,7 +24758,7 @@ Configuration for health checks.
 
 ---
 
-##### \`ignoreUnmodifiedSizeProperties\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.ignoreUnmodifiedSizeProperties\\"></a>
+##### \`ignoreUnmodifiedSizeProperties\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.ignoreUnmodifiedSizeProperties\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -24773,7 +24773,7 @@ on deployment.
 
 ---
 
-##### \`instanceMonitoring\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.instanceMonitoring\\"></a>
+##### \`instanceMonitoring\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.instanceMonitoring\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.Monitoring\`](#aws-cdk-lib.aws_autoscaling.Monitoring)
 - *Default:* Monitoring.DETAILED
@@ -24787,7 +24787,7 @@ is charged a fee. When you disable detailed monitoring, CloudWatch generates met
 
 ---
 
-##### \`keyName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.keyName\\"></a>
+##### \`keyName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.keyName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* No SSH access will be possible.
@@ -24796,7 +24796,7 @@ Name of SSH keypair to grant access to instances.
 
 ---
 
-##### \`maxCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.maxCapacity\\"></a>
+##### \`maxCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.maxCapacity\\"></a>
 
 - *Type:* \`number\`
 - *Default:* desiredCapacity
@@ -24805,7 +24805,7 @@ Maximum number of instances in the fleet.
 
 ---
 
-##### \`maxInstanceLifetime\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.maxInstanceLifetime\\"></a>
+##### \`maxInstanceLifetime\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.maxInstanceLifetime\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
 - *Default:* none
@@ -24823,7 +24823,7 @@ leave this property undefined.
 
 ---
 
-##### \`minCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.minCapacity\\"></a>
+##### \`minCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.minCapacity\\"></a>
 
 - *Type:* \`number\`
 - *Default:* 1
@@ -24832,7 +24832,7 @@ Minimum number of instances in the fleet.
 
 ---
 
-##### \`newInstancesProtectedFromScaleIn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.newInstancesProtectedFromScaleIn\\"></a>
+##### \`newInstancesProtectedFromScaleIn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.newInstancesProtectedFromScaleIn\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -24850,7 +24850,7 @@ an ECS Capacity Provider with managed termination protection.
 
 ---
 
-##### \`notifications\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.notifications\\"></a>
+##### \`notifications\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.notifications\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.NotificationConfiguration\`](#aws-cdk-lib.aws_autoscaling.NotificationConfiguration)[]
 - *Default:* No fleet change notifications will be sent.
@@ -24861,7 +24861,7 @@ Configure autoscaling group to send notifications about fleet changes to an SNS 
 
 ---
 
-##### \`signals\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.signals\\"></a>
+##### \`signals\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.signals\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.Signals\`](#aws-cdk-lib.aws_autoscaling.Signals)
 - *Default:* Do not wait for signals
@@ -24886,7 +24886,7 @@ https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services
 
 ---
 
-##### \`spotPrice\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.spotPrice\\"></a>
+##### \`spotPrice\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.spotPrice\\"></a>
 
 - *Type:* \`string\`
 - *Default:* none
@@ -24898,7 +24898,7 @@ launched when the price you specify exceeds the current Spot market price.
 
 ---
 
-##### \`updatePolicy\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.updatePolicy\\"></a>
+##### \`updatePolicy\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.updatePolicy\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.UpdatePolicy\`](#aws-cdk-lib.aws_autoscaling.UpdatePolicy)
 - *Default:* \`UpdatePolicy.rollingUpdate()\` if using \`init\`, \`UpdatePolicy.none()\` otherwise
@@ -24913,7 +24913,7 @@ is done and only new instances are launched with the new config.
 
 ---
 
-##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.vpcSubnets\\"></a>
+##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.vpcSubnets\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
 - *Default:* All Private subnets.
@@ -24922,7 +24922,7 @@ Where to place instances within the VPC.
 
 ---
 
-##### \`instanceType\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.instanceType\\"></a>
+##### \`instanceType\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.instanceType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.InstanceType\`](#aws-cdk-lib.aws_ec2.InstanceType)
 
@@ -24930,7 +24930,7 @@ Instance type of the instances to start.
 
 ---
 
-##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.bootstrapEnabled\\"></a>
+##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.bootstrapEnabled\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -24942,7 +24942,7 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 
 ---
 
-##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.bootstrapOptions\\"></a>
+##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.bootstrapOptions\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.BootstrapOptions\`](#aws-cdk-lib.aws_eks.BootstrapOptions)
 - *Default:* none
@@ -24951,7 +24951,7 @@ EKS node bootstrapping options.
 
 ---
 
-##### \`machineImageType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.machineImageType\\"></a>
+##### \`machineImageType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.machineImageType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.MachineImageType\`](#aws-cdk-lib.aws_eks.MachineImageType)
 - *Default:* MachineImageType.AMAZON_LINUX_2
@@ -24960,7 +24960,7 @@ Machine image type.
 
 ---
 
-##### \`mapRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.mapRole\\"></a>
+##### \`mapRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.mapRole\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true if the cluster has kubectl enabled (which is the default).
@@ -24971,7 +24971,7 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 
 ---
 
-##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.spotInterruptHandler\\"></a>
+##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.spotInterruptHandler\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -24994,7 +24994,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const autoScalingGroupOptions: aws_eks.AutoScalingGroupOptions = { ... }
 \`\`\`
 
-##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.bootstrapEnabled\\"></a>
+##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.bootstrapEnabled\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -25006,7 +25006,7 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 
 ---
 
-##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.bootstrapOptions\\"></a>
+##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.bootstrapOptions\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.BootstrapOptions\`](#aws-cdk-lib.aws_eks.BootstrapOptions)
 - *Default:* default options
@@ -25015,7 +25015,7 @@ Allows options for node bootstrapping through EC2 user data.
 
 ---
 
-##### \`machineImageType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.machineImageType\\"></a>
+##### \`machineImageType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.machineImageType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.MachineImageType\`](#aws-cdk-lib.aws_eks.MachineImageType)
 - *Default:* MachineImageType.AMAZON_LINUX_2
@@ -25024,7 +25024,7 @@ Allow options to specify different machine image type.
 
 ---
 
-##### \`mapRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.mapRole\\"></a>
+##### \`mapRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.mapRole\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true if the cluster has kubectl enabled (which is the default).
@@ -25035,7 +25035,7 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 
 ---
 
-##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.spotInterruptHandler\\"></a>
+##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.spotInterruptHandler\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -25058,7 +25058,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const awsAuthMapping: aws_eks.AwsAuthMapping = { ... }
 \`\`\`
 
-##### \`groups\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuthMapping.groups\\"></a>
+##### \`groups\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuthMapping.property.groups\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -25068,7 +25068,7 @@ A list of groups within Kubernetes to which the role is mapped.
 
 ---
 
-##### \`username\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuthMapping.username\\"></a>
+##### \`username\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuthMapping.property.username\\"></a>
 
 - *Type:* \`string\`
 - *Default:* By default, the user name is the ARN of the IAM role.
@@ -25089,7 +25089,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const awsAuthProps: aws_eks.AwsAuthProps = { ... }
 \`\`\`
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuthProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuthProps.property.cluster\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.Cluster\`](#aws-cdk-lib.aws_eks.Cluster)
 
@@ -25111,7 +25111,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const bootstrapOptions: aws_eks.BootstrapOptions = { ... }
 \`\`\`
 
-##### \`additionalArgs\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.additionalArgs\\"></a>
+##### \`additionalArgs\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.additionalArgs\\"></a>
 
 - *Type:* \`string\`
 - *Default:* none
@@ -25122,7 +25122,7 @@ Additional command line arguments to pass to the \`/etc/eks/bootstrap.sh\` comma
 
 ---
 
-##### \`awsApiRetryAttempts\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.awsApiRetryAttempts\\"></a>
+##### \`awsApiRetryAttempts\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.awsApiRetryAttempts\\"></a>
 
 - *Type:* \`number\`
 - *Default:* 3
@@ -25131,7 +25131,7 @@ Number of retry attempts for AWS API call (DescribeCluster).
 
 ---
 
-##### \`dnsClusterIp\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.dnsClusterIp\\"></a>
+##### \`dnsClusterIp\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.dnsClusterIp\\"></a>
 
 - *Type:* \`string\`
 - *Default:* 10.100.0.10 or 172.20.0.10 based on the IP
@@ -25141,7 +25141,7 @@ Overrides the IP address to use for DNS queries within the cluster.
 
 ---
 
-##### \`dockerConfigJson\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.dockerConfigJson\\"></a>
+##### \`dockerConfigJson\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.dockerConfigJson\\"></a>
 
 - *Type:* \`string\`
 - *Default:* none
@@ -25150,7 +25150,7 @@ The contents of the \`/etc/docker/daemon.json\` file. Useful if you want a custo
 
 ---
 
-##### \`enableDockerBridge\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.enableDockerBridge\\"></a>
+##### \`enableDockerBridge\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.enableDockerBridge\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -25159,7 +25159,7 @@ Restores the docker default bridge network.
 
 ---
 
-##### \`kubeletExtraArgs\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.kubeletExtraArgs\\"></a>
+##### \`kubeletExtraArgs\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.kubeletExtraArgs\\"></a>
 
 - *Type:* \`string\`
 - *Default:* none
@@ -25170,7 +25170,7 @@ Useful for adding labels or taints.
 
 ---
 
-##### \`useMaxPods\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.useMaxPods\\"></a>
+##### \`useMaxPods\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.useMaxPods\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -25193,7 +25193,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 \`\`\`
 
-##### \`addonName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.addonName\\"></a>
+##### \`addonName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.addonName\\"></a>
 
 - *Type:* \`string\`
 
@@ -25203,7 +25203,7 @@ const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 
 ---
 
-##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.clusterName\\"></a>
+##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 
@@ -25213,7 +25213,7 @@ const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 
 ---
 
-##### \`addonVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.addonVersion\\"></a>
+##### \`addonVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.addonVersion\\"></a>
 
 - *Type:* \`string\`
 
@@ -25223,7 +25223,7 @@ const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 
 ---
 
-##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.resolveConflicts\\"></a>
+##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.resolveConflicts\\"></a>
 
 - *Type:* \`string\`
 
@@ -25233,7 +25233,7 @@ const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 
 ---
 
-##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.serviceAccountRoleArn\\"></a>
+##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.serviceAccountRoleArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -25243,7 +25243,7 @@ const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.tags\\"></a>
 
 - *Type:* [\`aws-cdk-lib.CfnTag\`](#aws-cdk-lib.CfnTag)[]
 
@@ -25267,7 +25267,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 \`\`\`
 
-##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.resourcesVpcConfig\\"></a>
+##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.resourcesVpcConfig\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -25277,7 +25277,7 @@ const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 
 ---
 
-##### \`roleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.roleArn\\"></a>
+##### \`roleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.roleArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -25287,7 +25287,7 @@ const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 
 ---
 
-##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.encryptionConfig\\"></a>
+##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.encryptionConfig\\"></a>
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
@@ -25297,7 +25297,7 @@ const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 
 ---
 
-##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.kubernetesNetworkConfig\\"></a>
+##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.kubernetesNetworkConfig\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -25307,7 +25307,7 @@ const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 
 ---
 
-##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.name\\"></a>
+##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.name\\"></a>
 
 - *Type:* \`string\`
 
@@ -25317,7 +25317,7 @@ const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.version\\"></a>
 
 - *Type:* \`string\`
 
@@ -25341,7 +25341,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 \`\`\`
 
-##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.clusterName\\"></a>
+##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 
@@ -25351,7 +25351,7 @@ const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 
 ---
 
-##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.podExecutionRoleArn\\"></a>
+##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.podExecutionRoleArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -25361,7 +25361,7 @@ const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 
 ---
 
-##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.selectors\\"></a>
+##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.selectors\\"></a>
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
@@ -25371,7 +25371,7 @@ const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 
 ---
 
-##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.fargateProfileName\\"></a>
+##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.fargateProfileName\\"></a>
 
 - *Type:* \`string\`
 
@@ -25381,7 +25381,7 @@ const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 
 ---
 
-##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.subnets\\"></a>
+##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.subnets\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -25391,7 +25391,7 @@ const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.tags\\"></a>
 
 - *Type:* [\`aws-cdk-lib.CfnTag\`](#aws-cdk-lib.CfnTag)[]
 
@@ -25415,7 +25415,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 \`\`\`
 
-##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.clusterName\\"></a>
+##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 
@@ -25425,7 +25425,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`nodeRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.nodeRole\\"></a>
+##### \`nodeRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.nodeRole\\"></a>
 
 - *Type:* \`string\`
 
@@ -25435,7 +25435,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`subnets\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.subnets\\"></a>
+##### \`subnets\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.subnets\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -25445,7 +25445,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.amiType\\"></a>
+##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.amiType\\"></a>
 
 - *Type:* \`string\`
 
@@ -25455,7 +25455,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.capacityType\\"></a>
+##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.capacityType\\"></a>
 
 - *Type:* \`string\`
 
@@ -25465,7 +25465,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.diskSize\\"></a>
+##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.diskSize\\"></a>
 
 - *Type:* \`number\`
 
@@ -25475,7 +25475,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.forceUpdateEnabled\\"></a>
+##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.forceUpdateEnabled\\"></a>
 
 - *Type:* \`boolean\` | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -25485,7 +25485,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.instanceTypes\\"></a>
+##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.instanceTypes\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -25495,7 +25495,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.labels\\"></a>
+##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.labels\\"></a>
 
 - *Type:* \`any\`
 
@@ -25505,7 +25505,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.launchTemplate\\"></a>
+##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.launchTemplate\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -25515,7 +25515,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.nodegroupName\\"></a>
+##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.nodegroupName\\"></a>
 
 - *Type:* \`string\`
 
@@ -25525,7 +25525,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.releaseVersion\\"></a>
+##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.releaseVersion\\"></a>
 
 - *Type:* \`string\`
 
@@ -25535,7 +25535,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.remoteAccess\\"></a>
+##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.remoteAccess\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -25545,7 +25545,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.scalingConfig\\"></a>
+##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.scalingConfig\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -25555,7 +25555,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.tags\\"></a>
 
 - *Type:* \`any\`
 
@@ -25565,7 +25565,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`taints\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.taints\\"></a>
+##### \`taints\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.taints\\"></a>
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
@@ -25575,7 +25575,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.version\\"></a>
 
 - *Type:* \`string\`
 
@@ -25597,7 +25597,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const clusterAttributes: aws_eks.ClusterAttributes = { ... }
 \`\`\`
 
-##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.clusterName\\"></a>
+##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 
@@ -25605,7 +25605,7 @@ The physical name of the Cluster.
 
 ---
 
-##### \`clusterCertificateAuthorityData\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.clusterCertificateAuthorityData\\"></a>
+##### \`clusterCertificateAuthorityData\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterCertificateAuthorityData\\"></a>
 
 - *Type:* \`string\`
 - *Default:* if not specified \`cluster.clusterCertificateAuthorityData\` will
@@ -25615,7 +25615,7 @@ The certificate-authority-data for your cluster.
 
 ---
 
-##### \`clusterEncryptionConfigKeyArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.clusterEncryptionConfigKeyArn\\"></a>
+##### \`clusterEncryptionConfigKeyArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterEncryptionConfigKeyArn\\"></a>
 
 - *Type:* \`string\`
 - *Default:* if not specified \`cluster.clusterEncryptionConfigKeyArn\` will
@@ -25625,7 +25625,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ---
 
-##### \`clusterEndpoint\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.clusterEndpoint\\"></a>
+##### \`clusterEndpoint\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterEndpoint\\"></a>
 
 - *Type:* \`string\`
 - *Default:* if not specified \`cluster.clusterEndpoint\` will throw an error.
@@ -25634,7 +25634,7 @@ The API Server endpoint URL.
 
 ---
 
-##### \`clusterSecurityGroupId\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.clusterSecurityGroupId\\"></a>
+##### \`clusterSecurityGroupId\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterSecurityGroupId\\"></a>
 
 - *Type:* \`string\`
 - *Default:* if not specified \`cluster.clusterSecurityGroupId\` will throw an
@@ -25644,7 +25644,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 
 ---
 
-##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.kubectlEnvironment\\"></a>
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlEnvironment\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* no additional variables
@@ -25653,7 +25653,7 @@ Environment variables to use when running \`kubectl\` against this cluster.
 
 ---
 
-##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.kubectlLayer\\"></a>
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlLayer\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
 - *Default:* a layer bundled with this module.
@@ -25671,7 +25671,7 @@ The handler expects the layer to include the following executables:
 
 ---
 
-##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.kubectlMemory\\"></a>
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlMemory\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
 - *Default:* Size.gibibytes(1)
@@ -25680,7 +25680,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-##### \`kubectlPrivateSubnetIds\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.kubectlPrivateSubnetIds\\"></a>
+##### \`kubectlPrivateSubnetIds\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlPrivateSubnetIds\\"></a>
 
 - *Type:* \`string\`[]
 - *Default:* k8s endpoint is expected to be accessible publicly
@@ -25692,7 +25692,7 @@ endpoint is expected to be accessible publicly.
 
 ---
 
-##### \`kubectlRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.kubectlRoleArn\\"></a>
+##### \`kubectlRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlRoleArn\\"></a>
 
 - *Type:* \`string\`
 - *Default:* if not specified, it not be possible to issue \`kubectl\` commands
@@ -25702,7 +25702,7 @@ An IAM role with cluster administrator and \\"system:masters\\" permissions.
 
 ---
 
-##### \`kubectlSecurityGroupId\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.kubectlSecurityGroupId\\"></a>
+##### \`kubectlSecurityGroupId\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlSecurityGroupId\\"></a>
 
 - *Type:* \`string\`
 - *Default:* k8s endpoint is expected to be accessible publicly
@@ -25714,7 +25714,7 @@ endpoint is expected to be accessible publicly.
 
 ---
 
-##### \`openIdConnectProvider\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.openIdConnectProvider\\"></a>
+##### \`openIdConnectProvider\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.openIdConnectProvider\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IOpenIdConnectProvider\`](#aws-cdk-lib.aws_iam.IOpenIdConnectProvider)
 - *Default:* if not specified \`cluster.openIdConnectProvider\` and \`cluster.addServiceAccount\` will throw an error.
@@ -25726,7 +25726,7 @@ or create a new provider using \`new eks.OpenIdConnectProvider\`
 
 ---
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.prune\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -25739,7 +25739,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ---
 
-##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.securityGroupIds\\"></a>
+##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.securityGroupIds\\"></a>
 
 - *Type:* \`string\`[]
 - *Default:* if not specified, no additional security groups will be
@@ -25749,7 +25749,7 @@ Additional security groups associated with this cluster.
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.vpc\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* if not specified \`cluster.vpc\` will throw an error
@@ -25770,7 +25770,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const clusterOptions: aws_eks.ClusterOptions = { ... }
 \`\`\`
 
-##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.version\\"></a>
+##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.version\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -25778,7 +25778,7 @@ The Kubernetes version to run in the cluster.
 
 ---
 
-##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.clusterName\\"></a>
+##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* Automatically generated name
@@ -25787,7 +25787,7 @@ Name for the cluster.
 
 ---
 
-##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.outputClusterName\\"></a>
+##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.outputClusterName\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -25796,7 +25796,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 
 ---
 
-##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.outputConfigCommand\\"></a>
+##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.outputConfigCommand\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -25808,7 +25808,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ---
 
-##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.role\\"></a>
+##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.role\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* A role is automatically created for you
@@ -25817,7 +25817,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 
 ---
 
-##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.securityGroup\\"></a>
+##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.securityGroup\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -25826,7 +25826,7 @@ Security Group to use for Control Plane ENIs.
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.vpc\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
@@ -25835,7 +25835,7 @@ The VPC in which to create the Cluster.
 
 ---
 
-##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.vpcSubnets\\"></a>
+##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.vpcSubnets\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)[]
 - *Default:* All public and private subnets
@@ -25854,7 +25854,7 @@ vpcSubnets: [
 
 ---
 
-##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.clusterHandlerEnvironment\\"></a>
+##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.clusterHandlerEnvironment\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* No environment variables.
@@ -25863,7 +25863,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ---
 
-##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.coreDnsComputeType\\"></a>
+##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.coreDnsComputeType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CoreDnsComputeType\`](#aws-cdk-lib.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
@@ -25872,7 +25872,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 
 ---
 
-##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.endpointAccess\\"></a>
+##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.endpointAccess\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -25883,7 +25883,7 @@ Configure access to the Kubernetes API server endpoint..
 
 ---
 
-##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.kubectlEnvironment\\"></a>
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.kubectlEnvironment\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* No environment variables.
@@ -25894,7 +25894,7 @@ Only relevant for kubectl enabled clusters.
 
 ---
 
-##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.kubectlLayer\\"></a>
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.kubectlLayer\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -25921,7 +25921,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ---
 
-##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.kubectlMemory\\"></a>
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.kubectlMemory\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
 - *Default:* Size.gibibytes(1)
@@ -25930,7 +25930,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-##### \`mastersRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.mastersRole\\"></a>
+##### \`mastersRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.mastersRole\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -25942,7 +25942,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ---
 
-##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.outputMastersRoleArn\\"></a>
+##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.outputMastersRoleArn\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -25951,7 +25951,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ---
 
-##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.placeClusterHandlerInVpc\\"></a>
+##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.placeClusterHandlerInVpc\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -25960,7 +25960,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 
 ---
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.prune\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -25973,7 +25973,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ---
 
-##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.secretsEncryptionKey\\"></a>
+##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.secretsEncryptionKey\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_kms.IKey\`](#aws-cdk-lib.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
@@ -25996,7 +25996,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const clusterProps: aws_eks.ClusterProps = { ... }
 \`\`\`
 
-##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.version\\"></a>
+##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.version\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -26004,7 +26004,7 @@ The Kubernetes version to run in the cluster.
 
 ---
 
-##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.clusterName\\"></a>
+##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* Automatically generated name
@@ -26013,7 +26013,7 @@ Name for the cluster.
 
 ---
 
-##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.outputClusterName\\"></a>
+##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.outputClusterName\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -26022,7 +26022,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 
 ---
 
-##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.outputConfigCommand\\"></a>
+##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.outputConfigCommand\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -26034,7 +26034,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ---
 
-##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.role\\"></a>
+##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.role\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* A role is automatically created for you
@@ -26043,7 +26043,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 
 ---
 
-##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.securityGroup\\"></a>
+##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.securityGroup\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -26052,7 +26052,7 @@ Security Group to use for Control Plane ENIs.
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.vpc\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
@@ -26061,7 +26061,7 @@ The VPC in which to create the Cluster.
 
 ---
 
-##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.vpcSubnets\\"></a>
+##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.vpcSubnets\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)[]
 - *Default:* All public and private subnets
@@ -26080,7 +26080,7 @@ vpcSubnets: [
 
 ---
 
-##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.clusterHandlerEnvironment\\"></a>
+##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.clusterHandlerEnvironment\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* No environment variables.
@@ -26089,7 +26089,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ---
 
-##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.coreDnsComputeType\\"></a>
+##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.coreDnsComputeType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CoreDnsComputeType\`](#aws-cdk-lib.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
@@ -26098,7 +26098,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 
 ---
 
-##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.endpointAccess\\"></a>
+##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.endpointAccess\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -26109,7 +26109,7 @@ Configure access to the Kubernetes API server endpoint..
 
 ---
 
-##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.kubectlEnvironment\\"></a>
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.kubectlEnvironment\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* No environment variables.
@@ -26120,7 +26120,7 @@ Only relevant for kubectl enabled clusters.
 
 ---
 
-##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.kubectlLayer\\"></a>
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.kubectlLayer\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -26147,7 +26147,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ---
 
-##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.kubectlMemory\\"></a>
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.kubectlMemory\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
 - *Default:* Size.gibibytes(1)
@@ -26156,7 +26156,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-##### \`mastersRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.mastersRole\\"></a>
+##### \`mastersRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.mastersRole\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -26168,7 +26168,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ---
 
-##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.outputMastersRoleArn\\"></a>
+##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.outputMastersRoleArn\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -26177,7 +26177,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ---
 
-##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.placeClusterHandlerInVpc\\"></a>
+##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.placeClusterHandlerInVpc\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -26186,7 +26186,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 
 ---
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.prune\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -26199,7 +26199,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ---
 
-##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.secretsEncryptionKey\\"></a>
+##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.secretsEncryptionKey\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_kms.IKey\`](#aws-cdk-lib.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
@@ -26210,7 +26210,7 @@ KMS secret for envelope encryption for Kubernetes secrets.
 
 ---
 
-##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.defaultCapacity\\"></a>
+##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.defaultCapacity\\"></a>
 
 - *Type:* \`number\`
 - *Default:* 2
@@ -26225,7 +26225,7 @@ to \`0\` is you wish to avoid the initial capacity allocation.
 
 ---
 
-##### \`defaultCapacityInstance\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.defaultCapacityInstance\\"></a>
+##### \`defaultCapacityInstance\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.defaultCapacityInstance\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.InstanceType\`](#aws-cdk-lib.aws_ec2.InstanceType)
 - *Default:* m5.large
@@ -26237,7 +26237,7 @@ into account if \`defaultCapacity\` is > 0.
 
 ---
 
-##### \`defaultCapacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.defaultCapacityType\\"></a>
+##### \`defaultCapacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.defaultCapacityType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.DefaultCapacityType\`](#aws-cdk-lib.aws_eks.DefaultCapacityType)
 - *Default:* NODEGROUP
@@ -26258,7 +26258,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const commonClusterOptions: aws_eks.CommonClusterOptions = { ... }
 \`\`\`
 
-##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.version\\"></a>
+##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.version\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -26266,7 +26266,7 @@ The Kubernetes version to run in the cluster.
 
 ---
 
-##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.clusterName\\"></a>
+##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* Automatically generated name
@@ -26275,7 +26275,7 @@ Name for the cluster.
 
 ---
 
-##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.outputClusterName\\"></a>
+##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.outputClusterName\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -26284,7 +26284,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 
 ---
 
-##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.outputConfigCommand\\"></a>
+##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.outputConfigCommand\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -26296,7 +26296,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ---
 
-##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.role\\"></a>
+##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.role\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* A role is automatically created for you
@@ -26305,7 +26305,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 
 ---
 
-##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.securityGroup\\"></a>
+##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.securityGroup\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -26314,7 +26314,7 @@ Security Group to use for Control Plane ENIs.
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.vpc\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
@@ -26323,7 +26323,7 @@ The VPC in which to create the Cluster.
 
 ---
 
-##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.vpcSubnets\\"></a>
+##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.vpcSubnets\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)[]
 - *Default:* All public and private subnets
@@ -26354,7 +26354,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const eksOptimizedImageProps: aws_eks.EksOptimizedImageProps = { ... }
 \`\`\`
 
-##### \`cpuArch\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImageProps.cpuArch\\"></a>
+##### \`cpuArch\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImageProps.property.cpuArch\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CpuArch\`](#aws-cdk-lib.aws_eks.CpuArch)
 - *Default:* CpuArch.X86_64
@@ -26363,7 +26363,7 @@ What cpu architecture to retrieve the image for (arm64 or x86_64).
 
 ---
 
-##### \`kubernetesVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImageProps.kubernetesVersion\\"></a>
+##### \`kubernetesVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImageProps.property.kubernetesVersion\\"></a>
 
 - *Type:* \`string\`
 - *Default:* The latest version
@@ -26372,7 +26372,7 @@ The Kubernetes version to use.
 
 ---
 
-##### \`nodeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImageProps.nodeType\\"></a>
+##### \`nodeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImageProps.property.nodeType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodeType\`](#aws-cdk-lib.aws_eks.NodeType)
 - *Default:* NodeType.STANDARD
@@ -26393,7 +26393,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const encryptionConfigProperty: aws_eks.CfnCluster.EncryptionConfigProperty = { ... }
 \`\`\`
 
-##### \`provider\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty.provider\\"></a>
+##### \`provider\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty.property.provider\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.ProviderProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.ProviderProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -26403,7 +26403,7 @@ const encryptionConfigProperty: aws_eks.CfnCluster.EncryptionConfigProperty = { 
 
 ---
 
-##### \`resources\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty.resources\\"></a>
+##### \`resources\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty.property.resources\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -26425,7 +26425,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const fargateClusterProps: aws_eks.FargateClusterProps = { ... }
 \`\`\`
 
-##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.version\\"></a>
+##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.version\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -26433,7 +26433,7 @@ The Kubernetes version to run in the cluster.
 
 ---
 
-##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.clusterName\\"></a>
+##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* Automatically generated name
@@ -26442,7 +26442,7 @@ Name for the cluster.
 
 ---
 
-##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.outputClusterName\\"></a>
+##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.outputClusterName\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -26451,7 +26451,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 
 ---
 
-##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.outputConfigCommand\\"></a>
+##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.outputConfigCommand\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -26463,7 +26463,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ---
 
-##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.role\\"></a>
+##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.role\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* A role is automatically created for you
@@ -26472,7 +26472,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 
 ---
 
-##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.securityGroup\\"></a>
+##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.securityGroup\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -26481,7 +26481,7 @@ Security Group to use for Control Plane ENIs.
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.vpc\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
@@ -26490,7 +26490,7 @@ The VPC in which to create the Cluster.
 
 ---
 
-##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.vpcSubnets\\"></a>
+##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.vpcSubnets\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)[]
 - *Default:* All public and private subnets
@@ -26509,7 +26509,7 @@ vpcSubnets: [
 
 ---
 
-##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.clusterHandlerEnvironment\\"></a>
+##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.clusterHandlerEnvironment\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* No environment variables.
@@ -26518,7 +26518,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ---
 
-##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.coreDnsComputeType\\"></a>
+##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.coreDnsComputeType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CoreDnsComputeType\`](#aws-cdk-lib.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
@@ -26527,7 +26527,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 
 ---
 
-##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.endpointAccess\\"></a>
+##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.endpointAccess\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -26538,7 +26538,7 @@ Configure access to the Kubernetes API server endpoint..
 
 ---
 
-##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.kubectlEnvironment\\"></a>
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.kubectlEnvironment\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* No environment variables.
@@ -26549,7 +26549,7 @@ Only relevant for kubectl enabled clusters.
 
 ---
 
-##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.kubectlLayer\\"></a>
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.kubectlLayer\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -26576,7 +26576,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ---
 
-##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.kubectlMemory\\"></a>
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.kubectlMemory\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
 - *Default:* Size.gibibytes(1)
@@ -26585,7 +26585,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-##### \`mastersRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.mastersRole\\"></a>
+##### \`mastersRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.mastersRole\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -26597,7 +26597,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ---
 
-##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.outputMastersRoleArn\\"></a>
+##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.outputMastersRoleArn\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -26606,7 +26606,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ---
 
-##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.placeClusterHandlerInVpc\\"></a>
+##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.placeClusterHandlerInVpc\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -26615,7 +26615,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 
 ---
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.prune\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -26628,7 +26628,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ---
 
-##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.secretsEncryptionKey\\"></a>
+##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.secretsEncryptionKey\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_kms.IKey\`](#aws-cdk-lib.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
@@ -26639,7 +26639,7 @@ KMS secret for envelope encryption for Kubernetes secrets.
 
 ---
 
-##### \`defaultProfile\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.defaultProfile\\"></a>
+##### \`defaultProfile\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.defaultProfile\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.FargateProfileOptions\`](#aws-cdk-lib.aws_eks.FargateProfileOptions)
 - *Default:* A profile called \\"default\\" with 'default' and 'kube-system'
@@ -26661,7 +26661,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const fargateProfileOptions: aws_eks.FargateProfileOptions = { ... }
 \`\`\`
 
-##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.selectors\\"></a>
+##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.selectors\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.Selector\`](#aws-cdk-lib.aws_eks.Selector)[]
 
@@ -26675,7 +26675,7 @@ At least one selector is required and you may specify up to five selectors.
 
 ---
 
-##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.fargateProfileName\\"></a>
+##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.fargateProfileName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* generated
@@ -26684,7 +26684,7 @@ The name of the Fargate profile.
 
 ---
 
-##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.podExecutionRole\\"></a>
+##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.podExecutionRole\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* a role will be automatically created
@@ -26699,7 +26699,7 @@ ECR image repositories.
 
 ---
 
-##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.subnetSelection\\"></a>
+##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.subnetSelection\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
 - *Default:* all private subnets of the VPC are selected.
@@ -26712,7 +26712,7 @@ on Fargate are not assigned public IP addresses, so only private subnets
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.vpc\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* all private subnets used by theEKS cluster
@@ -26736,7 +26736,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const fargateProfileProps: aws_eks.FargateProfileProps = { ... }
 \`\`\`
 
-##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.selectors\\"></a>
+##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.selectors\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.Selector\`](#aws-cdk-lib.aws_eks.Selector)[]
 
@@ -26750,7 +26750,7 @@ At least one selector is required and you may specify up to five selectors.
 
 ---
 
-##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.fargateProfileName\\"></a>
+##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.fargateProfileName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* generated
@@ -26759,7 +26759,7 @@ The name of the Fargate profile.
 
 ---
 
-##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.podExecutionRole\\"></a>
+##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.podExecutionRole\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* a role will be automatically created
@@ -26774,7 +26774,7 @@ ECR image repositories.
 
 ---
 
-##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.subnetSelection\\"></a>
+##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.subnetSelection\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
 - *Default:* all private subnets of the VPC are selected.
@@ -26787,7 +26787,7 @@ on Fargate are not assigned public IP addresses, so only private subnets
 
 ---
 
-##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.vpc\\"></a>
+##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.vpc\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* all private subnets used by theEKS cluster
@@ -26799,7 +26799,7 @@ By default, all private subnets are selected. You can customize this using
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.cluster\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.Cluster\`](#aws-cdk-lib.aws_eks.Cluster)
 
@@ -26821,7 +26821,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const helmChartOptions: aws_eks.HelmChartOptions = { ... }
 \`\`\`
 
-##### \`chart\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.chart\\"></a>
+##### \`chart\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.chart\\"></a>
 
 - *Type:* \`string\`
 
@@ -26829,7 +26829,7 @@ The name of the chart.
 
 ---
 
-##### \`createNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.createNamespace\\"></a>
+##### \`createNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.createNamespace\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -26838,7 +26838,7 @@ create namespace if not exist.
 
 ---
 
-##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.namespace\\"></a>
+##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.namespace\\"></a>
 
 - *Type:* \`string\`
 - *Default:* default
@@ -26847,7 +26847,7 @@ The Kubernetes namespace scope of the requests.
 
 ---
 
-##### \`release\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.release\\"></a>
+##### \`release\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.release\\"></a>
 
 - *Type:* \`string\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
@@ -26856,7 +26856,7 @@ The name of the release.
 
 ---
 
-##### \`repository\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.repository\\"></a>
+##### \`repository\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.repository\\"></a>
 
 - *Type:* \`string\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -26867,7 +26867,7 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ---
 
-##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.timeout\\"></a>
+##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.timeout\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
 - *Default:* Duration.minutes(5)
@@ -26878,7 +26878,7 @@ Maximum 15 minutes.
 
 ---
 
-##### \`values\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.values\\"></a>
+##### \`values\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.values\\"></a>
 
 - *Type:* {[ key: string ]: \`any\`}
 - *Default:* No values are provided to the chart.
@@ -26887,7 +26887,7 @@ The values to be used by the chart.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.version\\"></a>
 
 - *Type:* \`string\`
 - *Default:* If this is not specified, the latest version is installed
@@ -26896,7 +26896,7 @@ The chart version to install.
 
 ---
 
-##### \`wait\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.wait\\"></a>
+##### \`wait\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.wait\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* Helm will not wait before marking release as successful
@@ -26917,7 +26917,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const helmChartProps: aws_eks.HelmChartProps = { ... }
 \`\`\`
 
-##### \`chart\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.chart\\"></a>
+##### \`chart\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.chart\\"></a>
 
 - *Type:* \`string\`
 
@@ -26925,7 +26925,7 @@ The name of the chart.
 
 ---
 
-##### \`createNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.createNamespace\\"></a>
+##### \`createNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.createNamespace\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -26934,7 +26934,7 @@ create namespace if not exist.
 
 ---
 
-##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.namespace\\"></a>
+##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.namespace\\"></a>
 
 - *Type:* \`string\`
 - *Default:* default
@@ -26943,7 +26943,7 @@ The Kubernetes namespace scope of the requests.
 
 ---
 
-##### \`release\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.release\\"></a>
+##### \`release\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.release\\"></a>
 
 - *Type:* \`string\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
@@ -26952,7 +26952,7 @@ The name of the release.
 
 ---
 
-##### \`repository\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.repository\\"></a>
+##### \`repository\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.repository\\"></a>
 
 - *Type:* \`string\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -26963,7 +26963,7 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ---
 
-##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.timeout\\"></a>
+##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.timeout\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
 - *Default:* Duration.minutes(5)
@@ -26974,7 +26974,7 @@ Maximum 15 minutes.
 
 ---
 
-##### \`values\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.values\\"></a>
+##### \`values\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.values\\"></a>
 
 - *Type:* {[ key: string ]: \`any\`}
 - *Default:* No values are provided to the chart.
@@ -26983,7 +26983,7 @@ The values to be used by the chart.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.version\\"></a>
 
 - *Type:* \`string\`
 - *Default:* If this is not specified, the latest version is installed
@@ -26992,7 +26992,7 @@ The chart version to install.
 
 ---
 
-##### \`wait\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.wait\\"></a>
+##### \`wait\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.wait\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* Helm will not wait before marking release as successful
@@ -27001,7 +27001,7 @@ Whether or not Helm should wait until all Pods, PVCs, Services, and minimum numb
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.cluster\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
@@ -27023,7 +27023,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const kubernetesManifestOptions: aws_eks.KubernetesManifestOptions = { ... }
 \`\`\`
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestOptions.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestOptions.property.prune\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* based on the prune option of the cluster, which is \`true\` unless
@@ -27049,7 +27049,7 @@ empty.
 
 ---
 
-##### \`skipValidation\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestOptions.skipValidation\\"></a>
+##### \`skipValidation\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestOptions.property.skipValidation\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -27070,7 +27070,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const kubernetesManifestProps: aws_eks.KubernetesManifestProps = { ... }
 \`\`\`
 
-##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.prune\\"></a>
+##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.prune\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* based on the prune option of the cluster, which is \`true\` unless
@@ -27096,7 +27096,7 @@ empty.
 
 ---
 
-##### \`skipValidation\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.skipValidation\\"></a>
+##### \`skipValidation\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.skipValidation\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -27105,7 +27105,7 @@ A flag to signify if the manifest validation should be skipped.
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.cluster\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
@@ -27115,7 +27115,7 @@ The EKS cluster to apply this manifest to.
 
 ---
 
-##### \`manifest\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.manifest\\"></a>
+##### \`manifest\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.manifest\\"></a>
 
 - *Type:* {[ key: string ]: \`any\`}[]
 
@@ -27129,7 +27129,7 @@ deleted, the resources in the manifest will be deleted through \`kubectl delete\
 
 ---
 
-##### \`overwrite\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.overwrite\\"></a>
+##### \`overwrite\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.overwrite\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -27154,7 +27154,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const kubernetesNetworkConfigProperty: aws_eks.CfnCluster.KubernetesNetworkConfigProperty = { ... }
 \`\`\`
 
-##### \`serviceIpv4Cidr\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty.serviceIpv4Cidr\\"></a>
+##### \`serviceIpv4Cidr\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty.property.serviceIpv4Cidr\\"></a>
 
 - *Type:* \`string\`
 
@@ -27176,7 +27176,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const kubernetesObjectValueProps: aws_eks.KubernetesObjectValueProps = { ... }
 \`\`\`
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.cluster\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
@@ -27186,7 +27186,7 @@ The EKS cluster to fetch attributes from.
 
 ---
 
-##### \`jsonPath\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.jsonPath\\"></a>
+##### \`jsonPath\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.jsonPath\\"></a>
 
 - *Type:* \`string\`
 
@@ -27196,7 +27196,7 @@ JSONPath to the specific value.
 
 ---
 
-##### \`objectName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.objectName\\"></a>
+##### \`objectName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.objectName\\"></a>
 
 - *Type:* \`string\`
 
@@ -27204,7 +27204,7 @@ The name of the object to query.
 
 ---
 
-##### \`objectType\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.objectType\\"></a>
+##### \`objectType\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.objectType\\"></a>
 
 - *Type:* \`string\`
 
@@ -27214,7 +27214,7 @@ The object type to query.
 
 ---
 
-##### \`objectNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.objectNamespace\\"></a>
+##### \`objectNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.objectNamespace\\"></a>
 
 - *Type:* \`string\`
 - *Default:* 'default'
@@ -27223,7 +27223,7 @@ The namespace the object belongs to.
 
 ---
 
-##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.timeout\\"></a>
+##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.timeout\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
 - *Default:* Duration.minutes(5)
@@ -27244,7 +27244,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const kubernetesPatchProps: aws_eks.KubernetesPatchProps = { ... }
 \`\`\`
 
-##### \`applyPatch\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.applyPatch\\"></a>
+##### \`applyPatch\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.applyPatch\\"></a>
 
 - *Type:* {[ key: string ]: \`any\`}
 
@@ -27252,7 +27252,7 @@ The JSON object to pass to \`kubectl patch\` when the resource is created/update
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.cluster\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
@@ -27262,7 +27262,7 @@ The cluster to apply the patch to.
 
 ---
 
-##### \`resourceName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.resourceName\\"></a>
+##### \`resourceName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.resourceName\\"></a>
 
 - *Type:* \`string\`
 
@@ -27270,7 +27270,7 @@ The full name of the resource to patch (e.g. \`deployment/coredns\`).
 
 ---
 
-##### \`restorePatch\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.restorePatch\\"></a>
+##### \`restorePatch\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.restorePatch\\"></a>
 
 - *Type:* {[ key: string ]: \`any\`}
 
@@ -27278,7 +27278,7 @@ The JSON object to pass to \`kubectl patch\` when the resource is removed.
 
 ---
 
-##### \`patchType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.patchType\\"></a>
+##### \`patchType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.patchType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.PatchType\`](#aws-cdk-lib.aws_eks.PatchType)
 - *Default:* PatchType.STRATEGIC
@@ -27289,7 +27289,7 @@ The default type used by \`kubectl patch\` is \\"strategic\\".
 
 ---
 
-##### \`resourceNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.resourceNamespace\\"></a>
+##### \`resourceNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.resourceNamespace\\"></a>
 
 - *Type:* \`string\`
 - *Default:* \\"default\\"
@@ -27310,7 +27310,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const labelProperty: aws_eks.CfnFargateProfile.LabelProperty = { ... }
 \`\`\`
 
-##### \`key\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty.key\\"></a>
+##### \`key\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty.property.key\\"></a>
 
 - *Type:* \`string\`
 
@@ -27320,7 +27320,7 @@ const labelProperty: aws_eks.CfnFargateProfile.LabelProperty = { ... }
 
 ---
 
-##### \`value\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty.value\\"></a>
+##### \`value\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty.property.value\\"></a>
 
 - *Type:* \`string\`
 
@@ -27342,7 +27342,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const launchTemplateSpec: aws_eks.LaunchTemplateSpec = { ... }
 \`\`\`
 
-##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.LaunchTemplateSpec.id\\"></a>
+##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.LaunchTemplateSpec.property.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -27350,7 +27350,7 @@ The Launch template ID.
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.LaunchTemplateSpec.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.LaunchTemplateSpec.property.version\\"></a>
 
 - *Type:* \`string\`
 - *Default:* the default version of the launch template
@@ -27371,7 +27371,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const launchTemplateSpecificationProperty: aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty = { ... }
 \`\`\`
 
-##### \`id\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.id\\"></a>
+##### \`id\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -27381,7 +27381,7 @@ const launchTemplateSpecificationProperty: aws_eks.CfnNodegroup.LaunchTemplateSp
 
 ---
 
-##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.name\\"></a>
+##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.name\\"></a>
 
 - *Type:* \`string\`
 
@@ -27391,7 +27391,7 @@ const launchTemplateSpecificationProperty: aws_eks.CfnNodegroup.LaunchTemplateSp
 
 ---
 
-##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.version\\"></a>
+##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.version\\"></a>
 
 - *Type:* \`string\`
 
@@ -27413,7 +27413,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const nodegroupOptions: aws_eks.NodegroupOptions = { ... }
 \`\`\`
 
-##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.amiType\\"></a>
+##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.amiType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupAmiType\`](#aws-cdk-lib.aws_eks.NodegroupAmiType)
 - *Default:* auto-determined from the instanceTypes property.
@@ -27422,7 +27422,7 @@ The AMI type for your node group.
 
 ---
 
-##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.capacityType\\"></a>
+##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.capacityType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CapacityType\`](#aws-cdk-lib.aws_eks.CapacityType)
 - *Default:* ON_DEMAND
@@ -27431,7 +27431,7 @@ The capacity type of the nodegroup.
 
 ---
 
-##### \`desiredSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.desiredSize\\"></a>
+##### \`desiredSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.desiredSize\\"></a>
 
 - *Type:* \`number\`
 - *Default:* 2
@@ -27443,7 +27443,7 @@ the nodewgroup will initially create \`minSize\` instances.
 
 ---
 
-##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.diskSize\\"></a>
+##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.diskSize\\"></a>
 
 - *Type:* \`number\`
 - *Default:* 20
@@ -27452,7 +27452,7 @@ The root device disk size (in GiB) for your node group instances.
 
 ---
 
-##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.forceUpdate\\"></a>
+##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.forceUpdate\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -27465,7 +27465,7 @@ running on the node.
 
 ---
 
-##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.instanceTypes\\"></a>
+##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.instanceTypes\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.InstanceType\`](#aws-cdk-lib.aws_ec2.InstanceType)[]
 - *Default:* t3.medium will be used according to the cloudformation document.
@@ -27476,7 +27476,7 @@ The instance types to use for your node group.
 
 ---
 
-##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.labels\\"></a>
+##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.labels\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* None
@@ -27485,7 +27485,7 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 
 ---
 
-##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.launchTemplateSpec\\"></a>
+##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.launchTemplateSpec\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.LaunchTemplateSpec\`](#aws-cdk-lib.aws_eks.LaunchTemplateSpec)
 - *Default:* no launch template
@@ -27496,7 +27496,7 @@ Launch template specification used for the nodegroup.
 
 ---
 
-##### \`maxSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.maxSize\\"></a>
+##### \`maxSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.maxSize\\"></a>
 
 - *Type:* \`number\`
 - *Default:* desiredSize
@@ -27507,7 +27507,7 @@ Managed node groups can support up to 100 nodes by default.
 
 ---
 
-##### \`minSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.minSize\\"></a>
+##### \`minSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.minSize\\"></a>
 
 - *Type:* \`number\`
 - *Default:* 1
@@ -27518,7 +27518,7 @@ This number must be greater than zero.
 
 ---
 
-##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.nodegroupName\\"></a>
+##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.nodegroupName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* resource ID
@@ -27527,7 +27527,7 @@ Name of the Nodegroup.
 
 ---
 
-##### \`nodeRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.nodeRole\\"></a>
+##### \`nodeRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.nodeRole\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* None. Auto-generated if not specified.
@@ -27541,7 +27541,7 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 
 ---
 
-##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.releaseVersion\\"></a>
+##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.releaseVersion\\"></a>
 
 - *Type:* \`string\`
 - *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
@@ -27550,7 +27550,7 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 
 ---
 
-##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.remoteAccess\\"></a>
+##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.remoteAccess\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupRemoteAccess\`](#aws-cdk-lib.aws_eks.NodegroupRemoteAccess)
 - *Default:* disabled
@@ -27563,7 +27563,7 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 
 ---
 
-##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.subnets\\"></a>
+##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.subnets\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
 - *Default:* private subnets
@@ -27577,7 +27577,7 @@ the name of your cluster.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.tags\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* None
@@ -27602,7 +27602,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const nodegroupProps: aws_eks.NodegroupProps = { ... }
 \`\`\`
 
-##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.amiType\\"></a>
+##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.amiType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupAmiType\`](#aws-cdk-lib.aws_eks.NodegroupAmiType)
 - *Default:* auto-determined from the instanceTypes property.
@@ -27611,7 +27611,7 @@ The AMI type for your node group.
 
 ---
 
-##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.capacityType\\"></a>
+##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.capacityType\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CapacityType\`](#aws-cdk-lib.aws_eks.CapacityType)
 - *Default:* ON_DEMAND
@@ -27620,7 +27620,7 @@ The capacity type of the nodegroup.
 
 ---
 
-##### \`desiredSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.desiredSize\\"></a>
+##### \`desiredSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.desiredSize\\"></a>
 
 - *Type:* \`number\`
 - *Default:* 2
@@ -27632,7 +27632,7 @@ the nodewgroup will initially create \`minSize\` instances.
 
 ---
 
-##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.diskSize\\"></a>
+##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.diskSize\\"></a>
 
 - *Type:* \`number\`
 - *Default:* 20
@@ -27641,7 +27641,7 @@ The root device disk size (in GiB) for your node group instances.
 
 ---
 
-##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.forceUpdate\\"></a>
+##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.forceUpdate\\"></a>
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -27654,7 +27654,7 @@ running on the node.
 
 ---
 
-##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.instanceTypes\\"></a>
+##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.instanceTypes\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.InstanceType\`](#aws-cdk-lib.aws_ec2.InstanceType)[]
 - *Default:* t3.medium will be used according to the cloudformation document.
@@ -27665,7 +27665,7 @@ The instance types to use for your node group.
 
 ---
 
-##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.labels\\"></a>
+##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.labels\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* None
@@ -27674,7 +27674,7 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 
 ---
 
-##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.launchTemplateSpec\\"></a>
+##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.launchTemplateSpec\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.LaunchTemplateSpec\`](#aws-cdk-lib.aws_eks.LaunchTemplateSpec)
 - *Default:* no launch template
@@ -27685,7 +27685,7 @@ Launch template specification used for the nodegroup.
 
 ---
 
-##### \`maxSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.maxSize\\"></a>
+##### \`maxSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.maxSize\\"></a>
 
 - *Type:* \`number\`
 - *Default:* desiredSize
@@ -27696,7 +27696,7 @@ Managed node groups can support up to 100 nodes by default.
 
 ---
 
-##### \`minSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.minSize\\"></a>
+##### \`minSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.minSize\\"></a>
 
 - *Type:* \`number\`
 - *Default:* 1
@@ -27707,7 +27707,7 @@ This number must be greater than zero.
 
 ---
 
-##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.nodegroupName\\"></a>
+##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.nodegroupName\\"></a>
 
 - *Type:* \`string\`
 - *Default:* resource ID
@@ -27716,7 +27716,7 @@ Name of the Nodegroup.
 
 ---
 
-##### \`nodeRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.nodeRole\\"></a>
+##### \`nodeRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.nodeRole\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* None. Auto-generated if not specified.
@@ -27730,7 +27730,7 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 
 ---
 
-##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.releaseVersion\\"></a>
+##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.releaseVersion\\"></a>
 
 - *Type:* \`string\`
 - *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
@@ -27739,7 +27739,7 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 
 ---
 
-##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.remoteAccess\\"></a>
+##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.remoteAccess\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupRemoteAccess\`](#aws-cdk-lib.aws_eks.NodegroupRemoteAccess)
 - *Default:* disabled
@@ -27752,7 +27752,7 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 
 ---
 
-##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.subnets\\"></a>
+##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.subnets\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
 - *Default:* private subnets
@@ -27766,7 +27766,7 @@ the name of your cluster.
 
 ---
 
-##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.tags\\"></a>
+##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.tags\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* None
@@ -27779,7 +27779,7 @@ associated with the node group, such as the Amazon EC2 instances or subnets.
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.cluster\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
@@ -27801,7 +27801,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const nodegroupRemoteAccess: aws_eks.NodegroupRemoteAccess = { ... }
 \`\`\`
 
-##### \`sshKeyName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupRemoteAccess.sshKeyName\\"></a>
+##### \`sshKeyName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupRemoteAccess.property.sshKeyName\\"></a>
 
 - *Type:* \`string\`
 
@@ -27809,7 +27809,7 @@ The Amazon EC2 SSH key that provides access for SSH communication with the worke
 
 ---
 
-##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupRemoteAccess.sourceSecurityGroups\\"></a>
+##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupRemoteAccess.property.sourceSecurityGroups\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)[]
 - *Default:* port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
@@ -27834,7 +27834,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const openIdConnectProviderProps: aws_eks.OpenIdConnectProviderProps = { ... }
 \`\`\`
 
-##### \`url\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.OpenIdConnectProviderProps.url\\"></a>
+##### \`url\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.OpenIdConnectProviderProps.property.url\\"></a>
 
 - *Type:* \`string\`
 
@@ -27863,7 +27863,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const providerProperty: aws_eks.CfnCluster.ProviderProperty = { ... }
 \`\`\`
 
-##### \`keyArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.ProviderProperty.keyArn\\"></a>
+##### \`keyArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.ProviderProperty.property.keyArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -27885,7 +27885,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const remoteAccessProperty: aws_eks.CfnNodegroup.RemoteAccessProperty = { ... }
 \`\`\`
 
-##### \`ec2SshKey\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty.ec2SshKey\\"></a>
+##### \`ec2SshKey\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty.property.ec2SshKey\\"></a>
 
 - *Type:* \`string\`
 
@@ -27895,7 +27895,7 @@ const remoteAccessProperty: aws_eks.CfnNodegroup.RemoteAccessProperty = { ... }
 
 ---
 
-##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty.sourceSecurityGroups\\"></a>
+##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty.property.sourceSecurityGroups\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -27917,7 +27917,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const resourcesVpcConfigProperty: aws_eks.CfnCluster.ResourcesVpcConfigProperty = { ... }
 \`\`\`
 
-##### \`subnetIds\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty.subnetIds\\"></a>
+##### \`subnetIds\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty.property.subnetIds\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -27927,7 +27927,7 @@ const resourcesVpcConfigProperty: aws_eks.CfnCluster.ResourcesVpcConfigProperty 
 
 ---
 
-##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty.securityGroupIds\\"></a>
+##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty.property.securityGroupIds\\"></a>
 
 - *Type:* \`string\`[]
 
@@ -27949,7 +27949,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const scalingConfigProperty: aws_eks.CfnNodegroup.ScalingConfigProperty = { ... }
 \`\`\`
 
-##### \`desiredSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty.desiredSize\\"></a>
+##### \`desiredSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty.property.desiredSize\\"></a>
 
 - *Type:* \`number\`
 
@@ -27959,7 +27959,7 @@ const scalingConfigProperty: aws_eks.CfnNodegroup.ScalingConfigProperty = { ... 
 
 ---
 
-##### \`maxSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty.maxSize\\"></a>
+##### \`maxSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty.property.maxSize\\"></a>
 
 - *Type:* \`number\`
 
@@ -27969,7 +27969,7 @@ const scalingConfigProperty: aws_eks.CfnNodegroup.ScalingConfigProperty = { ... 
 
 ---
 
-##### \`minSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty.minSize\\"></a>
+##### \`minSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty.property.minSize\\"></a>
 
 - *Type:* \`number\`
 
@@ -27991,7 +27991,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const selector: aws_eks.Selector = { ... }
 \`\`\`
 
-##### \`namespace\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Selector.namespace\\"></a>
+##### \`namespace\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Selector.property.namespace\\"></a>
 
 - *Type:* \`string\`
 
@@ -28003,7 +28003,7 @@ to target multiple namespaces.
 
 ---
 
-##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Selector.labels\\"></a>
+##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Selector.property.labels\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* all pods within the namespace will be selected.
@@ -28028,7 +28028,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const selectorProperty: aws_eks.CfnFargateProfile.SelectorProperty = { ... }
 \`\`\`
 
-##### \`namespace\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty.namespace\\"></a>
+##### \`namespace\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty.property.namespace\\"></a>
 
 - *Type:* \`string\`
 
@@ -28038,7 +28038,7 @@ const selectorProperty: aws_eks.CfnFargateProfile.SelectorProperty = { ... }
 
 ---
 
-##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty.labels\\"></a>
+##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty.property.labels\\"></a>
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty\`](#aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
@@ -28060,7 +28060,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const serviceAccountOptions: aws_eks.ServiceAccountOptions = { ... }
 \`\`\`
 
-##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountOptions.name\\"></a>
+##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountOptions.property.name\\"></a>
 
 - *Type:* \`string\`
 - *Default:* If no name is given, it will use the id of the resource.
@@ -28069,7 +28069,7 @@ The name of the service account.
 
 ---
 
-##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountOptions.namespace\\"></a>
+##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountOptions.property.namespace\\"></a>
 
 - *Type:* \`string\`
 - *Default:* \\"default\\"
@@ -28090,7 +28090,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const serviceAccountProps: aws_eks.ServiceAccountProps = { ... }
 \`\`\`
 
-##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountProps.name\\"></a>
+##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountProps.property.name\\"></a>
 
 - *Type:* \`string\`
 - *Default:* If no name is given, it will use the id of the resource.
@@ -28099,7 +28099,7 @@ The name of the service account.
 
 ---
 
-##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountProps.namespace\\"></a>
+##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountProps.property.namespace\\"></a>
 
 - *Type:* \`string\`
 - *Default:* \\"default\\"
@@ -28108,7 +28108,7 @@ The namespace of the service account.
 
 ---
 
-##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountProps.cluster\\"></a>
+##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountProps.property.cluster\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
@@ -28128,7 +28128,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const serviceLoadBalancerAddressOptions: aws_eks.ServiceLoadBalancerAddressOptions = { ... }
 \`\`\`
 
-##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceLoadBalancerAddressOptions.namespace\\"></a>
+##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceLoadBalancerAddressOptions.property.namespace\\"></a>
 
 - *Type:* \`string\`
 - *Default:* 'default'
@@ -28137,7 +28137,7 @@ The namespace the service belongs to.
 
 ---
 
-##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceLoadBalancerAddressOptions.timeout\\"></a>
+##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceLoadBalancerAddressOptions.property.timeout\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
 - *Default:* Duration.minutes(5)
@@ -28158,7 +28158,7 @@ import { aws_eks } from 'aws-cdk-lib'
 const taintProperty: aws_eks.CfnNodegroup.TaintProperty = { ... }
 \`\`\`
 
-##### \`effect\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty.effect\\"></a>
+##### \`effect\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty.property.effect\\"></a>
 
 - *Type:* \`string\`
 
@@ -28168,7 +28168,7 @@ const taintProperty: aws_eks.CfnNodegroup.TaintProperty = { ... }
 
 ---
 
-##### \`key\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty.key\\"></a>
+##### \`key\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty.property.key\\"></a>
 
 - *Type:* \`string\`
 
@@ -28178,7 +28178,7 @@ const taintProperty: aws_eks.CfnNodegroup.TaintProperty = { ... }
 
 ---
 
-##### \`value\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty.value\\"></a>
+##### \`value\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty.property.value\\"></a>
 
 - *Type:* \`string\`
 
@@ -28204,7 +28204,7 @@ import { aws_eks } from 'aws-cdk-lib'
 new aws_eks.EksOptimizedImage(props?: EksOptimizedImageProps)
 \`\`\`
 
-##### \`props\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImage.props\\"></a>
+##### \`props\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImage.parameter.props\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EksOptimizedImageProps\`](#aws-cdk-lib.aws_eks.EksOptimizedImageProps)
 
@@ -28218,7 +28218,7 @@ new aws_eks.EksOptimizedImage(props?: EksOptimizedImageProps)
 public getImage(scope: Construct)
 \`\`\`
 
-###### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImage.scope\\"></a>
+###### \`scope\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImage.parameter.scope\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -28239,7 +28239,7 @@ Endpoint access characteristics.
 public onlyFrom(cidr: string)
 \`\`\`
 
-###### \`cidr\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.cidr\\"></a>
+###### \`cidr\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.parameter.cidr\\"></a>
 
 - *Type:* \`string\`
 
@@ -28251,7 +28251,7 @@ CIDR blocks.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`PRIVATE\` <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.PRIVATE\\"></a>
+##### \`PRIVATE\` <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.property.PRIVATE\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 
@@ -28261,7 +28261,7 @@ Worker node traffic to the endpoint will stay within your VPC.
 
 ---
 
-##### \`PUBLIC\` <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.PUBLIC\\"></a>
+##### \`PUBLIC\` <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.property.PUBLIC\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 
@@ -28276,7 +28276,7 @@ access the public endpoint from.
 
 ---
 
-##### \`PUBLIC_AND_PRIVATE\` <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.PUBLIC_AND_PRIVATE\\"></a>
+##### \`PUBLIC_AND_PRIVATE\` <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.property.PUBLIC_AND_PRIVATE\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 
@@ -28306,7 +28306,7 @@ import { aws_eks } from 'aws-cdk-lib'
 aws_eks.KubernetesVersion.of(version: string)
 \`\`\`
 
-###### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.version\\"></a>
+###### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.parameter.version\\"></a>
 
 - *Type:* \`string\`
 
@@ -28316,7 +28316,7 @@ custom version number.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.version\\"></a>
+##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.version\\"></a>
 
 - *Type:* \`string\`
 
@@ -28326,7 +28326,7 @@ cluster version number.
 
 #### Constants <a name=\\"Constants\\"></a>
 
-##### \`V1_14\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.V1_14\\"></a>
+##### \`V1_14\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_14\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -28334,7 +28334,7 @@ Kubernetes version 1.14.
 
 ---
 
-##### \`V1_15\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.V1_15\\"></a>
+##### \`V1_15\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_15\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -28342,7 +28342,7 @@ Kubernetes version 1.15.
 
 ---
 
-##### \`V1_16\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.V1_16\\"></a>
+##### \`V1_16\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_16\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -28350,7 +28350,7 @@ Kubernetes version 1.16.
 
 ---
 
-##### \`V1_17\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.V1_17\\"></a>
+##### \`V1_17\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_17\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -28358,7 +28358,7 @@ Kubernetes version 1.17.
 
 ---
 
-##### \`V1_18\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.V1_18\\"></a>
+##### \`V1_18\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_18\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -28366,7 +28366,7 @@ Kubernetes version 1.18.
 
 ---
 
-##### \`V1_19\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.V1_19\\"></a>
+##### \`V1_19\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_19\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -28392,7 +28392,7 @@ An EKS cluster.
 public addCdk8sChart(id: string, chart: Construct)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -28400,7 +28400,7 @@ logical id of this chart.
 
 ---
 
-###### \`chart\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.chart\\"></a>
+###### \`chart\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.parameter.chart\\"></a>
 
 - *Type:* [\`constructs.Construct\`](#constructs.Construct)
 
@@ -28414,7 +28414,7 @@ the cdk8s chart.
 public addHelmChart(id: string, options: HelmChartOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -28422,7 +28422,7 @@ logical id of this chart.
 
 ---
 
-###### \`options\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.options\\"></a>
+###### \`options\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.parameter.options\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.HelmChartOptions\`](#aws-cdk-lib.aws_eks.HelmChartOptions)
 
@@ -28436,7 +28436,7 @@ options of this chart.
 public addManifest(id: string, manifest: {[ key: string ]: any})
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -28444,7 +28444,7 @@ logical id of this manifest.
 
 ---
 
-###### \`manifest\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.manifest\\"></a>
+###### \`manifest\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.parameter.manifest\\"></a>
 
 - *Type:* {[ key: string ]: \`any\`}
 
@@ -28458,7 +28458,7 @@ a list of Kubernetes resource specifications.
 public addServiceAccount(id: string, options?: ServiceAccountOptions)
 \`\`\`
 
-###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.id\\"></a>
+###### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -28466,7 +28466,7 @@ logical id of service account.
 
 ---
 
-###### \`options\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.options\\"></a>
+###### \`options\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.parameter.options\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ServiceAccountOptions\`](#aws-cdk-lib.aws_eks.ServiceAccountOptions)
 
@@ -28476,7 +28476,7 @@ service account options.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`node\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.node\\"></a>
+##### \`node\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.node\\"></a>
 
 - *Type:* [\`constructs.Node\`](#constructs.Node)
 
@@ -28484,7 +28484,7 @@ The tree node.
 
 ---
 
-##### \`env\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.env\\"></a>
+##### \`env\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.env\\"></a>
 
 - *Type:* [\`aws-cdk-lib.ResourceEnvironment\`](#aws-cdk-lib.ResourceEnvironment)
 
@@ -28499,7 +28499,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-##### \`stack\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.stack\\"></a>
+##### \`stack\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.stack\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Stack\`](#aws-cdk-lib.Stack)
 
@@ -28507,13 +28507,13 @@ The stack in which this resource is defined.
 
 ---
 
-##### \`connections\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.connections\\"></a>
+##### \`connections\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.connections\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.Connections\`](#aws-cdk-lib.aws_ec2.Connections)
 
 ---
 
-##### \`clusterArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.clusterArn\\"></a>
+##### \`clusterArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -28521,7 +28521,7 @@ The unique ARN assigned to the service by AWS in the form of arn:aws:eks:.
 
 ---
 
-##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.clusterCertificateAuthorityData\\"></a>
+##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterCertificateAuthorityData\\"></a>
 
 - *Type:* \`string\`
 
@@ -28529,7 +28529,7 @@ The certificate-authority-data for your cluster.
 
 ---
 
-##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.clusterEncryptionConfigKeyArn\\"></a>
+##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterEncryptionConfigKeyArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -28537,7 +28537,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ---
 
-##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.clusterEndpoint\\"></a>
+##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterEndpoint\\"></a>
 
 - *Type:* \`string\`
 
@@ -28545,7 +28545,7 @@ The API Server endpoint URL.
 
 ---
 
-##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.clusterName\\"></a>
+##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterName\\"></a>
 
 - *Type:* \`string\`
 
@@ -28553,7 +28553,7 @@ The physical name of the Cluster.
 
 ---
 
-##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.clusterSecurityGroup\\"></a>
+##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterSecurityGroup\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 
@@ -28561,7 +28561,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 
 ---
 
-##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.clusterSecurityGroupId\\"></a>
+##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterSecurityGroupId\\"></a>
 
 - *Type:* \`string\`
 
@@ -28569,7 +28569,7 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 
 ---
 
-##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.openIdConnectProvider\\"></a>
+##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.openIdConnectProvider\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IOpenIdConnectProvider\`](#aws-cdk-lib.aws_iam.IOpenIdConnectProvider)
 
@@ -28577,7 +28577,7 @@ The Open ID Connect Provider of the cluster used to configure Service Accounts.
 
 ---
 
-##### \`prune\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.prune\\"></a>
+##### \`prune\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.prune\\"></a>
 
 - *Type:* \`boolean\`
 
@@ -28590,7 +28590,7 @@ apply\` operation with the \`--prune\` switch.
 
 ---
 
-##### \`vpc\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.vpc\\"></a>
+##### \`vpc\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.vpc\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 
@@ -28598,7 +28598,7 @@ The VPC in which this Cluster was created.
 
 ---
 
-##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.kubectlEnvironment\\"></a>
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlEnvironment\\"></a>
 
 - *Type:* {[ key: string ]: \`string\`}
 
@@ -28606,7 +28606,7 @@ Custom environment variables when running \`kubectl\` against this cluster.
 
 ---
 
-##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.kubectlLayer\\"></a>
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlLayer\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
 
@@ -28616,7 +28616,7 @@ If not defined, a default layer will be used.
 
 ---
 
-##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.kubectlMemory\\"></a>
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlMemory\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
 
@@ -28624,7 +28624,7 @@ Amount of memory to allocate to the provider's lambda function.
 
 ---
 
-##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.kubectlPrivateSubnets\\"></a>
+##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlPrivateSubnets\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISubnet\`](#aws-cdk-lib.aws_ec2.ISubnet)[]
 
@@ -28635,7 +28635,7 @@ publicly.
 
 ---
 
-##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.kubectlRole\\"></a>
+##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlRole\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
@@ -28645,7 +28645,7 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 
 ---
 
-##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.kubectlSecurityGroup\\"></a>
+##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlSecurityGroup\\"></a>
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 
@@ -28667,7 +28667,7 @@ NodeGroup interface.
 
 #### Properties <a name=\\"Properties\\"></a>
 
-##### \`node\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.node\\"></a>
+##### \`node\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.property.node\\"></a>
 
 - *Type:* [\`constructs.Node\`](#constructs.Node)
 
@@ -28675,7 +28675,7 @@ The tree node.
 
 ---
 
-##### \`env\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.env\\"></a>
+##### \`env\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.property.env\\"></a>
 
 - *Type:* [\`aws-cdk-lib.ResourceEnvironment\`](#aws-cdk-lib.ResourceEnvironment)
 
@@ -28690,7 +28690,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-##### \`stack\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.stack\\"></a>
+##### \`stack\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.property.stack\\"></a>
 
 - *Type:* [\`aws-cdk-lib.Stack\`](#aws-cdk-lib.Stack)
 
@@ -28698,7 +28698,7 @@ The stack in which this resource is defined.
 
 ---
 
-##### \`nodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.nodegroupName\\"></a>
+##### \`nodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.property.nodegroupName\\"></a>
 
 - *Type:* \`string\`
 

--- a/test/docgen/view/__snapshots__/initializer.test.ts.snap
+++ b/test/docgen/view/__snapshots__/initializer.test.ts.snap
@@ -14,7 +14,7 @@ aws_cdk.aws_ecr.CfnPublicRepository(scope: Construct,
                                     tags: typing.List[CfnTag] = None)
 \`\`\`
 
-# \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.scope\\"></a>
+# \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.parameter.scope\\"></a>
 
 - *Type:* [\`aws_cdk.core.Construct\`](#aws_cdk.core.Construct)
 
@@ -22,7 +22,7 @@ scope in which this resource is defined.
 
 ---
 
-# \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.id\\"></a>
+# \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -30,7 +30,7 @@ scoped id of the resource.
 
 ---
 
-# \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_catalog_data\\"></a>
+# \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.repository_catalog_data\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -40,7 +40,7 @@ scoped id of the resource.
 
 ---
 
-# \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_name\\"></a>
+# \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -50,7 +50,7 @@ scoped id of the resource.
 
 ---
 
-# \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_policy_text\\"></a>
+# \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -60,7 +60,7 @@ scoped id of the resource.
 
 ---
 
-# \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.tags\\"></a>
+# \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.parameter.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -81,7 +81,7 @@ import { CfnPublicRepository } from '@aws-cdk/aws-ecr'
 new CfnPublicRepository(scope: Construct, id: string, props?: CfnPublicRepositoryProps)
 \`\`\`
 
-# \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.scope\\"></a>
+# \`scope\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.parameter.scope\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Construct\`](#@aws-cdk/core.Construct)
 
@@ -89,7 +89,7 @@ scope in which this resource is defined.
 
 ---
 
-# \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.id\\"></a>
+# \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -97,7 +97,7 @@ scoped id of the resource.
 
 ---
 
-# \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.props\\"></a>
+# \`props\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.parameter.props\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.CfnPublicRepositoryProps\`](#@aws-cdk/aws-ecr.CfnPublicRepositoryProps)
 

--- a/test/docgen/view/__snapshots__/instance-method.test.ts.snap
+++ b/test/docgen/view/__snapshots__/instance-method.test.ts.snap
@@ -7,7 +7,7 @@ exports[`python snapshot 1`] = `
 def inspect(inspector: TreeInspector)
 \`\`\`
 
-# \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.inspector\\"></a>
+# \`inspector\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.parameter.inspector\\"></a>
 
 - *Type:* [\`aws_cdk.core.TreeInspector\`](#aws_cdk.core.TreeInspector)
 
@@ -24,7 +24,7 @@ exports[`typescript snapshot 1`] = `
 public inspect(inspector: TreeInspector)
 \`\`\`
 
-# \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.inspector\\"></a>
+# \`inspector\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.parameter.inspector\\"></a>
 
 - *Type:* [\`@aws-cdk/core.TreeInspector\`](#@aws-cdk/core.TreeInspector)
 

--- a/test/docgen/view/__snapshots__/interface.test.ts.snap
+++ b/test/docgen/view/__snapshots__/interface.test.ts.snap
@@ -17,7 +17,7 @@ Represents an ECR repository.
 def add_to_resource_policy(statement: PolicyStatement)
 \`\`\`
 
-### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.statement\\"></a>
+### \`statement\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.statement\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.PolicyStatement\`](#aws_cdk.aws_iam.PolicyStatement)
 
@@ -30,13 +30,13 @@ def grant(grantee: IGrantable,
           actions: str)
 \`\`\`
 
-### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.grantee\\"></a>
+### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
 ---
 
-### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.actions\\"></a>
+### \`actions\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.actions\\"></a>
 
 - *Type:* \`str\`
 
@@ -48,7 +48,7 @@ def grant(grantee: IGrantable,
 def grant_pull(grantee: IGrantable)
 \`\`\`
 
-### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.grantee\\"></a>
+### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -60,7 +60,7 @@ def grant_pull(grantee: IGrantable)
 def grant_pull_push(grantee: IGrantable)
 \`\`\`
 
-### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.grantee\\"></a>
+### \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -76,7 +76,7 @@ def on_cloud_trail_event(id: str,
                          target: IRuleTarget = None)
 \`\`\`
 
-### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -84,7 +84,7 @@ The id of the rule.
 
 ---
 
-### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -93,7 +93,7 @@ A description of the rule's purpose.
 
 ---
 
-### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -108,7 +108,7 @@ on top of that filtering.
 
 ---
 
-### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -117,7 +117,7 @@ A name for the rule.
 
 ---
 
-### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -137,7 +137,7 @@ def on_cloud_trail_image_pushed(id: str,
                                 image_tag: str = None)
 \`\`\`
 
-### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -145,7 +145,7 @@ The id of the rule.
 
 ---
 
-### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.description\\"></a>
+### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -154,7 +154,7 @@ A description of the rule's purpose.
 
 ---
 
-### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.event_pattern\\"></a>
+### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -169,7 +169,7 @@ on top of that filtering.
 
 ---
 
-### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.rule_name\\"></a>
+### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -178,7 +178,7 @@ A name for the rule.
 
 ---
 
-### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.target\\"></a>
+### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -187,7 +187,7 @@ The target to register for the event.
 
 ---
 
-### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.image_tag\\"></a>
+### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.parameter.image_tag\\"></a>
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -206,13 +206,13 @@ def on_event(id: str,
              target: IRuleTarget = None)
 \`\`\`
 
-### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
 ---
 
-### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.description\\"></a>
+### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -221,7 +221,7 @@ A description of the rule's purpose.
 
 ---
 
-### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.event_pattern\\"></a>
+### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -236,7 +236,7 @@ on top of that filtering.
 
 ---
 
-### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.rule_name\\"></a>
+### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -245,7 +245,7 @@ A name for the rule.
 
 ---
 
-### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.target\\"></a>
+### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_events.OnEventOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -265,7 +265,7 @@ def on_image_scan_completed(id: str,
                             image_tags: typing.List[str] = None)
 \`\`\`
 
-### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.id\\"></a>
+### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`str\`
 
@@ -273,7 +273,7 @@ The id of the rule.
 
 ---
 
-### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.description\\"></a>
+### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.description\\"></a>
 
 - *Type:* \`str\`
 - *Default:* No description
@@ -282,7 +282,7 @@ A description of the rule's purpose.
 
 ---
 
-### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.event_pattern\\"></a>
+### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.event_pattern\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -297,7 +297,7 @@ on top of that filtering.
 
 ---
 
-### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.rule_name\\"></a>
+### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.rule_name\\"></a>
 
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
@@ -306,7 +306,7 @@ A name for the rule.
 
 ---
 
-### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.target\\"></a>
+### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.target\\"></a>
 
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
@@ -315,7 +315,7 @@ The target to register for the event.
 
 ---
 
-### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.image_tags\\"></a>
+### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.parameter.image_tags\\"></a>
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -332,7 +332,7 @@ Leave it undefined to watch the full repository.
 def repository_uri_for_digest(digest: str = None)
 \`\`\`
 
-### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.digest\\"></a>
+### \`digest\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.digest\\"></a>
 
 - *Type:* \`str\`
 
@@ -346,7 +346,7 @@ Image digest to use (tools usually default to the image with the \\"latest\\" ta
 def repository_uri_for_tag(tag: str = None)
 \`\`\`
 
-### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.tag\\"></a>
+### \`tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.parameter.tag\\"></a>
 
 - *Type:* \`str\`
 
@@ -356,7 +356,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 # Properties <a name=\\"Properties\\"></a>
 
-## \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.node\\"></a>
+## \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.node\\"></a>
 
 - *Type:* [\`aws_cdk.core.ConstructNode\`](#aws_cdk.core.ConstructNode)
 
@@ -364,7 +364,7 @@ The construct tree node for this construct.
 
 ---
 
-## \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.env\\"></a>
+## \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.env\\"></a>
 
 - *Type:* [\`aws_cdk.core.ResourceEnvironment\`](#aws_cdk.core.ResourceEnvironment)
 
@@ -379,7 +379,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-## \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.stack\\"></a>
+## \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.stack\\"></a>
 
 - *Type:* [\`aws_cdk.core.Stack\`](#aws_cdk.core.Stack)
 
@@ -387,7 +387,7 @@ The stack in which this resource is defined.
 
 ---
 
-## \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.repository_arn\\"></a>
+## \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_arn\\"></a>
 
 - *Type:* \`str\`
 
@@ -395,7 +395,7 @@ The ARN of the repository.
 
 ---
 
-## \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.repository_name\\"></a>
+## \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -403,7 +403,7 @@ The name of the repository.
 
 ---
 
-## \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.repository_uri\\"></a>
+## \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_uri\\"></a>
 
 - *Type:* \`str\`
 
@@ -432,7 +432,7 @@ Represents an ECR repository.
 public addToResourcePolicy(statement: PolicyStatement)
 \`\`\`
 
-### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.statement\\"></a>
+### \`statement\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.statement\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.PolicyStatement\`](#@aws-cdk/aws-iam.PolicyStatement)
 
@@ -444,13 +444,13 @@ public addToResourcePolicy(statement: PolicyStatement)
 public grant(grantee: IGrantable, actions: string)
 \`\`\`
 
-### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.grantee\\"></a>
+### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
 ---
 
-### \`actions\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.actions\\"></a>
+### \`actions\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.actions\\"></a>
 
 - *Type:* \`string\`
 
@@ -462,7 +462,7 @@ public grant(grantee: IGrantable, actions: string)
 public grantPull(grantee: IGrantable)
 \`\`\`
 
-### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.grantee\\"></a>
+### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -474,7 +474,7 @@ public grantPull(grantee: IGrantable)
 public grantPullPush(grantee: IGrantable)
 \`\`\`
 
-### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.grantee\\"></a>
+### \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 
@@ -486,7 +486,7 @@ public grantPullPush(grantee: IGrantable)
 public onCloudTrailEvent(id: string, options?: OnEventOptions)
 \`\`\`
 
-### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.id\\"></a>
+### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -494,7 +494,7 @@ The id of the rule.
 
 ---
 
-### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.options\\"></a>
+### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.OnEventOptions\`](#@aws-cdk/aws-events.OnEventOptions)
 
@@ -508,7 +508,7 @@ Options for adding the rule.
 public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOptions)
 \`\`\`
 
-### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.id\\"></a>
+### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -516,7 +516,7 @@ The id of the rule.
 
 ---
 
-### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.options\\"></a>
+### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions\`](#@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions)
 
@@ -530,13 +530,13 @@ Options for adding the rule.
 public onEvent(id: string, options?: OnEventOptions)
 \`\`\`
 
-### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.id\\"></a>
+### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
 ---
 
-### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.options\\"></a>
+### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-events.OnEventOptions\`](#@aws-cdk/aws-events.OnEventOptions)
 
@@ -548,7 +548,7 @@ public onEvent(id: string, options?: OnEventOptions)
 public onImageScanCompleted(id: string, options?: OnImageScanCompletedOptions)
 \`\`\`
 
-### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.id\\"></a>
+### \`id\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.id\\"></a>
 
 - *Type:* \`string\`
 
@@ -556,7 +556,7 @@ The id of the rule.
 
 ---
 
-### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.options\\"></a>
+### \`options\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.options\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-ecr.OnImageScanCompletedOptions\`](#@aws-cdk/aws-ecr.OnImageScanCompletedOptions)
 
@@ -570,7 +570,7 @@ Options for adding the rule.
 public repositoryUriForDigest(digest?: string)
 \`\`\`
 
-### \`digest\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.digest\\"></a>
+### \`digest\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.digest\\"></a>
 
 - *Type:* \`string\`
 
@@ -584,7 +584,7 @@ Image digest to use (tools usually default to the image with the \\"latest\\" ta
 public repositoryUriForTag(tag?: string)
 \`\`\`
 
-### \`tag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.tag\\"></a>
+### \`tag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.parameter.tag\\"></a>
 
 - *Type:* \`string\`
 
@@ -594,7 +594,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 # Properties <a name=\\"Properties\\"></a>
 
-## \`node\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.node\\"></a>
+## \`node\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.node\\"></a>
 
 - *Type:* [\`@aws-cdk/core.ConstructNode\`](#@aws-cdk/core.ConstructNode)
 
@@ -602,7 +602,7 @@ The construct tree node for this construct.
 
 ---
 
-## \`env\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.env\\"></a>
+## \`env\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.env\\"></a>
 
 - *Type:* [\`@aws-cdk/core.ResourceEnvironment\`](#@aws-cdk/core.ResourceEnvironment)
 
@@ -617,7 +617,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-## \`stack\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.stack\\"></a>
+## \`stack\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.stack\\"></a>
 
 - *Type:* [\`@aws-cdk/core.Stack\`](#@aws-cdk/core.Stack)
 
@@ -625,7 +625,7 @@ The stack in which this resource is defined.
 
 ---
 
-## \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.repositoryArn\\"></a>
+## \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryArn\\"></a>
 
 - *Type:* \`string\`
 
@@ -633,7 +633,7 @@ The ARN of the repository.
 
 ---
 
-## \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.repositoryName\\"></a>
+## \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -641,7 +641,7 @@ The name of the repository.
 
 ---
 
-## \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.repositoryUri\\"></a>
+## \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryUri\\"></a>
 
 - *Type:* \`string\`
 

--- a/test/docgen/view/__snapshots__/parameter.test.ts.snap
+++ b/test/docgen/view/__snapshots__/parameter.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`python snapshot 1`] = `
-" \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.grantee\\"></a>
+" \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -10,7 +10,7 @@ exports[`python snapshot 1`] = `
 `;
 
 exports[`typescript snapshot 1`] = `
-" \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken.grantee\\"></a>
+" \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 

--- a/test/docgen/view/__snapshots__/property.test.ts.snap
+++ b/test/docgen/view/__snapshots__/property.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`python snapshot 1`] = `
-" \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_catalog_data\\"></a>
+" \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_catalog_data\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -14,7 +14,7 @@ exports[`python snapshot 1`] = `
 `;
 
 exports[`typescript snapshot 1`] = `
-" \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryCatalogData\\"></a>
+" \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 - *Type:* \`any\`
 

--- a/test/docgen/view/__snapshots__/static-function.test.ts.snap
+++ b/test/docgen/view/__snapshots__/static-function.test.ts.snap
@@ -9,7 +9,7 @@ import aws_cdk.aws_ecr
 aws_cdk.aws_ecr.AuthorizationToken.grant_read(grantee: IGrantable)
 \`\`\`
 
-# \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.grantee\\"></a>
+# \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
 
@@ -26,7 +26,7 @@ import { AuthorizationToken } from '@aws-cdk/aws-ecr'
 AuthorizationToken.grantRead(grantee: IGrantable)
 \`\`\`
 
-# \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken.grantee\\"></a>
+# \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)
 

--- a/test/docgen/view/__snapshots__/struct.test.ts.snap
+++ b/test/docgen/view/__snapshots__/struct.test.ts.snap
@@ -18,7 +18,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
                                          tags: typing.List[CfnTag] = None)
 \`\`\`
 
-## \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_catalog_data\\"></a>
+## \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_catalog_data\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -28,7 +28,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
 
 ---
 
-## \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_name\\"></a>
+## \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_name\\"></a>
 
 - *Type:* \`str\`
 
@@ -38,7 +38,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
 
 ---
 
-## \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_policy_text\\"></a>
+## \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_policy_text\\"></a>
 
 - *Type:* \`typing.Any\`
 
@@ -48,7 +48,7 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(repository_catalog_data: typing.Any = N
 
 ---
 
-## \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.tags\\"></a>
+## \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -75,7 +75,7 @@ import { CfnPublicRepositoryProps } from '@aws-cdk/aws-ecr'
 const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 \`\`\`
 
-## \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryCatalogData\\"></a>
+## \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 - *Type:* \`any\`
 
@@ -85,7 +85,7 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ---
 
-## \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryName\\"></a>
+## \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
 
 - *Type:* \`string\`
 
@@ -95,7 +95,7 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ---
 
-## \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryPolicyText\\"></a>
+## \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
 - *Type:* \`any\`
 
@@ -105,7 +105,7 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ---
 
-## \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.tags\\"></a>
+## \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
 


### PR DESCRIPTION
The current implementation overrides the `HOME` env variable before running any `npm` command because otherwise running it inside a lambda function (where `HOME` is a read-only filesystem) will fail. 

This works well when installing from the default registry, but when a custom registry is configured in the actual `HOME` directory (via `.npmrc` file), this causes the command to ignore those configurations. 

As a result, and following https://github.com/cdklabs/construct-hub/pull/164, docgen generation currently fails because it tries to connect to the default registry, which it cannot since the lambda doesn't have internet access.

The solution is to completely drop the logic for overriding the `HOME` directory - it is not the responsibility of `jsii-docgen`, but rather of the consumer. 

In addition, this PR includes:

- Expose some needed information on `TransliteratedType` so that consumers can construct custom links using [`linkFormatter`](https://github.com/cdklabs/jsii-docgen/blob/master/src/docgen/view/documentation.ts#L47)
- Fix possible FQN collision between a type and a property/parameter. For example: the `@aws-cdk/aws-esk.AwsAuthProps` struct will have the same FQN as the `@aws-cdk/aws-eks.AwsAuth.props` parameter (after sanitation). 

For some context, all of these fixes are necessary for https://github.com/cdklabs/construct-hub/pull/175