### PR TITLE
fix: rosetta failures causes fallback to typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,13 +53,13 @@
     "typescript": "^3.9.10"
   },
   "dependencies": {
-    "@jsii/spec": "^1.31.0",
+    "@jsii/spec": "^1.32.0",
     "case": "^1.6.3",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.7",
     "glob-promise": "^3.4.0",
-    "jsii-reflect": "^1.31.0",
-    "jsii-rosetta": "^1.31.0",
+    "jsii-reflect": "^1.32.0",
+    "jsii-rosetta": "^1.32.0",
     "yargs": "^16.2.0"
   },
   "bundledDependencies": [],

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -262,17 +262,13 @@ async function createAssembly(name: string, tsDir: string, loose: boolean, langu
   console.log(`Creating assembly in ${language ?? 'ts'} for ${name} from ${tsDir} (loose: ${loose})`);
   const ts = new reflect.TypeSystem();
   for (let dotJsii of await glob.promise(`${tsDir}/**/.jsii`)) {
-    if (language) {
+    // we only transliterate the top level assembly and not the entire type-system.
+    // note that the only reason to translate dependant assemblies is to show code examples
+    // for expanded python arguments - which we don't to right now anyway.
+    if (language && dotJsii.endsWith(`${name}/.jsii`)) {
       const packageDir = path.dirname(dotJsii);
-      try {
-        await transliterateAssembly([packageDir], [language], { loose });
-        dotJsii = path.join(packageDir, `.jsii.${language}`);
-      } catch (e) {
-        if (!loose) {
-          throw e;
-        }
-        console.log(`Caught transliteration error: ${e}. Ignoring...`);
-      }
+      await transliterateAssembly([packageDir], [language], { loose });
+      dotJsii = path.join(packageDir, `.jsii.${language}`);
     }
     await ts.load(dotJsii);
   }

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -265,7 +265,10 @@ async function createAssembly(name: string, tsDir: string, loose: boolean, langu
     // we only transliterate the top level assembly and not the entire type-system.
     // note that the only reason to translate dependant assemblies is to show code examples
     // for expanded python arguments - which we don't to right now anyway.
-    if (language && dotJsii.endsWith(`${name}/.jsii`)) {
+    // we don't want to make any assumption of the directory structure, so this is the most
+    // robuse way to detect the root assembly.
+    const spec = JSON.parse(await fs.readFile(dotJsii, 'utf-8'));
+    if (language && spec.name === name) {
       const packageDir = path.dirname(dotJsii);
       await transliterateAssembly([packageDir], [language], { loose });
       dotJsii = path.join(packageDir, `.jsii.${language}`);

--- a/test/docgen/view/__snapshots__/documentation.test.ts.snap
+++ b/test/docgen/view/__snapshots__/documentation.test.ts.snap
@@ -5230,16 +5230,15 @@ Rule applies to untagged images.
 
 exports[`python snapshot - root module 1`] = `
 "# Amazon ECR Construct Library
-<!--BEGIN STABILITY BANNER-->
 
----
+<!--BEGIN STABILITY BANNER-->---
+
 
 ![cfn-resources: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
 
 ![cdk-constructs: Stable](https://img.shields.io/badge/cdk--constructs-stable-success.svg?style=for-the-badge)
 
 ---
-
 <!--END STABILITY BANNER-->
 
 This package contains constructs for working with Amazon Elastic Container Registry.
@@ -5249,25 +5248,33 @@ This package contains constructs for working with Amazon Elastic Container Regis
 Define a repository by creating a new instance of \`Repository\`. A repository
 holds multiple verions of a single container image.
 
-\`\`\`ts
-const repository = new ecr.Repository(this, 'Repository');
+\`\`\`python
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
+repository = ecr.Repository(self, \\"Repository\\")
 \`\`\`
 
 ## Image scanning
 
 Amazon ECR image scanning helps in identifying software vulnerabilities in your container images. You can manually scan container images stored in Amazon ECR, or you can configure your repositories to scan images when you push them to a repository. To create a new repository to scan on push, simply enable \`imageScanOnPush\` in the properties
 
-\`\`\`ts
-const repository = new ecr.Repository(stack, 'Repo', {
-  imageScanOnPush: true
-});
+\`\`\`python
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
+repository = ecr.Repository(stack, \\"Repo\\",
+    image_scan_on_push=True
+)
 \`\`\`
 
 To create an \`onImageScanCompleted\` event rule and trigger the event target
 
-\`\`\`ts
-repository.onImageScanCompleted('ImageScanComplete')
-  .addTarget(...)
+\`\`\`python
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
+repository.on_image_scan_completed(\\"ImageScanComplete\\").add_target(...)
 \`\`\`
 
 ### Authorization Token
@@ -5280,12 +5287,15 @@ More information can be found at at [Registry Authentication](https://docs.aws.a
 A Docker authorization token can be obtained using the \`GetAuthorizationToken\` ECR API. The following code snippets
 grants an IAM user access to call this API.
 
-\`\`\`ts
-import * as iam from '@aws-cdk/aws-iam';
-import * as ecr from '@aws-cdk/aws-ecr';
+\`\`\`python
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
 
-const user = new iam.User(this, 'User', { ... });
-ecr.AuthorizationToken.grantRead(user);
+import aws_cdk.aws_iam as iam
+import aws_cdk.aws_ecr as ecr
+
+user = iam.User(self, \\"User\\", ...)
+ecr.AuthorizationToken.grant_read(user)
 \`\`\`
 
 If you access images in the [Public ECR Gallery](https://gallery.ecr.aws/) as well, it is recommended you authenticate to the registry to benefit from
@@ -5295,12 +5305,15 @@ higher rate and bandwidth limits.
 
 The following code snippet grants an IAM user access to retrieve an authorization token for the public gallery.
 
-\`\`\`ts
-import * as iam from '@aws-cdk/aws-iam';
-import * as ecr from '@aws-cdk/aws-ecr';
+\`\`\`python
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
 
-const user = new iam.User(this, 'User', { ... });
-ecr.PublicGalleryAuthorizationToken.grantRead(user);
+import aws_cdk.aws_iam as iam
+import aws_cdk.aws_ecr as ecr
+
+user = iam.User(self, \\"User\\", ...)
+ecr.PublicGalleryAuthorizationToken.grant_read(user)
 \`\`\`
 
 This user can then proceed to login to the registry using one of the [authentication methods](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html#public-registry-auth).
@@ -5309,8 +5322,11 @@ This user can then proceed to login to the registry using one of the [authentica
 
 You can set tag immutability on images in our repository using the \`imageTagMutability\` construct prop.
 
-\`\`\`ts
-new ecr.Repository(stack, 'Repo', { imageTagMutability: ecr.TagMutability.IMMUTABLE });
+\`\`\`python
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
+ecr.Repository(stack, \\"Repo\\", image_tag_mutability=ecr.TagMutability.IMMUTABLE)
 \`\`\`
 
 ## Automatically clean up repositories
@@ -5321,11 +5337,13 @@ against that image. For example, the following deletes images older than
 30 days, while keeping all images tagged with prod (note that the order
 is important here):
 
-\`\`\`ts
-repository.addLifecycleRule({ tagPrefixList: ['prod'], maxImageCount: 9999 });
-repository.addLifecycleRule({ maxImageAge: cdk.Duration.days(30) });
-\`\`\`
+\`\`\`python
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
 
+repository.add_lifecycle_rule(tag_prefix_list=[\\"prod\\"], max_image_count=9999)
+repository.add_lifecycle_rule(max_image_age=cdk.Duration.days(30))
+\`\`\`
 # API Reference <a name=\\"API Reference\\"></a>
 
 ## Constructs <a name=\\"Constructs\\"></a>

--- a/test/docgen/view/__snapshots__/documentation.test.ts.snap
+++ b/test/docgen/view/__snapshots__/documentation.test.ts.snap
@@ -21,7 +21,9 @@ Define a repository by creating a new instance of \`Repository\`. A repository
 holds multiple verions of a single container image.
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 repository = ecr.Repository(self, \\"Repository\\")
 \`\`\`
 
@@ -30,7 +32,9 @@ repository = ecr.Repository(self, \\"Repository\\")
 Amazon ECR image scanning helps in identifying software vulnerabilities in your container images. You can manually scan container images stored in Amazon ECR, or you can configure your repositories to scan images when you push them to a repository. To create a new repository to scan on push, simply enable \`imageScanOnPush\` in the properties
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 repository = ecr.Repository(stack, \\"Repo\\",
     image_scan_on_push=True
 )
@@ -39,7 +43,9 @@ repository = ecr.Repository(stack, \\"Repo\\",
 To create an \`onImageScanCompleted\` event rule and trigger the event target
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 repository.on_image_scan_completed(\\"ImageScanComplete\\").add_target(...)
 \`\`\`
 
@@ -54,7 +60,9 @@ A Docker authorization token can be obtained using the \`GetAuthorizationToken\`
 grants an IAM user access to call this API.
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 import aws_cdk.aws_iam as iam
 import aws_cdk.aws_ecr as ecr
 
@@ -70,7 +78,9 @@ higher rate and bandwidth limits.
 The following code snippet grants an IAM user access to retrieve an authorization token for the public gallery.
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 import aws_cdk.aws_iam as iam
 import aws_cdk.aws_ecr as ecr
 
@@ -85,7 +95,9 @@ This user can then proceed to login to the registry using one of the [authentica
 You can set tag immutability on images in our repository using the \`imageTagMutability\` construct prop.
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 ecr.Repository(stack, \\"Repo\\", image_tag_mutability=ecr.TagMutability.IMMUTABLE)
 \`\`\`
 
@@ -98,7 +110,9 @@ against that image. For example, the following deletes images older than
 is important here):
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 repository.add_lifecycle_rule(tag_prefix_list=[\\"prod\\"], max_image_count=9999)
 repository.add_lifecycle_rule(max_image_age=cdk.Duration.days(30))
 \`\`\`
@@ -2573,217 +2587,6 @@ Rule applies to untagged images.
 "
 `;
 
-exports[`loose mode grossly ignores assembly transliteration failures 1`] = `
-"# CDK Construct library for higher-level Route 53 Constructs
-
-<!--BEGIN STABILITY BANNER-->---
-
-
-![cdk-constructs: Stable](https://img.shields.io/badge/cdk--constructs-stable-success.svg?style=for-the-badge)
-
----
-<!--END STABILITY BANNER-->
-
-This library provides higher-level Amazon Route 53 constructs which follow common
-architectural patterns.
-
-## HTTPS Redirect
-
-If you want to speed up delivery of your web content, you can use Amazon CloudFront,
-the AWS content delivery network (CDN). CloudFront can deliver your entire website
-—including dynamic, static, streaming, and interactive content—by using a global
-network of edge locations. Requests for your content are automatically routed to the
-edge location that gives your users the lowest latency.
-
-This construct allows creating a redirect from domainA to domainB using Amazon
-CloudFront and Amazon S3. You can specify multiple domains to be redirected.
-[Learn more](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-cloudfront-distribution.html) about routing traffic to a CloudFront web distribution.
-
-The \`HttpsRedirect\` constructs creates:
-
-* Amazon CloudFront distribution - makes website available from data centres
-  around the world
-* Amazon S3 bucket - empty bucket used for website hosting redirect (\`websiteRedirect\`) capabilities.
-* Amazon Route 53 A/AAAA Alias records - routes traffic to the CloudFront distribution
-* AWS Certificate Manager certificate - SSL/TLS certificate used by
-  CloudFront for your domain
-
-⚠️ The stack/construct can be used in any region for configuring an HTTPS redirect.
-The certificate created in Amazon Certificate Manager (ACM) will be in US East (N. Virginia)
-region. If you use an existing certificate, the AWS region of the certificate
-must be in US East (N. Virginia).
-
-The following example creates an HTTPS redirect from \`foo.example.com\` to \`bar.example.com\`
-As an existing certificate is not provided, one will be created in \`us-east-1\` by the CDK.
-
-\`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
-HttpsRedirect(stack, \\"Redirect\\",
-    record_names=[\\"foo.example.com\\"],
-    target_domain=\\"bar.example.com\\",
-    zone=HostedZone.from_hosted_zone_attributes(stack, \\"HostedZone\\",
-        hosted_zone_id=\\"ID\\",
-        zone_name=\\"example.com\\"
-    )
-)
-\`\`\`
-# API Reference <a name=\\"API Reference\\"></a>
-
-## Constructs <a name=\\"Constructs\\"></a>
-
-### HttpsRedirect <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirect\\"></a>
-
-Allows creating a domainA -> domainB redirect using CloudFront and S3.
-
-You can specify multiple domains to be redirected.
-
-#### Initializer <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirect.Initializer\\"></a>
-
-\`\`\`python
-import aws_cdk.aws_route53_patterns
-
-aws_cdk.aws_route53_patterns.HttpsRedirect(scope: Construct, 
-                                           id: str, 
-                                           target_domain: str, 
-                                           zone: IHostedZone, 
-                                           certificate: ICertificate = None, 
-                                           record_names: typing.List[str] = None)
-\`\`\`
-
-##### \`scope\`<sup>Required</sup> <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirect.parameter.scope\\"></a>
-
-- *Type:* [\`constructs.Construct\`](#constructs.Construct)
-
----
-
-##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirect.parameter.id\\"></a>
-
-- *Type:* \`str\`
-
----
-
-##### \`target_domain\`<sup>Required</sup> <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirectProps.parameter.target_domain\\"></a>
-
-- *Type:* \`str\`
-
-The redirect target fully qualified domain name (FQDN).
-
-An alias record
-will be created that points to your CloudFront distribution. Root domain
-or sub-domain can be supplied.
-
----
-
-##### \`zone\`<sup>Required</sup> <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirectProps.parameter.zone\\"></a>
-
-- *Type:* [\`aws_cdk.aws_route53.IHostedZone\`](#aws_cdk.aws_route53.IHostedZone)
-
-Hosted zone of the domain which will be used to create alias record(s) from domain names in the hosted zone to the target domain.
-
-The hosted zone must
-contain entries for the domain name(s) supplied through \`recordNames\` that
-will redirect to the target domain.
-
-Domain names in the hosted zone can include a specific domain (example.com)
-and its subdomains (acme.example.com, zenith.example.com).
-
----
-
-##### \`certificate\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirectProps.parameter.certificate\\"></a>
-
-- *Type:* [\`aws_cdk.aws_certificatemanager.ICertificate\`](#aws_cdk.aws_certificatemanager.ICertificate)
-- *Default:* A new certificate is created in us-east-1 (N. Virginia)
-
-The AWS Certificate Manager (ACM) certificate that will be associated with the CloudFront distribution that will be created.
-
-If provided, the certificate must be
-stored in us-east-1 (N. Virginia)
-
----
-
-##### \`record_names\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirectProps.parameter.record_names\\"></a>
-
-- *Type:* typing.List[\`str\`]
-- *Default:* the domain name of the hosted zone
-
-The domain names that will redirect to \`targetDomain\`.
-
----
-
-
-
-
-
-## Structs <a name=\\"Structs\\"></a>
-
-### HttpsRedirectProps <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirectProps\\"></a>
-
-Properties to configure an HTTPS Redirect.
-
-#### Initializer <a name=\\"[object Object].Initializer\\"></a>
-
-\`\`\`python
-import aws_cdk.aws_route53_patterns
-
-aws_cdk.aws_route53_patterns.HttpsRedirectProps(target_domain: str, 
-                                                zone: IHostedZone, 
-                                                certificate: ICertificate = None, 
-                                                record_names: typing.List[str] = None)
-\`\`\`
-
-##### \`target_domain\`<sup>Required</sup> <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirectProps.property.target_domain\\"></a>
-
-- *Type:* \`str\`
-
-The redirect target fully qualified domain name (FQDN).
-
-An alias record
-will be created that points to your CloudFront distribution. Root domain
-or sub-domain can be supplied.
-
----
-
-##### \`zone\`<sup>Required</sup> <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirectProps.property.zone\\"></a>
-
-- *Type:* [\`aws_cdk.aws_route53.IHostedZone\`](#aws_cdk.aws_route53.IHostedZone)
-
-Hosted zone of the domain which will be used to create alias record(s) from domain names in the hosted zone to the target domain.
-
-The hosted zone must
-contain entries for the domain name(s) supplied through \`recordNames\` that
-will redirect to the target domain.
-
-Domain names in the hosted zone can include a specific domain (example.com)
-and its subdomains (acme.example.com, zenith.example.com).
-
----
-
-##### \`certificate\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirectProps.property.certificate\\"></a>
-
-- *Type:* [\`aws_cdk.aws_certificatemanager.ICertificate\`](#aws_cdk.aws_certificatemanager.ICertificate)
-- *Default:* A new certificate is created in us-east-1 (N. Virginia)
-
-The AWS Certificate Manager (ACM) certificate that will be associated with the CloudFront distribution that will be created.
-
-If provided, the certificate must be
-stored in us-east-1 (N. Virginia)
-
----
-
-##### \`record_names\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_route53_patterns.HttpsRedirectProps.property.record_names\\"></a>
-
-- *Type:* typing.List[\`str\`]
-- *Default:* the domain name of the hosted zone
-
-The domain names that will redirect to \`targetDomain\`.
-
----
-
-
-
-"
-`;
-
 exports[`package installation does not run lifecycle hooks 1`] = `
 "# construct-library
 
@@ -2859,7 +2662,9 @@ Define a repository by creating a new instance of \`Repository\`. A repository
 holds multiple verions of a single container image.
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 repository = ecr.Repository(self, \\"Repository\\")
 \`\`\`
 
@@ -2868,7 +2673,9 @@ repository = ecr.Repository(self, \\"Repository\\")
 Amazon ECR image scanning helps in identifying software vulnerabilities in your container images. You can manually scan container images stored in Amazon ECR, or you can configure your repositories to scan images when you push them to a repository. To create a new repository to scan on push, simply enable \`imageScanOnPush\` in the properties
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 repository = ecr.Repository(stack, \\"Repo\\",
     image_scan_on_push=True
 )
@@ -2877,7 +2684,9 @@ repository = ecr.Repository(stack, \\"Repo\\",
 To create an \`onImageScanCompleted\` event rule and trigger the event target
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 repository.on_image_scan_completed(\\"ImageScanComplete\\").add_target(...)
 \`\`\`
 
@@ -2892,7 +2701,9 @@ A Docker authorization token can be obtained using the \`GetAuthorizationToken\`
 grants an IAM user access to call this API.
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 import aws_cdk.aws_iam as iam
 import aws_cdk.aws_ecr as ecr
 
@@ -2908,7 +2719,9 @@ higher rate and bandwidth limits.
 The following code snippet grants an IAM user access to retrieve an authorization token for the public gallery.
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 import aws_cdk.aws_iam as iam
 import aws_cdk.aws_ecr as ecr
 
@@ -2923,7 +2736,9 @@ This user can then proceed to login to the registry using one of the [authentica
 You can set tag immutability on images in our repository using the \`imageTagMutability\` construct prop.
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 ecr.Repository(stack, \\"Repo\\", image_tag_mutability=ecr.TagMutability.IMMUTABLE)
 \`\`\`
 
@@ -2936,7 +2751,9 @@ against that image. For example, the following deletes images older than
 is important here):
 
 \`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
+# This example was automatically transliterated with incomplete type information. It may not work as-is.
+# See https://github.com/aws/jsii/issues/826 for more information.
+
 repository.add_lifecycle_rule(tag_prefix_list=[\\"prod\\"], max_image_count=9999)
 repository.add_lifecycle_rule(max_image_age=cdk.Duration.days(30))
 \`\`\`
@@ -5413,15 +5230,16 @@ Rule applies to untagged images.
 
 exports[`python snapshot - root module 1`] = `
 "# Amazon ECR Construct Library
+<!--BEGIN STABILITY BANNER-->
 
-<!--BEGIN STABILITY BANNER-->---
-
+---
 
 ![cfn-resources: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
 
 ![cdk-constructs: Stable](https://img.shields.io/badge/cdk--constructs-stable-success.svg?style=for-the-badge)
 
 ---
+
 <!--END STABILITY BANNER-->
 
 This package contains constructs for working with Amazon Elastic Container Registry.
@@ -5431,27 +5249,25 @@ This package contains constructs for working with Amazon Elastic Container Regis
 Define a repository by creating a new instance of \`Repository\`. A repository
 holds multiple verions of a single container image.
 
-\`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
-repository = ecr.Repository(self, \\"Repository\\")
+\`\`\`ts
+const repository = new ecr.Repository(this, 'Repository');
 \`\`\`
 
 ## Image scanning
 
 Amazon ECR image scanning helps in identifying software vulnerabilities in your container images. You can manually scan container images stored in Amazon ECR, or you can configure your repositories to scan images when you push them to a repository. To create a new repository to scan on push, simply enable \`imageScanOnPush\` in the properties
 
-\`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
-repository = ecr.Repository(stack, \\"Repo\\",
-    image_scan_on_push=True
-)
+\`\`\`ts
+const repository = new ecr.Repository(stack, 'Repo', {
+  imageScanOnPush: true
+});
 \`\`\`
 
 To create an \`onImageScanCompleted\` event rule and trigger the event target
 
-\`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
-repository.on_image_scan_completed(\\"ImageScanComplete\\").add_target(...)
+\`\`\`ts
+repository.onImageScanCompleted('ImageScanComplete')
+  .addTarget(...)
 \`\`\`
 
 ### Authorization Token
@@ -5464,13 +5280,12 @@ More information can be found at at [Registry Authentication](https://docs.aws.a
 A Docker authorization token can be obtained using the \`GetAuthorizationToken\` ECR API. The following code snippets
 grants an IAM user access to call this API.
 
-\`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
-import aws_cdk.aws_iam as iam
-import aws_cdk.aws_ecr as ecr
+\`\`\`ts
+import * as iam from '@aws-cdk/aws-iam';
+import * as ecr from '@aws-cdk/aws-ecr';
 
-user = iam.User(self, \\"User\\", ...)
-ecr.AuthorizationToken.grant_read(user)
+const user = new iam.User(this, 'User', { ... });
+ecr.AuthorizationToken.grantRead(user);
 \`\`\`
 
 If you access images in the [Public ECR Gallery](https://gallery.ecr.aws/) as well, it is recommended you authenticate to the registry to benefit from
@@ -5480,13 +5295,12 @@ higher rate and bandwidth limits.
 
 The following code snippet grants an IAM user access to retrieve an authorization token for the public gallery.
 
-\`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
-import aws_cdk.aws_iam as iam
-import aws_cdk.aws_ecr as ecr
+\`\`\`ts
+import * as iam from '@aws-cdk/aws-iam';
+import * as ecr from '@aws-cdk/aws-ecr';
 
-user = iam.User(self, \\"User\\", ...)
-ecr.PublicGalleryAuthorizationToken.grant_read(user)
+const user = new iam.User(this, 'User', { ... });
+ecr.PublicGalleryAuthorizationToken.grantRead(user);
 \`\`\`
 
 This user can then proceed to login to the registry using one of the [authentication methods](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html#public-registry-auth).
@@ -5495,9 +5309,8 @@ This user can then proceed to login to the registry using one of the [authentica
 
 You can set tag immutability on images in our repository using the \`imageTagMutability\` construct prop.
 
-\`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
-ecr.Repository(stack, \\"Repo\\", image_tag_mutability=ecr.TagMutability.IMMUTABLE)
+\`\`\`ts
+new ecr.Repository(stack, 'Repo', { imageTagMutability: ecr.TagMutability.IMMUTABLE });
 \`\`\`
 
 ## Automatically clean up repositories
@@ -5508,11 +5321,11 @@ against that image. For example, the following deletes images older than
 30 days, while keeping all images tagged with prod (note that the order
 is important here):
 
-\`\`\`python
-# Example automatically generated without compilation. See https://github.com/aws/jsii/issues/826
-repository.add_lifecycle_rule(tag_prefix_list=[\\"prod\\"], max_image_count=9999)
-repository.add_lifecycle_rule(max_image_age=cdk.Duration.days(30))
+\`\`\`ts
+repository.addLifecycleRule({ tagPrefixList: ['prod'], maxImageCount: 9999 });
+repository.addLifecycleRule({ maxImageAge: cdk.Duration.days(30) });
 \`\`\`
+
 # API Reference <a name=\\"API Reference\\"></a>
 
 ## Constructs <a name=\\"Constructs\\"></a>

--- a/test/docgen/view/documentation.test.ts
+++ b/test/docgen/view/documentation.test.ts
@@ -10,7 +10,7 @@ const LIBRARIES = `${__dirname}/../../__fixtures__/libraries`;
 
 // this is a little concerning...we should be mindful
 // if need to keep increasing this.
-jest.setTimeout(3 * 60 * 1000);
+jest.setTimeout(60 * 1000);
 
 
 describe('extractPackageName', () => {
@@ -110,18 +110,4 @@ describe('typescript', () => {
     const markdown = docs.render({ submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
   });
-});
-
-test('loose mode grossly ignores assembly transliteration failures', async () => {
-
-  // for some yet unknown reason, this package crashes the typescript compiler
-  // in a way that isn't recoverable by rosetta at the moment.
-  // so we use it to check that jsii-docgen ignores even those errors when requested to.
-  const docs = await Documentation.forPackage('@aws-cdk/aws-route53-patterns@1.106.0', {
-    language: Language.PYTHON,
-    loose: true,
-  });
-
-  const markdown = docs.render();
-  expect(markdown.render()).toMatchSnapshot();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -500,10 +500,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jsii/spec@^1.31.0":
-  version "1.31.0"
-  resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.31.0.tgz#9298dc163fdae0bab4006b817592235a29922871"
-  integrity sha512-qpJqZ+xj4lnKfk/HJYdYURDmHzh9aBIVOTgwd314AxKmwubDAajlAup+D2F9z9kylAB7GsQiva/SXgUlFjBeQw==
+"@jsii/spec@^1.32.0":
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.32.0.tgz#e921afaa89e19a74abee2182ff259c9090f4c452"
+  integrity sha512-XjSnqvmBXvFork9w3ehacqaa0JmUVaEYubOzR1l6z67z2FDZ9C4KP7EqMqjnv/S+j+Ou3tWQPfLICnl6aK1iGA==
   dependencies:
     jsonschema "^1.4.0"
 
@@ -3972,23 +3972,23 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-jsii-reflect@^1.31.0:
-  version "1.31.0"
-  resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.31.0.tgz#83acdae835071c734bb8847cf3cad7ccc4497540"
-  integrity sha512-jKc3tryVeEyEBZFv5bDB8rOaEgW+yBPh0DE4GQCKQQLdkp76Lm9ZSkrnJk5e0gEuAWsmuc1DUs35OcVNr8QRWg==
+jsii-reflect@^1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.32.0.tgz#30ad211bf2d325ad66d7e6690189225421f81de4"
+  integrity sha512-BJN8pgxSa3LlP5yPfxtaviSjsHKpG9b4xOr2kXv6w/SElIX15Q5/tKauI4/ZHTnBHGimRWh9ACNtxXAxvH0Vqg==
   dependencies:
-    "@jsii/spec" "^1.31.0"
+    "@jsii/spec" "^1.32.0"
     colors "^1.4.0"
     fs-extra "^9.1.0"
-    oo-ascii-tree "^1.31.0"
+    oo-ascii-tree "^1.32.0"
     yargs "^16.2.0"
 
-jsii-rosetta@^1.31.0:
-  version "1.31.0"
-  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-1.31.0.tgz#f5174b532b4c3a79eadd9ed059aa33bee21e3225"
-  integrity sha512-Heu6D+yI5mmUklLQdX3PdDvHUQm14618Fj4PQM9seKa4cohxzJ7EHopfRObKYHMko9awopx4Qr7Gtu6u/QPqfw==
+jsii-rosetta@^1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-1.32.0.tgz#654b1daf2afda8d970c62a4aa59f455303077403"
+  integrity sha512-NrhHIJ0BNKxpjyvqtqhunIcHhJiA5dhlRSPPuO+EGsCQB+yc94aRj+hZZXYvWj+X1o61kdLVudJLn54sn7ESoQ==
   dependencies:
-    "@jsii/spec" "^1.31.0"
+    "@jsii/spec" "^1.32.0"
     commonmark "^0.29.3"
     fs-extra "^9.1.0"
     typescript "~3.9.9"
@@ -4846,10 +4846,10 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-oo-ascii-tree@^1.31.0:
-  version "1.31.0"
-  resolved "https://registry.yarnpkg.com/oo-ascii-tree/-/oo-ascii-tree-1.31.0.tgz#36e10dcad35ba767db41c2d2050ff2174f3d5e6f"
-  integrity sha512-gNb2MyP1ZcF7cX0WgsAjYe4gZcx7BMLBWKE2TJZZbQ9/j4D8gbJh5Aq6RlXBgev74ODlgAVVcPr2wKU4Dufhqg==
+oo-ascii-tree@^1.32.0:
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/oo-ascii-tree/-/oo-ascii-tree-1.32.0.tgz#b02255864bc2753d05d6960cc6bb4351f6515043"
+  integrity sha512-QCYSWgdhbQwvMzw1OguyZ+K2KwZeQ1xvhFXa0/XV8XfmUXgr07MlnUoNthntfYgY6w7w+KI8WvqIxr+Q/NF5gw==
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"


### PR DESCRIPTION
This PR reverts a previous misguided decision to [ignore](https://github.com/cdklabs/jsii-docgen/pull/370) rosetta failures and fallback to typescript assemblies. 

We decided we never want to show typescript code in the documentation of other languages, a better experience is actually to fail and either introduce more heuristics in rosetta to bypass such failures, or make the necessary adjustments to the published package. 

In addition, we used to transliterate the entire type-system (i.e all dependent assemblies) and not just the top level assembly. 
The rational being that code snippets might come from those assemblies when expanding arguments for python docs. 

Problem is that this means that a transliteration failure in a deeply nested dependency, that most likely doesn't have any affect on the documentation, prevents package transliteration. This can act as a sort of poison pill because many packages depend on the same core libraries. 

Also, we aren't currently even rendering those code snippets in the docs, so there is no good reason to do it.