### PR TITLE
feat: add code examples for properties

### DIFF
--- a/src/docgen/transpile/java.ts
+++ b/src/docgen/transpile/java.ts
@@ -177,7 +177,7 @@ export class JavaTranspile extends transpile.TranspileBase {
       parentType: this.type(parameter.parentType),
       typeReference: typeRef,
       optional: parameter.optional,
-      signatureOrGetter: this.formatProperty(parameter.name, typeRef),
+      declaration: this.formatProperty(parameter.name, typeRef),
     };
   }
 
@@ -188,7 +188,7 @@ export class JavaTranspile extends transpile.TranspileBase {
       parentType: this.type(property.parentType),
       typeReference: typeRef,
       optional: property.optional,
-      signatureOrGetter: this.formatProperty(property.name, typeRef),
+      declaration: this.formatProperty(property.name, typeRef),
     };
   }
 
@@ -391,9 +391,9 @@ export class JavaTranspile extends transpile.TranspileBase {
       typeFormatter: (t) => t.name,
     });
     if (tf.includes(' OR ')) {
-      return `public java.lang.Object get${toUpperCamelCase(name)}()`;
+      return `public java.lang.Object get${toUpperCamelCase(name)}();`;
     } else {
-      return `public ${tf} get${toUpperCamelCase(name)}()`;
+      return `public ${tf} get${toUpperCamelCase(name)}();`;
     }
   }
 }

--- a/src/docgen/transpile/python.ts
+++ b/src/docgen/transpile/python.ts
@@ -138,11 +138,14 @@ export class PythonTranspile extends transpile.TranspileBase {
   }
 
   public property(property: reflect.Property): transpile.TranspiledProperty {
+    const name = property.const ? property.name : toSnakeCase(property.name);
+    const typeRef = this.typeReference(property.type);
     return {
-      name: property.const ? property.name : toSnakeCase(property.name),
+      name,
       parentType: this.type(property.parentType),
-      typeReference: this.typeReference(property.type),
+      typeReference: typeRef,
       optional: property.optional,
+      signatureOrGetter: this.formatProperty(name, typeRef),
     };
   }
 
@@ -156,11 +159,14 @@ export class PythonTranspile extends transpile.TranspileBase {
   public parameter(
     parameter: reflect.Parameter,
   ): transpile.TranspiledParameter {
+    const name = toSnakeCase(parameter.name);
+    const typeRef = this.typeReference(parameter.type);
     return {
-      name: toSnakeCase(parameter.name),
+      name,
       parentType: this.type(parameter.parentType),
-      typeReference: this.typeReference(parameter.type),
+      typeReference: typeRef,
       optional: parameter.optional,
+      signatureOrGetter: this.formatProperty(name, typeRef),
     };
   }
 
@@ -266,5 +272,15 @@ export class PythonTranspile extends transpile.TranspileBase {
       typeFormatter: (t) => t.name,
     });
     return `${transpiled.name}: ${tf}${transpiled.optional ? ' = None' : ''}`;
+  }
+
+  private formatProperty(
+    name: string,
+    typeReference: transpile.TranspiledTypeReference,
+  ): string {
+    const tf = typeReference.toString({
+      typeFormatter: (t) => t.name,
+    });
+    return `${name}: ${tf}`;
   }
 }

--- a/src/docgen/transpile/python.ts
+++ b/src/docgen/transpile/python.ts
@@ -145,7 +145,7 @@ export class PythonTranspile extends transpile.TranspileBase {
       parentType: this.type(property.parentType),
       typeReference: typeRef,
       optional: property.optional,
-      signatureOrGetter: this.formatProperty(name, typeRef),
+      declaration: this.formatProperty(name, typeRef),
     };
   }
 
@@ -166,7 +166,7 @@ export class PythonTranspile extends transpile.TranspileBase {
       parentType: this.type(parameter.parentType),
       typeReference: typeRef,
       optional: parameter.optional,
-      signatureOrGetter: this.formatProperty(name, typeRef),
+      declaration: this.formatProperty(name, typeRef),
     };
   }
 

--- a/src/docgen/transpile/transpile.ts
+++ b/src/docgen/transpile/transpile.ts
@@ -144,6 +144,11 @@ export interface TranspiledParameter {
    * Whether or not the parameter is optional.
    */
   readonly optional: boolean;
+  /**
+   * The signature of the property, or its getter if the language
+   * supports that.
+   */
+  readonly signatureOrGetter: string;
 }
 
 /**

--- a/src/docgen/transpile/transpile.ts
+++ b/src/docgen/transpile/transpile.ts
@@ -148,7 +148,7 @@ export interface TranspiledParameter {
    * The signature of the property, or its getter if the language
    * supports that.
    */
-  readonly signatureOrGetter: string;
+  readonly declaration: string;
 }
 
 /**

--- a/src/docgen/transpile/typescript.ts
+++ b/src/docgen/transpile/typescript.ts
@@ -112,11 +112,13 @@ export class TypeScriptTranspile extends transpile.TranspileBase {
   }
 
   public property(property: reflect.Property): transpile.TranspiledProperty {
+    const typeRef = this.typeReference(property.type);
     return {
       name: property.name,
       parentType: this.type(property.parentType),
-      typeReference: this.typeReference(property.type),
+      typeReference: typeRef,
       optional: property.optional,
+      signatureOrGetter: this.formatProperty(property.name, typeRef),
     };
   }
 
@@ -130,11 +132,13 @@ export class TypeScriptTranspile extends transpile.TranspileBase {
   public parameter(
     parameter: reflect.Parameter,
   ): transpile.TranspiledParameter {
+    const typeRef = this.typeReference(parameter.type);
     return {
       name: parameter.name,
       parentType: this.type(parameter.parentType),
-      typeReference: this.typeReference(parameter.type),
+      typeReference: typeRef,
       optional: parameter.optional,
+      signatureOrGetter: this.formatProperty(parameter.name, typeRef),
     };
   }
 
@@ -208,5 +212,15 @@ export class TypeScriptTranspile extends transpile.TranspileBase {
       typeFormatter: (t) => t.name,
     });
     return `${transpiled.name}${transpiled.optional ? '?' : ''}: ${tf}`;
+  }
+
+  private formatProperty(
+    name: string,
+    typeReference: transpile.TranspiledTypeReference,
+  ): string {
+    const tf = typeReference.toString({
+      typeFormatter: (t) => t.name,
+    });
+    return `public readonly ${name}: ${tf}`;
   }
 }

--- a/src/docgen/transpile/typescript.ts
+++ b/src/docgen/transpile/typescript.ts
@@ -118,7 +118,7 @@ export class TypeScriptTranspile extends transpile.TranspileBase {
       parentType: this.type(property.parentType),
       typeReference: typeRef,
       optional: property.optional,
-      signatureOrGetter: this.formatProperty(property.name, typeRef),
+      declaration: this.formatProperty(property.name, typeRef),
     };
   }
 
@@ -138,7 +138,7 @@ export class TypeScriptTranspile extends transpile.TranspileBase {
       parentType: this.type(parameter.parentType),
       typeReference: typeRef,
       optional: parameter.optional,
-      signatureOrGetter: this.formatProperty(parameter.name, typeRef),
+      declaration: this.formatProperty(parameter.name, typeRef),
     };
   }
 
@@ -221,6 +221,6 @@ export class TypeScriptTranspile extends transpile.TranspileBase {
     const tf = typeReference.toString({
       typeFormatter: (t) => t.name,
     });
-    return `public readonly ${name}: ${tf}`;
+    return `public readonly ${name}: ${tf};`;
   }
 }

--- a/src/docgen/view/constant.ts
+++ b/src/docgen/view/constant.ts
@@ -6,7 +6,7 @@ import { Property } from './property';
 export class Constant {
   private readonly constant: Property;
   constructor(transpile: Transpile, property: reflect.Property, linkFormatter: (type: TranspiledType) => string) {
-    this.constant = new Property(transpile, property, linkFormatter, true);
+    this.constant = new Property(transpile, property, linkFormatter);
   }
   public render(): Markdown {
     return this.constant.render();

--- a/src/docgen/view/constant.ts
+++ b/src/docgen/view/constant.ts
@@ -6,7 +6,7 @@ import { Property } from './property';
 export class Constant {
   private readonly constant: Property;
   constructor(transpile: Transpile, property: reflect.Property, linkFormatter: (type: TranspiledType) => string) {
-    this.constant = new Property(transpile, property, linkFormatter);
+    this.constant = new Property(transpile, property, linkFormatter, true);
   }
   public render(): Markdown {
     return this.constant.render();

--- a/src/docgen/view/property.ts
+++ b/src/docgen/view/property.ts
@@ -8,6 +8,7 @@ export class Property {
     private readonly transpile: Transpile,
     private readonly property: reflect.Property,
     private readonly linkFormatter: (type: TranspiledType) => string,
+    private readonly isConstant: boolean = false,
   ) {
     this.transpiled = transpile.property(property);
   }
@@ -38,7 +39,9 @@ export class Property {
       md.lines('');
     }
 
-    md.code(this.transpile.language.toString(), this.transpiled.signatureOrGetter);
+    if (!this.isConstant) {
+      md.code(this.transpile.language.toString(), this.transpiled.declaration);
+    }
 
     const metadata: any = {
       Type: this.transpiled.typeReference.toString({

--- a/src/docgen/view/property.ts
+++ b/src/docgen/view/property.ts
@@ -5,7 +5,7 @@ import { Transpile, TranspiledProperty, TranspiledType } from '../transpile/tran
 export class Property {
   private readonly transpiled: TranspiledProperty;
   constructor(
-    transpile: Transpile,
+    private readonly transpile: Transpile,
     private readonly property: reflect.Property,
     private readonly linkFormatter: (type: TranspiledType) => string,
   ) {
@@ -37,6 +37,8 @@ export class Property {
       );
       md.lines('');
     }
+
+    md.code(this.transpile.language.toString(), this.transpiled.signatureOrGetter);
 
     const metadata: any = {
       Type: this.transpiled.typeReference.toString({

--- a/src/docgen/view/property.ts
+++ b/src/docgen/view/property.ts
@@ -8,7 +8,6 @@ export class Property {
     private readonly transpile: Transpile,
     private readonly property: reflect.Property,
     private readonly linkFormatter: (type: TranspiledType) => string,
-    private readonly isConstant: boolean = false,
   ) {
     this.transpiled = transpile.property(property);
   }
@@ -39,7 +38,7 @@ export class Property {
       md.lines('');
     }
 
-    if (!this.isConstant) {
+    if (!this.property.const) {
       md.code(this.transpile.language.toString(), this.transpiled.declaration);
     }
 

--- a/test/docgen/view/__snapshots__/documentation.test.ts.snap
+++ b/test/docgen/view/__snapshots__/documentation.test.ts.snap
@@ -222,11 +222,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.attr_arn\\"></a>
 
+\`\`\`python
+attr_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.tags\\"></a>
+
+\`\`\`python
+tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.TagManager\`](#custom-aws_cdk.core.TagManager)
 
@@ -238,6 +246,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repository_catalog_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_catalog_data\\"></a>
 
+\`\`\`python
+repository_catalog_data: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -248,6 +260,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -257,6 +273,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -269,6 +289,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -345,11 +369,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.attr_registry_id\\"></a>
 
+\`\`\`python
+attr_registry_id: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.policy_text\\"></a>
+
+\`\`\`python
+policy_text: typing.Any
+\`\`\`
 
 - *Type:* \`typing.Any\`
 
@@ -362,6 +394,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -438,11 +474,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.attr_registry_id\\"></a>
 
+\`\`\`python
+attr_registry_id: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.replication_configuration\\"></a>
+
+\`\`\`python
+replication_configuration: typing.Union[IResolvable, ReplicationConfigurationProperty]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#custom-aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -455,6 +499,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -597,17 +645,29 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.attr_arn\\"></a>
 
+\`\`\`python
+attr_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`attr_repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.attr_repository_uri\\"></a>
 
+\`\`\`python
+attr_repository_uri: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.tags\\"></a>
+
+\`\`\`python
+tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.TagManager\`](#custom-aws_cdk.core.TagManager)
 
@@ -619,6 +679,10 @@ tree inspector to collect and process attributes.
 
 ##### \`encryption_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.encryption_configuration\\"></a>
 
+\`\`\`python
+encryption_configuration: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -628,6 +692,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`image_scanning_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.image_scanning_configuration\\"></a>
+
+\`\`\`python
+image_scanning_configuration: typing.Any
+\`\`\`
 
 - *Type:* \`typing.Any\`
 
@@ -639,6 +707,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -648,6 +720,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.image_tag_mutability\\"></a>
+
+\`\`\`python
+image_tag_mutability: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -659,6 +735,10 @@ tree inspector to collect and process attributes.
 
 ##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.lifecycle_policy\\"></a>
 
+\`\`\`python
+lifecycle_policy: typing.Union[IResolvable, LifecyclePolicyProperty]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#custom-aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
 \`AWS::ECR::Repository.LifecyclePolicy\`.
@@ -668,6 +748,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -680,6 +764,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -1009,6 +1097,10 @@ aws_cdk.aws_ecr.Repository.from_repository_name(
 
 ##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.property.repository_arn\\"></a>
 
+\`\`\`python
+repository_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The ARN of the repository.
@@ -1016,6 +1108,10 @@ The ARN of the repository.
 ---
 
 ##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -1476,6 +1572,10 @@ Optional image tag.
 
 ##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_arn\\"></a>
 
+\`\`\`python
+repository_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The ARN of the repository.
@@ -1484,6 +1584,10 @@ The ARN of the repository.
 
 ##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_name\\"></a>
 
+\`\`\`python
+repository_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The name of the repository.
@@ -1491,6 +1595,10 @@ The name of the repository.
 ---
 
 ##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_uri\\"></a>
+
+\`\`\`python
+repository_uri: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -1524,6 +1632,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 
 ##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_catalog_data\\"></a>
 
+\`\`\`python
+repository_catalog_data: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -1533,6 +1645,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 ---
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -1544,6 +1660,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 
 ##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -1553,6 +1673,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.tags\\"></a>
+
+\`\`\`python
+tags: typing.List[CfnTag]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#custom-aws_cdk.core.CfnTag)]
 
@@ -1580,6 +1704,10 @@ aws_cdk.aws_ecr.CfnRegistryPolicyProps(
 
 ##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.property.policy_text\\"></a>
 
+\`\`\`python
+policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::RegistryPolicy.PolicyText\`.
@@ -1605,6 +1733,10 @@ aws_cdk.aws_ecr.CfnReplicationConfigurationProps(
 \`\`\`
 
 ##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.property.replication_configuration\\"></a>
+
+\`\`\`python
+replication_configuration: typing.Union[IResolvable, ReplicationConfigurationProperty]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#custom-aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -1638,6 +1770,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 
 ##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.encryption_configuration\\"></a>
 
+\`\`\`python
+encryption_configuration: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -1647,6 +1783,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 ---
 
 ##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.image_scanning_configuration\\"></a>
+
+\`\`\`python
+image_scanning_configuration: typing.Any
+\`\`\`
 
 - *Type:* \`typing.Any\`
 
@@ -1658,6 +1798,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 
 ##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.image_tag_mutability\\"></a>
 
+\`\`\`python
+image_tag_mutability: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::ECR::Repository.ImageTagMutability\`.
@@ -1667,6 +1811,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 ---
 
 ##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.lifecycle_policy\\"></a>
+
+\`\`\`python
+lifecycle_policy: typing.Union[IResolvable, LifecyclePolicyProperty]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#custom-aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
@@ -1678,6 +1826,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.repository_name\\"></a>
 
+\`\`\`python
+repository_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::ECR::Repository.RepositoryName\`.
@@ -1688,6 +1840,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 
 ##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -1697,6 +1853,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.tags\\"></a>
+
+\`\`\`python
+tags: typing.List[CfnTag]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#custom-aws_cdk.core.CfnTag)]
 
@@ -1723,6 +1883,10 @@ aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty(
 
 ##### \`lifecycle_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.property.lifecycle_policy_text\\"></a>
 
+\`\`\`python
+lifecycle_policy_text: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnRepository.LifecyclePolicyProperty.LifecyclePolicyText\`.
@@ -1732,6 +1896,10 @@ aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty(
 ---
 
 ##### \`registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.property.registry_id\\"></a>
+
+\`\`\`python
+registry_id: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -1762,6 +1930,10 @@ aws_cdk.aws_ecr.LifecycleRule(
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.description\\"></a>
 
+\`\`\`python
+description: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* No description
 
@@ -1770,6 +1942,10 @@ Describes the purpose of the rule.
 ---
 
 ##### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.max_image_age\\"></a>
+
+\`\`\`python
+max_image_age: Duration
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.Duration\`](#custom-aws_cdk.core.Duration)
 
@@ -1781,6 +1957,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ##### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.max_image_count\\"></a>
 
+\`\`\`python
+max_image_count: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 
 The maximum number of images to retain.
@@ -1790,6 +1970,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 ---
 
 ##### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.rule_priority\\"></a>
+
+\`\`\`python
+rule_priority: typing.Union[int, float]
+\`\`\`
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* Automatically assigned
@@ -1809,6 +1993,10 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ##### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.tag_prefix_list\\"></a>
 
+\`\`\`python
+tag_prefix_list: typing.List[str]
+\`\`\`
+
 - *Type:* typing.List[\`str\`]
 
 Select images that have ALL the given prefixes in their tag.
@@ -1818,6 +2006,10 @@ Only if tagStatus == TagStatus.Tagged
 ---
 
 ##### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.tag_status\\"></a>
+
+\`\`\`python
+tag_status: TagStatus
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ecr.TagStatus\`](#custom-aws_cdk.aws_ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -1849,6 +2041,10 @@ aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions(
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
+\`\`\`python
+description: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* No description
 
@@ -1857,6 +2053,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.event_pattern\\"></a>
+
+\`\`\`python
+event_pattern: EventPattern
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#custom-aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -1873,6 +2073,10 @@ on top of that filtering.
 
 ##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.rule_name\\"></a>
 
+\`\`\`python
+rule_name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -1882,6 +2086,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
+\`\`\`python
+target: IRuleTarget
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#custom-aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -1890,6 +2098,10 @@ The target to register for the event.
 ---
 
 ##### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.image_tag\\"></a>
+
+\`\`\`python
+image_tag: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -1918,6 +2130,10 @@ aws_cdk.aws_ecr.OnImageScanCompletedOptions(
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
+\`\`\`python
+description: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* No description
 
@@ -1926,6 +2142,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.event_pattern\\"></a>
+
+\`\`\`python
+event_pattern: EventPattern
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#custom-aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -1942,6 +2162,10 @@ on top of that filtering.
 
 ##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.rule_name\\"></a>
 
+\`\`\`python
+rule_name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -1951,6 +2175,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
+\`\`\`python
+target: IRuleTarget
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#custom-aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -1959,6 +2187,10 @@ The target to register for the event.
 ---
 
 ##### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.image_tags\\"></a>
+
+\`\`\`python
+image_tags: typing.List[str]
+\`\`\`
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -1985,6 +2217,10 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty(
 
 ##### \`rules\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
+\`\`\`python
+rules: typing.Union[IResolvable, typing.List[typing.Union[IResolvable, ReplicationRuleProperty]]]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), typing.List[typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#custom-aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty)]]]
 
 \`CfnReplicationConfiguration.ReplicationConfigurationProperty.Rules\`.
@@ -2010,6 +2246,10 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty(
 
 ##### \`region\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
+\`\`\`python
+region: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnReplicationConfiguration.ReplicationDestinationProperty.Region\`.
@@ -2019,6 +2259,10 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty(
 ---
 
 ##### \`registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registry_id\\"></a>
+
+\`\`\`python
+registry_id: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -2044,6 +2288,10 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty(
 
 ##### \`destinations\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
+\`\`\`python
+destinations: typing.Union[IResolvable, typing.List[typing.Union[IResolvable, ReplicationDestinationProperty]]]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), typing.List[typing.Union[[\`aws_cdk.core.IResolvable\`](#custom-aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#custom-aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)]]]
 
 \`CfnReplicationConfiguration.ReplicationRuleProperty.Destinations\`.
@@ -2067,11 +2315,19 @@ aws_cdk.aws_ecr.RepositoryAttributes(
 
 ##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.property.repository_arn\\"></a>
 
+\`\`\`python
+repository_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -2096,6 +2352,10 @@ aws_cdk.aws_ecr.RepositoryProps(
 
 ##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.image_scan_on_push\\"></a>
 
+\`\`\`python
+image_scan_on_push: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -2104,6 +2364,10 @@ Enable the scan on push when creating the repository.
 ---
 
 ##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.image_tag_mutability\\"></a>
+
+\`\`\`python
+image_tag_mutability: TagMutability
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ecr.TagMutability\`](#custom-aws_cdk.aws_ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -2116,6 +2380,10 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.lifecycle_registry_id\\"></a>
 
+\`\`\`python
+lifecycle_registry_id: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* The default registry is assumed.
 
@@ -2127,6 +2395,10 @@ The AWS account ID associated with the registry that contains the repository.
 
 ##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.lifecycle_rules\\"></a>
 
+\`\`\`python
+lifecycle_rules: typing.List[LifecycleRule]
+\`\`\`
+
 - *Type:* typing.List[[\`aws_cdk.aws_ecr.LifecycleRule\`](#custom-aws_cdk.aws_ecr.LifecycleRule)]
 - *Default:* No life cycle rules
 
@@ -2136,6 +2408,10 @@ Life cycle rules to apply to this registry.
 
 ##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.removal_policy\\"></a>
 
+\`\`\`python
+removal_policy: RemovalPolicy
+\`\`\`
+
 - *Type:* [\`aws_cdk.core.RemovalPolicy\`](#custom-aws_cdk.core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
 
@@ -2144,6 +2420,10 @@ Determine what happens to the repository when the resource/stack is deleted.
 ---
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name.
@@ -2587,6 +2867,10 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 ##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.node\\"></a>
 
+\`\`\`python
+node: ConstructNode
+\`\`\`
+
 - *Type:* [\`aws_cdk.core.ConstructNode\`](#custom-aws_cdk.core.ConstructNode)
 
 The construct tree node for this construct.
@@ -2594,6 +2878,10 @@ The construct tree node for this construct.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.env\\"></a>
+
+\`\`\`python
+env: ResourceEnvironment
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.ResourceEnvironment\`](#custom-aws_cdk.core.ResourceEnvironment)
 
@@ -2610,6 +2898,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.stack\\"></a>
 
+\`\`\`python
+stack: Stack
+\`\`\`
+
 - *Type:* [\`aws_cdk.core.Stack\`](#custom-aws_cdk.core.Stack)
 
 The stack in which this resource is defined.
@@ -2617,6 +2909,10 @@ The stack in which this resource is defined.
 ---
 
 ##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_arn\\"></a>
+
+\`\`\`python
+repository_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -2626,6 +2922,10 @@ The ARN of the repository.
 
 ##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_name\\"></a>
 
+\`\`\`python
+repository_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The name of the repository.
@@ -2633,6 +2933,10 @@ The name of the repository.
 ---
 
 ##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_uri\\"></a>
+
+\`\`\`python
+repository_uri: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -2907,11 +3211,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.attrArn\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.tags\\"></a>
+
+\`\`\`java
+public TagManager getTags()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.TagManager\`](#software.amazon.awscdk.core.TagManager)
 
@@ -2923,6 +3235,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repositoryCatalogData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.repositoryCatalogData\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryCatalogData()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -2933,6 +3249,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.repositoryPolicyText\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryPolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -2942,6 +3262,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -2954,6 +3278,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`java
+public java.lang.String getCfnResourceTypeName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3026,11 +3354,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicy.property.attrRegistryId\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrRegistryId()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`policyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicy.property.policyText\\"></a>
+
+\`\`\`java
+public java.lang.Object getPolicyText()
+\`\`\`
 
 - *Type:* \`java.lang.Object\`
 
@@ -3043,6 +3379,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`java
+public java.lang.String getCfnResourceTypeName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3116,11 +3456,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.property.attrRegistryId\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrRegistryId()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.property.replicationConfiguration\\"></a>
+
+\`\`\`java
+public java.lang.Object getReplicationConfiguration()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
 
@@ -3133,6 +3481,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`java
+public java.lang.String getCfnResourceTypeName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3272,17 +3624,29 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.attrArn\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`attrRepositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.attrRepositoryUri\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrRepositoryUri()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.tags\\"></a>
+
+\`\`\`java
+public TagManager getTags()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.TagManager\`](#software.amazon.awscdk.core.TagManager)
 
@@ -3294,6 +3658,10 @@ tree inspector to collect and process attributes.
 
 ##### \`encryptionConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.encryptionConfiguration\\"></a>
 
+\`\`\`java
+public java.lang.Object getEncryptionConfiguration()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -3303,6 +3671,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`imageScanningConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.imageScanningConfiguration\\"></a>
+
+\`\`\`java
+public java.lang.Object getImageScanningConfiguration()
+\`\`\`
 
 - *Type:* \`java.lang.Object\`
 
@@ -3314,6 +3686,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.repositoryPolicyText\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryPolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -3323,6 +3699,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.imageTagMutability\\"></a>
+
+\`\`\`java
+public java.lang.String getImageTagMutability()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3334,6 +3714,10 @@ tree inspector to collect and process attributes.
 
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.lifecyclePolicy\\"></a>
 
+\`\`\`java
+public java.lang.Object getLifecyclePolicy()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty\`](#software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty)
 
 \`AWS::ECR::Repository.LifecyclePolicy\`.
@@ -3343,6 +3727,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3355,6 +3743,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`java
+public java.lang.String getCfnResourceTypeName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3588,6 +3980,10 @@ Repository.fromRepositoryName(Construct scope, java.lang.String id, java.lang.St
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.Repository.property.repositoryArn\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The ARN of the repository.
@@ -3595,6 +3991,10 @@ The ARN of the repository.
 ---
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.Repository.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3862,6 +4262,10 @@ Optional image tag.
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryBase.property.repositoryArn\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The ARN of the repository.
@@ -3870,6 +4274,10 @@ The ARN of the repository.
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryBase.property.repositoryName\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The name of the repository.
@@ -3877,6 +4285,10 @@ The name of the repository.
 ---
 
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryBase.property.repositoryUri\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryUri()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3910,6 +4322,10 @@ CfnPublicRepositoryProps.builder()
 
 ##### \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryCatalogData()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -3919,6 +4335,10 @@ CfnPublicRepositoryProps.builder()
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3930,6 +4350,10 @@ CfnPublicRepositoryProps.builder()
 
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryPolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -3939,6 +4363,10 @@ CfnPublicRepositoryProps.builder()
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.tags\\"></a>
+
+\`\`\`java
+public java.util.List<CfnTag> getTags()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
 
@@ -3966,6 +4394,10 @@ CfnRegistryPolicyProps.builder()
 
 ##### \`policyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicyProps.property.policyText\\"></a>
 
+\`\`\`java
+public java.lang.Object getPolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::RegistryPolicy.PolicyText\`.
@@ -3992,6 +4424,10 @@ CfnReplicationConfigurationProps.builder()
 \`\`\`
 
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfigurationProps.property.replicationConfiguration\\"></a>
+
+\`\`\`java
+public java.lang.Object getReplicationConfiguration()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
 
@@ -4026,6 +4462,10 @@ CfnRepositoryProps.builder()
 
 ##### \`encryptionConfiguration\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.encryptionConfiguration\\"></a>
 
+\`\`\`java
+public java.lang.Object getEncryptionConfiguration()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -4035,6 +4475,10 @@ CfnRepositoryProps.builder()
 ---
 
 ##### \`imageScanningConfiguration\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.imageScanningConfiguration\\"></a>
+
+\`\`\`java
+public java.lang.Object getImageScanningConfiguration()
+\`\`\`
 
 - *Type:* \`java.lang.Object\`
 
@@ -4046,6 +4490,10 @@ CfnRepositoryProps.builder()
 
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.imageTagMutability\\"></a>
 
+\`\`\`java
+public java.lang.String getImageTagMutability()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::ECR::Repository.ImageTagMutability\`.
@@ -4055,6 +4503,10 @@ CfnRepositoryProps.builder()
 ---
 
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.lifecyclePolicy\\"></a>
+
+\`\`\`java
+public java.lang.Object getLifecyclePolicy()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty\`](#software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty)
 
@@ -4066,6 +4518,10 @@ CfnRepositoryProps.builder()
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.repositoryName\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::ECR::Repository.RepositoryName\`.
@@ -4076,6 +4532,10 @@ CfnRepositoryProps.builder()
 
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.repositoryPolicyText\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryPolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -4085,6 +4545,10 @@ CfnRepositoryProps.builder()
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.tags\\"></a>
+
+\`\`\`java
+public java.util.List<CfnTag> getTags()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
 
@@ -4111,6 +4575,10 @@ LifecyclePolicyProperty.builder()
 
 ##### \`lifecyclePolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty.property.lifecyclePolicyText\\"></a>
 
+\`\`\`java
+public java.lang.String getLifecyclePolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`CfnRepository.LifecyclePolicyProperty.LifecyclePolicyText\`.
@@ -4120,6 +4588,10 @@ LifecyclePolicyProperty.builder()
 ---
 
 ##### \`registryId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty.property.registryId\\"></a>
+
+\`\`\`java
+public java.lang.String getRegistryId()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -4150,6 +4622,10 @@ LifecycleRule.builder()
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.description\\"></a>
 
+\`\`\`java
+public java.lang.String getDescription()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* No description
 
@@ -4158,6 +4634,10 @@ Describes the purpose of the rule.
 ---
 
 ##### \`maxImageAge\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.maxImageAge\\"></a>
+
+\`\`\`java
+public Duration getMaxImageAge()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
 
@@ -4169,6 +4649,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ##### \`maxImageCount\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.maxImageCount\\"></a>
 
+\`\`\`java
+public java.lang.Number getMaxImageCount()
+\`\`\`
+
 - *Type:* \`java.lang.Number\`
 
 The maximum number of images to retain.
@@ -4178,6 +4662,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 ---
 
 ##### \`rulePriority\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.rulePriority\\"></a>
+
+\`\`\`java
+public java.lang.Number getRulePriority()
+\`\`\`
 
 - *Type:* \`java.lang.Number\`
 - *Default:* Automatically assigned
@@ -4197,6 +4685,10 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ##### \`tagPrefixList\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.tagPrefixList\\"></a>
 
+\`\`\`java
+public java.util.List<java.lang.String> getTagPrefixList()
+\`\`\`
+
 - *Type:* java.util.List<\`java.lang.String\`>
 
 Select images that have ALL the given prefixes in their tag.
@@ -4206,6 +4698,10 @@ Only if tagStatus == TagStatus.Tagged
 ---
 
 ##### \`tagStatus\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.tagStatus\\"></a>
+
+\`\`\`java
+public TagStatus getTagStatus()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ecr.TagStatus\`](#software.amazon.awscdk.services.ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -4237,6 +4733,10 @@ OnCloudTrailImagePushedOptions.builder()
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
+\`\`\`java
+public java.lang.String getDescription()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* No description
 
@@ -4245,6 +4745,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.eventPattern\\"></a>
+
+\`\`\`java
+public EventPattern getEventPattern()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.events.EventPattern\`](#software.amazon.awscdk.services.events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -4261,6 +4765,10 @@ on top of that filtering.
 
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.ruleName\\"></a>
 
+\`\`\`java
+public java.lang.String getRuleName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -4270,6 +4778,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
+\`\`\`java
+public IRuleTarget getTarget()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.events.IRuleTarget\`](#software.amazon.awscdk.services.events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -4278,6 +4790,10 @@ The target to register for the event.
 ---
 
 ##### \`imageTag\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.imageTag\\"></a>
+
+\`\`\`java
+public java.lang.String getImageTag()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* Watch changes to all tags
@@ -4306,6 +4822,10 @@ OnImageScanCompletedOptions.builder()
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
+\`\`\`java
+public java.lang.String getDescription()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* No description
 
@@ -4314,6 +4834,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.eventPattern\\"></a>
+
+\`\`\`java
+public EventPattern getEventPattern()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.events.EventPattern\`](#software.amazon.awscdk.services.events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -4330,6 +4854,10 @@ on top of that filtering.
 
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.ruleName\\"></a>
 
+\`\`\`java
+public java.lang.String getRuleName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -4339,6 +4867,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
+\`\`\`java
+public IRuleTarget getTarget()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.events.IRuleTarget\`](#software.amazon.awscdk.services.events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -4347,6 +4879,10 @@ The target to register for the event.
 ---
 
 ##### \`imageTags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.imageTags\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getImageTags()
+\`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
 - *Default:* Watch the changes to the repository with all image tags
@@ -4375,6 +4911,10 @@ ReplicationConfigurationProperty.builder()
 
 ##### \`rules\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
+\`\`\`java
+public java.lang.Object getRules()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationRuleProperty)>
 
 \`CfnReplicationConfiguration.ReplicationConfigurationProperty.Rules\`.
@@ -4400,6 +4940,10 @@ ReplicationDestinationProperty.builder()
 
 ##### \`region\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
+\`\`\`java
+public java.lang.String getRegion()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`CfnReplicationConfiguration.ReplicationDestinationProperty.Region\`.
@@ -4409,6 +4953,10 @@ ReplicationDestinationProperty.builder()
 ---
 
 ##### \`registryId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registryId\\"></a>
+
+\`\`\`java
+public java.lang.String getRegistryId()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -4436,6 +4984,10 @@ ReplicationRuleProperty.builder()
 
 ##### \`destinations\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
+\`\`\`java
+public java.lang.Object getDestinations()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)>
 
 \`CfnReplicationConfiguration.ReplicationRuleProperty.Destinations\`.
@@ -4459,11 +5011,19 @@ RepositoryAttributes.builder()
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryAttributes.property.repositoryArn\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryAttributes.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -4488,6 +5048,10 @@ RepositoryProps.builder()
 
 ##### \`imageScanOnPush\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.imageScanOnPush\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getImageScanOnPush()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -4496,6 +5060,10 @@ Enable the scan on push when creating the repository.
 ---
 
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.imageTagMutability\\"></a>
+
+\`\`\`java
+public TagMutability getImageTagMutability()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ecr.TagMutability\`](#software.amazon.awscdk.services.ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -4508,6 +5076,10 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ##### \`lifecycleRegistryId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.lifecycleRegistryId\\"></a>
 
+\`\`\`java
+public java.lang.String getLifecycleRegistryId()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* The default registry is assumed.
 
@@ -4519,6 +5091,10 @@ The AWS account ID associated with the registry that contains the repository.
 
 ##### \`lifecycleRules\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.lifecycleRules\\"></a>
 
+\`\`\`java
+public java.util.List<LifecycleRule> getLifecycleRules()
+\`\`\`
+
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ecr.LifecycleRule\`](#software.amazon.awscdk.services.ecr.LifecycleRule)>
 - *Default:* No life cycle rules
 
@@ -4528,6 +5104,10 @@ Life cycle rules to apply to this registry.
 
 ##### \`removalPolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.removalPolicy\\"></a>
 
+\`\`\`java
+public RemovalPolicy getRemovalPolicy()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.RemovalPolicy\`](#software.amazon.awscdk.core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
 
@@ -4536,6 +5116,10 @@ Determine what happens to the repository when the resource/stack is deleted.
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* Automatically generated name.
@@ -4784,6 +5368,10 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 ##### \`node\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.node\\"></a>
 
+\`\`\`java
+public ConstructNode getNode()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.ConstructNode\`](#software.amazon.awscdk.core.ConstructNode)
 
 The construct tree node for this construct.
@@ -4791,6 +5379,10 @@ The construct tree node for this construct.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.env\\"></a>
+
+\`\`\`java
+public ResourceEnvironment getEnv()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.ResourceEnvironment\`](#software.amazon.awscdk.core.ResourceEnvironment)
 
@@ -4807,6 +5399,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.stack\\"></a>
 
+\`\`\`java
+public Stack getStack()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.Stack\`](#software.amazon.awscdk.core.Stack)
 
 The stack in which this resource is defined.
@@ -4814,6 +5410,10 @@ The stack in which this resource is defined.
 ---
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryArn\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryArn()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -4823,6 +5423,10 @@ The ARN of the repository.
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryName\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The name of the repository.
@@ -4830,6 +5434,10 @@ The name of the repository.
 ---
 
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryUri\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryUri()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -5104,11 +5712,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.attrArn\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.tags\\"></a>
+
+\`\`\`java
+public TagManager getTags()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.TagManager\`](#software.amazon.awscdk.core.TagManager)
 
@@ -5120,6 +5736,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repositoryCatalogData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.repositoryCatalogData\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryCatalogData()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -5130,6 +5750,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.repositoryPolicyText\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryPolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -5139,6 +5763,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -5151,6 +5779,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`java
+public java.lang.String getCfnResourceTypeName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -5223,11 +5855,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicy.property.attrRegistryId\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrRegistryId()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`policyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicy.property.policyText\\"></a>
+
+\`\`\`java
+public java.lang.Object getPolicyText()
+\`\`\`
 
 - *Type:* \`java.lang.Object\`
 
@@ -5240,6 +5880,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`java
+public java.lang.String getCfnResourceTypeName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -5313,11 +5957,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.property.attrRegistryId\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrRegistryId()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.property.replicationConfiguration\\"></a>
+
+\`\`\`java
+public java.lang.Object getReplicationConfiguration()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
 
@@ -5330,6 +5982,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`java
+public java.lang.String getCfnResourceTypeName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -5469,17 +6125,29 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.attrArn\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`attrRepositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.attrRepositoryUri\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrRepositoryUri()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.tags\\"></a>
+
+\`\`\`java
+public TagManager getTags()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.TagManager\`](#software.amazon.awscdk.core.TagManager)
 
@@ -5491,6 +6159,10 @@ tree inspector to collect and process attributes.
 
 ##### \`encryptionConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.encryptionConfiguration\\"></a>
 
+\`\`\`java
+public java.lang.Object getEncryptionConfiguration()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -5500,6 +6172,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`imageScanningConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.imageScanningConfiguration\\"></a>
+
+\`\`\`java
+public java.lang.Object getImageScanningConfiguration()
+\`\`\`
 
 - *Type:* \`java.lang.Object\`
 
@@ -5511,6 +6187,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.repositoryPolicyText\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryPolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -5520,6 +6200,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.imageTagMutability\\"></a>
+
+\`\`\`java
+public java.lang.String getImageTagMutability()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -5531,6 +6215,10 @@ tree inspector to collect and process attributes.
 
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.lifecyclePolicy\\"></a>
 
+\`\`\`java
+public java.lang.Object getLifecyclePolicy()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty\`](#software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty)
 
 \`AWS::ECR::Repository.LifecyclePolicy\`.
@@ -5540,6 +6228,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -5552,6 +6244,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`java
+public java.lang.String getCfnResourceTypeName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -5785,6 +6481,10 @@ Repository.fromRepositoryName(Construct scope, java.lang.String id, java.lang.St
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.Repository.property.repositoryArn\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The ARN of the repository.
@@ -5792,6 +6492,10 @@ The ARN of the repository.
 ---
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.Repository.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -6059,6 +6763,10 @@ Optional image tag.
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryBase.property.repositoryArn\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The ARN of the repository.
@@ -6067,6 +6775,10 @@ The ARN of the repository.
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryBase.property.repositoryName\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The name of the repository.
@@ -6074,6 +6786,10 @@ The name of the repository.
 ---
 
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryBase.property.repositoryUri\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryUri()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -6107,6 +6823,10 @@ CfnPublicRepositoryProps.builder()
 
 ##### \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryCatalogData()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -6116,6 +6836,10 @@ CfnPublicRepositoryProps.builder()
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -6127,6 +6851,10 @@ CfnPublicRepositoryProps.builder()
 
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryPolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -6136,6 +6864,10 @@ CfnPublicRepositoryProps.builder()
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.tags\\"></a>
+
+\`\`\`java
+public java.util.List<CfnTag> getTags()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
 
@@ -6163,6 +6895,10 @@ CfnRegistryPolicyProps.builder()
 
 ##### \`policyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicyProps.property.policyText\\"></a>
 
+\`\`\`java
+public java.lang.Object getPolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::RegistryPolicy.PolicyText\`.
@@ -6189,6 +6925,10 @@ CfnReplicationConfigurationProps.builder()
 \`\`\`
 
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfigurationProps.property.replicationConfiguration\\"></a>
+
+\`\`\`java
+public java.lang.Object getReplicationConfiguration()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
 
@@ -6223,6 +6963,10 @@ CfnRepositoryProps.builder()
 
 ##### \`encryptionConfiguration\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.encryptionConfiguration\\"></a>
 
+\`\`\`java
+public java.lang.Object getEncryptionConfiguration()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -6232,6 +6976,10 @@ CfnRepositoryProps.builder()
 ---
 
 ##### \`imageScanningConfiguration\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.imageScanningConfiguration\\"></a>
+
+\`\`\`java
+public java.lang.Object getImageScanningConfiguration()
+\`\`\`
 
 - *Type:* \`java.lang.Object\`
 
@@ -6243,6 +6991,10 @@ CfnRepositoryProps.builder()
 
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.imageTagMutability\\"></a>
 
+\`\`\`java
+public java.lang.String getImageTagMutability()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::ECR::Repository.ImageTagMutability\`.
@@ -6252,6 +7004,10 @@ CfnRepositoryProps.builder()
 ---
 
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.lifecyclePolicy\\"></a>
+
+\`\`\`java
+public java.lang.Object getLifecyclePolicy()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty\`](#software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty)
 
@@ -6263,6 +7019,10 @@ CfnRepositoryProps.builder()
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.repositoryName\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::ECR::Repository.RepositoryName\`.
@@ -6273,6 +7033,10 @@ CfnRepositoryProps.builder()
 
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.repositoryPolicyText\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryPolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -6282,6 +7046,10 @@ CfnRepositoryProps.builder()
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.tags\\"></a>
+
+\`\`\`java
+public java.util.List<CfnTag> getTags()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
 
@@ -6308,6 +7076,10 @@ LifecyclePolicyProperty.builder()
 
 ##### \`lifecyclePolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty.property.lifecyclePolicyText\\"></a>
 
+\`\`\`java
+public java.lang.String getLifecyclePolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`CfnRepository.LifecyclePolicyProperty.LifecyclePolicyText\`.
@@ -6317,6 +7089,10 @@ LifecyclePolicyProperty.builder()
 ---
 
 ##### \`registryId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty.property.registryId\\"></a>
+
+\`\`\`java
+public java.lang.String getRegistryId()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -6347,6 +7123,10 @@ LifecycleRule.builder()
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.description\\"></a>
 
+\`\`\`java
+public java.lang.String getDescription()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* No description
 
@@ -6355,6 +7135,10 @@ Describes the purpose of the rule.
 ---
 
 ##### \`maxImageAge\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.maxImageAge\\"></a>
+
+\`\`\`java
+public Duration getMaxImageAge()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
 
@@ -6366,6 +7150,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ##### \`maxImageCount\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.maxImageCount\\"></a>
 
+\`\`\`java
+public java.lang.Number getMaxImageCount()
+\`\`\`
+
 - *Type:* \`java.lang.Number\`
 
 The maximum number of images to retain.
@@ -6375,6 +7163,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 ---
 
 ##### \`rulePriority\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.rulePriority\\"></a>
+
+\`\`\`java
+public java.lang.Number getRulePriority()
+\`\`\`
 
 - *Type:* \`java.lang.Number\`
 - *Default:* Automatically assigned
@@ -6394,6 +7186,10 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ##### \`tagPrefixList\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.tagPrefixList\\"></a>
 
+\`\`\`java
+public java.util.List<java.lang.String> getTagPrefixList()
+\`\`\`
+
 - *Type:* java.util.List<\`java.lang.String\`>
 
 Select images that have ALL the given prefixes in their tag.
@@ -6403,6 +7199,10 @@ Only if tagStatus == TagStatus.Tagged
 ---
 
 ##### \`tagStatus\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.tagStatus\\"></a>
+
+\`\`\`java
+public TagStatus getTagStatus()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ecr.TagStatus\`](#software.amazon.awscdk.services.ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -6434,6 +7234,10 @@ OnCloudTrailImagePushedOptions.builder()
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
+\`\`\`java
+public java.lang.String getDescription()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* No description
 
@@ -6442,6 +7246,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.eventPattern\\"></a>
+
+\`\`\`java
+public EventPattern getEventPattern()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.events.EventPattern\`](#software.amazon.awscdk.services.events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -6458,6 +7266,10 @@ on top of that filtering.
 
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.ruleName\\"></a>
 
+\`\`\`java
+public java.lang.String getRuleName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -6467,6 +7279,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
+\`\`\`java
+public IRuleTarget getTarget()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.events.IRuleTarget\`](#software.amazon.awscdk.services.events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -6475,6 +7291,10 @@ The target to register for the event.
 ---
 
 ##### \`imageTag\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.imageTag\\"></a>
+
+\`\`\`java
+public java.lang.String getImageTag()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* Watch changes to all tags
@@ -6503,6 +7323,10 @@ OnImageScanCompletedOptions.builder()
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
+\`\`\`java
+public java.lang.String getDescription()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* No description
 
@@ -6511,6 +7335,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.eventPattern\\"></a>
+
+\`\`\`java
+public EventPattern getEventPattern()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.events.EventPattern\`](#software.amazon.awscdk.services.events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -6527,6 +7355,10 @@ on top of that filtering.
 
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.ruleName\\"></a>
 
+\`\`\`java
+public java.lang.String getRuleName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -6536,6 +7368,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
+\`\`\`java
+public IRuleTarget getTarget()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.events.IRuleTarget\`](#software.amazon.awscdk.services.events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -6544,6 +7380,10 @@ The target to register for the event.
 ---
 
 ##### \`imageTags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.imageTags\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getImageTags()
+\`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
 - *Default:* Watch the changes to the repository with all image tags
@@ -6572,6 +7412,10 @@ ReplicationConfigurationProperty.builder()
 
 ##### \`rules\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
+\`\`\`java
+public java.lang.Object getRules()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationRuleProperty)>
 
 \`CfnReplicationConfiguration.ReplicationConfigurationProperty.Rules\`.
@@ -6597,6 +7441,10 @@ ReplicationDestinationProperty.builder()
 
 ##### \`region\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
+\`\`\`java
+public java.lang.String getRegion()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`CfnReplicationConfiguration.ReplicationDestinationProperty.Region\`.
@@ -6606,6 +7454,10 @@ ReplicationDestinationProperty.builder()
 ---
 
 ##### \`registryId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registryId\\"></a>
+
+\`\`\`java
+public java.lang.String getRegistryId()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -6633,6 +7485,10 @@ ReplicationRuleProperty.builder()
 
 ##### \`destinations\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
+\`\`\`java
+public java.lang.Object getDestinations()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)>
 
 \`CfnReplicationConfiguration.ReplicationRuleProperty.Destinations\`.
@@ -6656,11 +7512,19 @@ RepositoryAttributes.builder()
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryAttributes.property.repositoryArn\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryAttributes.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -6685,6 +7549,10 @@ RepositoryProps.builder()
 
 ##### \`imageScanOnPush\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.imageScanOnPush\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getImageScanOnPush()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -6693,6 +7561,10 @@ Enable the scan on push when creating the repository.
 ---
 
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.imageTagMutability\\"></a>
+
+\`\`\`java
+public TagMutability getImageTagMutability()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ecr.TagMutability\`](#software.amazon.awscdk.services.ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -6705,6 +7577,10 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ##### \`lifecycleRegistryId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.lifecycleRegistryId\\"></a>
 
+\`\`\`java
+public java.lang.String getLifecycleRegistryId()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* The default registry is assumed.
 
@@ -6716,6 +7592,10 @@ The AWS account ID associated with the registry that contains the repository.
 
 ##### \`lifecycleRules\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.lifecycleRules\\"></a>
 
+\`\`\`java
+public java.util.List<LifecycleRule> getLifecycleRules()
+\`\`\`
+
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ecr.LifecycleRule\`](#software.amazon.awscdk.services.ecr.LifecycleRule)>
 - *Default:* No life cycle rules
 
@@ -6725,6 +7605,10 @@ Life cycle rules to apply to this registry.
 
 ##### \`removalPolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.removalPolicy\\"></a>
 
+\`\`\`java
+public RemovalPolicy getRemovalPolicy()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.RemovalPolicy\`](#software.amazon.awscdk.core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
 
@@ -6733,6 +7617,10 @@ Determine what happens to the repository when the resource/stack is deleted.
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* Automatically generated name.
@@ -6981,6 +7869,10 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 ##### \`node\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.node\\"></a>
 
+\`\`\`java
+public ConstructNode getNode()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.ConstructNode\`](#software.amazon.awscdk.core.ConstructNode)
 
 The construct tree node for this construct.
@@ -6988,6 +7880,10 @@ The construct tree node for this construct.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.env\\"></a>
+
+\`\`\`java
+public ResourceEnvironment getEnv()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.ResourceEnvironment\`](#software.amazon.awscdk.core.ResourceEnvironment)
 
@@ -7004,6 +7900,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.stack\\"></a>
 
+\`\`\`java
+public Stack getStack()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.Stack\`](#software.amazon.awscdk.core.Stack)
 
 The stack in which this resource is defined.
@@ -7011,6 +7911,10 @@ The stack in which this resource is defined.
 ---
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryArn\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryArn()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -7020,6 +7924,10 @@ The ARN of the repository.
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryName\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The name of the repository.
@@ -7027,6 +7935,10 @@ The name of the repository.
 ---
 
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryUri\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryUri()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -8543,11 +9455,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.attrArn\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.tags\\"></a>
+
+\`\`\`java
+public TagManager getTags()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.TagManager\`](#software.amazon.awscdk.TagManager)
 
@@ -8559,6 +9479,10 @@ tree inspector to collect and process attributes.
 
 ##### \`addonName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.addonName\\"></a>
 
+\`\`\`java
+public java.lang.String getAddonName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Addon.AddonName\`.
@@ -8568,6 +9492,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -8579,6 +9507,10 @@ tree inspector to collect and process attributes.
 
 ##### \`addonVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.addonVersion\\"></a>
 
+\`\`\`java
+public java.lang.String getAddonVersion()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Addon.AddonVersion\`.
@@ -8589,6 +9521,10 @@ tree inspector to collect and process attributes.
 
 ##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.resolveConflicts\\"></a>
 
+\`\`\`java
+public java.lang.String getResolveConflicts()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Addon.ResolveConflicts\`.
@@ -8598,6 +9534,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.serviceAccountRoleArn\\"></a>
+
+\`\`\`java
+public java.lang.String getServiceAccountRoleArn()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -8610,6 +9550,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`java
+public java.lang.String getCfnResourceTypeName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -8741,11 +9685,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrArn\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`attrCertificateAuthorityData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrCertificateAuthorityData\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrCertificateAuthorityData()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -8753,11 +9705,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrClusterSecurityGroupId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrClusterSecurityGroupId\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrClusterSecurityGroupId()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`attrEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrEncryptionConfigKeyArn\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrEncryptionConfigKeyArn()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -8765,17 +9725,29 @@ tree inspector to collect and process attributes.
 
 ##### \`attrEndpoint\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrEndpoint\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrEndpoint()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`attrOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrOpenIdConnectIssuerUrl\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrOpenIdConnectIssuerUrl()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.resourcesVpcConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getResourcesVpcConfig()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
@@ -8787,6 +9759,10 @@ tree inspector to collect and process attributes.
 
 ##### \`roleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.roleArn\\"></a>
 
+\`\`\`java
+public java.lang.String getRoleArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Cluster.RoleArn\`.
@@ -8796,6 +9772,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.encryptionConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getEncryptionConfig()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
 
@@ -8807,6 +9787,10 @@ tree inspector to collect and process attributes.
 
 ##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.kubernetesNetworkConfig\\"></a>
 
+\`\`\`java
+public java.lang.Object getKubernetesNetworkConfig()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
 \`AWS::EKS::Cluster.KubernetesNetworkConfig\`.
@@ -8817,6 +9801,10 @@ tree inspector to collect and process attributes.
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.name\\"></a>
 
+\`\`\`java
+public java.lang.String getName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Cluster.Name\`.
@@ -8826,6 +9814,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -8838,6 +9830,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`java
+public java.lang.String getCfnResourceTypeName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -8967,11 +9963,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.attrArn\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.tags\\"></a>
+
+\`\`\`java
+public TagManager getTags()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.TagManager\`](#software.amazon.awscdk.TagManager)
 
@@ -8983,6 +9987,10 @@ tree inspector to collect and process attributes.
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.clusterName\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::FargateProfile.ClusterName\`.
@@ -8992,6 +10000,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.podExecutionRoleArn\\"></a>
+
+\`\`\`java
+public java.lang.String getPodExecutionRoleArn()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -9003,6 +10015,10 @@ tree inspector to collect and process attributes.
 
 ##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.selectors\\"></a>
 
+\`\`\`java
+public java.lang.Object getSelectors()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty\`](#software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
 
 \`AWS::EKS::FargateProfile.Selectors\`.
@@ -9013,6 +10029,10 @@ tree inspector to collect and process attributes.
 
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.fargateProfileName\\"></a>
 
+\`\`\`java
+public java.lang.String getFargateProfileName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::FargateProfile.FargateProfileName\`.
@@ -9022,6 +10042,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.subnets\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getSubnets()
+\`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
 
@@ -9034,6 +10058,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`java
+public java.lang.String getCfnResourceTypeName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -9288,11 +10316,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.attrArn\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`attrClusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.attrClusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrClusterName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -9300,11 +10336,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrNodegroupName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.attrNodegroupName\\"></a>
 
+\`\`\`java
+public java.lang.String getAttrNodegroupName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.tags\\"></a>
+
+\`\`\`java
+public TagManager getTags()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.TagManager\`](#software.amazon.awscdk.TagManager)
 
@@ -9316,6 +10360,10 @@ tree inspector to collect and process attributes.
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.clusterName\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Nodegroup.ClusterName\`.
@@ -9325,6 +10373,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`labels\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.labels\\"></a>
+
+\`\`\`java
+public java.lang.Object getLabels()
+\`\`\`
 
 - *Type:* \`java.lang.Object\`
 
@@ -9336,6 +10388,10 @@ tree inspector to collect and process attributes.
 
 ##### \`nodeRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.nodeRole\\"></a>
 
+\`\`\`java
+public java.lang.String getNodeRole()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Nodegroup.NodeRole\`.
@@ -9345,6 +10401,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`subnets\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.subnets\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getSubnets()
+\`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
 
@@ -9356,6 +10416,10 @@ tree inspector to collect and process attributes.
 
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.amiType\\"></a>
 
+\`\`\`java
+public java.lang.String getAmiType()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Nodegroup.AmiType\`.
@@ -9365,6 +10429,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.capacityType\\"></a>
+
+\`\`\`java
+public java.lang.String getCapacityType()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -9376,6 +10444,10 @@ tree inspector to collect and process attributes.
 
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.diskSize\\"></a>
 
+\`\`\`java
+public java.lang.Number getDiskSize()
+\`\`\`
+
 - *Type:* \`java.lang.Number\`
 
 \`AWS::EKS::Nodegroup.DiskSize\`.
@@ -9385,6 +10457,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.forceUpdateEnabled\\"></a>
+
+\`\`\`java
+public java.lang.Object getForceUpdateEnabled()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\` OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
@@ -9396,6 +10472,10 @@ tree inspector to collect and process attributes.
 
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.instanceTypes\\"></a>
 
+\`\`\`java
+public java.util.List<java.lang.String> getInstanceTypes()
+\`\`\`
+
 - *Type:* java.util.List<\`java.lang.String\`>
 
 \`AWS::EKS::Nodegroup.InstanceTypes\`.
@@ -9405,6 +10485,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.launchTemplate\\"></a>
+
+\`\`\`java
+public java.lang.Object getLaunchTemplate()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
@@ -9416,6 +10500,10 @@ tree inspector to collect and process attributes.
 
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.nodegroupName\\"></a>
 
+\`\`\`java
+public java.lang.String getNodegroupName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Nodegroup.NodegroupName\`.
@@ -9425,6 +10513,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.releaseVersion\\"></a>
+
+\`\`\`java
+public java.lang.String getReleaseVersion()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -9436,6 +10528,10 @@ tree inspector to collect and process attributes.
 
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.remoteAccess\\"></a>
 
+\`\`\`java
+public java.lang.Object getRemoteAccess()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
 \`AWS::EKS::Nodegroup.RemoteAccess\`.
@@ -9445,6 +10541,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.scalingConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getScalingConfig()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
@@ -9456,6 +10556,10 @@ tree inspector to collect and process attributes.
 
 ##### \`taints\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.taints\\"></a>
 
+\`\`\`java
+public java.lang.Object getTaints()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
 
 \`AWS::EKS::Nodegroup.Taints\`.
@@ -9465,6 +10569,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -9477,6 +10585,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`java
+public java.lang.String getCfnResourceTypeName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -10023,6 +11135,10 @@ the cluster properties to use for importing information.
 
 ##### \`adminRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.adminRole\\"></a>
 
+\`\`\`java
+public Role getAdminRole()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.iam.Role\`](#software.amazon.awscdk.services.iam.Role)
 
 An IAM role with administrative permissions to create or update the cluster.
@@ -10033,6 +11149,10 @@ This role also has \`systems:master\` permissions.
 
 ##### \`awsAuth\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.awsAuth\\"></a>
 
+\`\`\`java
+public AwsAuth getAwsAuth()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.AwsAuth\`](#software.amazon.awscdk.services.eks.AwsAuth)
 
 Lazily creates the AwsAuth resource, which manages AWS authentication mapping.
@@ -10040,6 +11160,10 @@ Lazily creates the AwsAuth resource, which manages AWS authentication mapping.
 ---
 
 ##### \`clusterArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterArn\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterArn()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -10049,6 +11173,10 @@ The AWS generated ARN for the Cluster resource.
 
 ##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterCertificateAuthorityData\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterCertificateAuthorityData()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The certificate-authority-data for your cluster.
@@ -10057,6 +11185,10 @@ The certificate-authority-data for your cluster.
 
 ##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterEncryptionConfigKeyArn\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterEncryptionConfigKeyArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 Amazon Resource Name (ARN) or alias of the customer master key (CMK).
@@ -10064,6 +11196,10 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 ---
 
 ##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterEndpoint\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterEndpoint()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -10075,6 +11211,10 @@ This is the URL inside the kubeconfig file to use with kubectl
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterName\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The Name of the created EKS Cluster.
@@ -10082,6 +11222,10 @@ The Name of the created EKS Cluster.
 ---
 
 ##### \`clusterOpenIdConnectIssuer\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterOpenIdConnectIssuer\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterOpenIdConnectIssuer()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -10095,6 +11239,10 @@ stock \`CfnCluster\`), this is \`undefined\`.
 
 ##### \`clusterOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterOpenIdConnectIssuerUrl\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterOpenIdConnectIssuerUrl()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 If this cluster is kubectl-enabled, returns the OpenID Connect issuer url.
@@ -10107,6 +11255,10 @@ stock \`CfnCluster\`), this is \`undefined\`.
 
 ##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterSecurityGroup\\"></a>
 
+\`\`\`java
+public ISecurityGroup getClusterSecurityGroup()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
 
 The cluster security group that was created by Amazon EKS for the cluster.
@@ -10114,6 +11266,10 @@ The cluster security group that was created by Amazon EKS for the cluster.
 ---
 
 ##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterSecurityGroupId\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterSecurityGroupId()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -10123,6 +11279,10 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 
 ##### \`connections\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.connections\\"></a>
 
+\`\`\`java
+public Connections getConnections()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.Connections\`](#software.amazon.awscdk.services.ec2.Connections)
 
 Manages connection rules (Security Group Rules) for the cluster.
@@ -10130,6 +11290,10 @@ Manages connection rules (Security Group Rules) for the cluster.
 ---
 
 ##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.openIdConnectProvider\\"></a>
+
+\`\`\`java
+public IOpenIdConnectProvider getOpenIdConnectProvider()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IOpenIdConnectProvider\`](#software.amazon.awscdk.services.iam.IOpenIdConnectProvider)
 
@@ -10141,6 +11305,10 @@ A provider will only be defined if this property is accessed (lazy initializatio
 
 ##### \`prune\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.prune\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getPrune()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 
 Determines if Kubernetes resources can be pruned automatically.
@@ -10148,6 +11316,10 @@ Determines if Kubernetes resources can be pruned automatically.
 ---
 
 ##### \`role\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.role\\"></a>
+
+\`\`\`java
+public IRole getRole()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 
@@ -10157,6 +11329,10 @@ IAM role assumed by the EKS Control Plane.
 
 ##### \`vpc\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.vpc\\"></a>
 
+\`\`\`java
+public IVpc getVpc()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
 
 The VPC in which this Cluster was created.
@@ -10164,6 +11340,10 @@ The VPC in which this Cluster was created.
 ---
 
 ##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.defaultCapacity\\"></a>
+
+\`\`\`java
+public AutoScalingGroup getDefaultCapacity()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.autoscaling.AutoScalingGroup\`](#software.amazon.awscdk.services.autoscaling.AutoScalingGroup)
 
@@ -10176,6 +11356,10 @@ This will be \`undefined\` if the \`defaultCapacityType\` is not \`EC2\` or
 
 ##### \`defaultNodegroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.defaultNodegroup\\"></a>
 
+\`\`\`java
+public Nodegroup getDefaultNodegroup()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.Nodegroup\`](#software.amazon.awscdk.services.eks.Nodegroup)
 
 The node group that hosts the default capacity for this cluster.
@@ -10187,6 +11371,10 @@ This will be \`undefined\` if the \`defaultCapacityType\` is \`EC2\` or
 
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlEnvironment\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 
 Custom environment variables when running \`kubectl\` against this cluster.
@@ -10194,6 +11382,10 @@ Custom environment variables when running \`kubectl\` against this cluster.
 ---
 
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlLayer\\"></a>
+
+\`\`\`java
+public ILayerVersion getKubectlLayer()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
 
@@ -10206,6 +11398,10 @@ undefined, a SAR app that contains this layer will be used.
 
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlMemory\\"></a>
 
+\`\`\`java
+public Size getKubectlMemory()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.Size\`](#software.amazon.awscdk.Size)
 
 The amount of memory allocated to the kubectl provider's lambda function.
@@ -10213,6 +11409,10 @@ The amount of memory allocated to the kubectl provider's lambda function.
 ---
 
 ##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlPrivateSubnets\\"></a>
+
+\`\`\`java
+public java.util.List<ISubnet> getKubectlPrivateSubnets()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.ISubnet\`](#software.amazon.awscdk.services.ec2.ISubnet)>
 - *Default:* If not specified, the k8s endpoint is expected to be accessible
@@ -10224,6 +11424,10 @@ Subnets to host the \`kubectl\` compute resources.
 
 ##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlRole\\"></a>
 
+\`\`\`java
+public IRole getKubectlRole()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 
 An IAM role that can perform kubectl operations against this cluster.
@@ -10233,6 +11437,10 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 ---
 
 ##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlSecurityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getKubectlSecurityGroup()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
 - *Default:* If not specified, the k8s endpoint is expected to be accessible
@@ -10649,6 +11857,10 @@ The EKS cluster to apply the Fargate profile to.
 
 ##### \`fargateProfileArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.property.fargateProfileArn\\"></a>
 
+\`\`\`java
+public java.lang.String getFargateProfileArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The full Amazon Resource Name (ARN) of the Fargate profile.
@@ -10657,6 +11869,10 @@ The full Amazon Resource Name (ARN) of the Fargate profile.
 
 ##### \`fargateProfileName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.property.fargateProfileName\\"></a>
 
+\`\`\`java
+public java.lang.String getFargateProfileName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The name of the Fargate profile.
@@ -10664,6 +11880,10 @@ The name of the Fargate profile.
 ---
 
 ##### \`podExecutionRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.property.podExecutionRole\\"></a>
+
+\`\`\`java
+public IRole getPodExecutionRole()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 
@@ -10676,6 +11896,10 @@ ECR image repositories.
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.property.tags\\"></a>
+
+\`\`\`java
+public TagManager getTags()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.TagManager\`](#software.amazon.awscdk.TagManager)
 
@@ -10822,6 +12046,10 @@ The EKS cluster to apply this configuration to.
 
 ##### \`RESOURCE_TYPE\` <a name=\\"software.amazon.awscdk.services.eks.HelmChart.property.RESOURCE_TYPE\\"></a>
 
+\`\`\`java
+public java.lang.String getResourceType()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The CloudFormation resource type.
@@ -10942,6 +12170,10 @@ in the cluster with the same name, the operation will fail.
 
 ##### \`RESOURCE_TYPE\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifest.property.RESOURCE_TYPE\\"></a>
 
+\`\`\`java
+public java.lang.String getResourceType()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The CloudFormation reosurce type.
@@ -11043,6 +12275,10 @@ Timeout for waiting on a value.
 
 ##### \`value\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValue.property.value\\"></a>
 
+\`\`\`java
+public java.lang.String getValue()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The value as a string token.
@@ -11052,6 +12288,10 @@ The value as a string token.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`RESOURCE_TYPE\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValue.property.RESOURCE_TYPE\\"></a>
+
+\`\`\`java
+public java.lang.String getResourceType()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -11412,6 +12652,10 @@ services.eks.Nodegroup.fromNodegroupName(Construct scope, java.lang.String id, j
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.property.cluster\\"></a>
 
+\`\`\`java
+public ICluster getCluster()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
 
 the Amazon EKS cluster resource.
@@ -11419,6 +12663,10 @@ the Amazon EKS cluster resource.
 ---
 
 ##### \`nodegroupArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.property.nodegroupArn\\"></a>
+
+\`\`\`java
+public java.lang.String getNodegroupArn()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -11428,6 +12676,10 @@ ARN of the nodegroup.
 
 ##### \`nodegroupName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.property.nodegroupName\\"></a>
 
+\`\`\`java
+public java.lang.String getNodegroupName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 Nodegroup name.
@@ -11435,6 +12687,10 @@ Nodegroup name.
 ---
 
 ##### \`role\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.property.role\\"></a>
+
+\`\`\`java
+public IRole getRole()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 
@@ -11578,6 +12834,10 @@ public addToPrincipalPolicy(PolicyStatement statement)
 
 ##### \`assumeRoleAction\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.assumeRoleAction\\"></a>
 
+\`\`\`java
+public java.lang.String getAssumeRoleAction()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 When this Principal is used in an AssumeRole policy, the action to use.
@@ -11585,6 +12845,10 @@ When this Principal is used in an AssumeRole policy, the action to use.
 ---
 
 ##### \`grantPrincipal\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.grantPrincipal\\"></a>
+
+\`\`\`java
+public IPrincipal getGrantPrincipal()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IPrincipal\`](#software.amazon.awscdk.services.iam.IPrincipal)
 
@@ -11594,6 +12858,10 @@ The principal to grant permissions to.
 
 ##### \`policyFragment\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.policyFragment\\"></a>
 
+\`\`\`java
+public PrincipalPolicyFragment getPolicyFragment()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.iam.PrincipalPolicyFragment\`](#software.amazon.awscdk.services.iam.PrincipalPolicyFragment)
 
 Return the policy fragment that identifies this principal in a Policy.
@@ -11601,6 +12869,10 @@ Return the policy fragment that identifies this principal in a Policy.
 ---
 
 ##### \`role\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.role\\"></a>
+
+\`\`\`java
+public IRole getRole()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 
@@ -11610,6 +12882,10 @@ The role which is linked to the service account.
 
 ##### \`serviceAccountName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.serviceAccountName\\"></a>
 
+\`\`\`java
+public java.lang.String getServiceAccountName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The name of the service account.
@@ -11617,6 +12893,10 @@ The name of the service account.
 ---
 
 ##### \`serviceAccountNamespace\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.serviceAccountNamespace\\"></a>
+
+\`\`\`java
+public java.lang.String getServiceAccountNamespace()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -11668,6 +12948,10 @@ AutoScalingGroupCapacityOptions.builder()
 
 ##### \`allowAllOutbound\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.allowAllOutbound\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getAllowAllOutbound()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
 
@@ -11677,6 +12961,10 @@ Whether the instances can initiate connections to anywhere by default.
 
 ##### \`associatePublicIpAddress\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.associatePublicIpAddress\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getAssociatePublicIpAddress()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* Use subnet setting.
 
@@ -11685,6 +12973,10 @@ Whether instances in the Auto Scaling Group should have public IP addresses asso
 ---
 
 ##### \`autoScalingGroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.autoScalingGroupName\\"></a>
+
+\`\`\`java
+public java.lang.String getAutoScalingGroupName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* Auto generated by CloudFormation
@@ -11696,6 +12988,10 @@ This name must be unique per Region per account.
 ---
 
 ##### \`blockDevices\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.blockDevices\\"></a>
+
+\`\`\`java
+public java.util.List<BlockDevice> getBlockDevices()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.autoscaling.BlockDevice\`](#software.amazon.awscdk.services.autoscaling.BlockDevice)>
 - *Default:* Uses the block device mapping of the AMI
@@ -11713,6 +13009,10 @@ instance store volumes to attach to an instance when it is launched.
 
 ##### \`cooldown\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.cooldown\\"></a>
 
+\`\`\`java
+public Duration getCooldown()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.Duration\`](#software.amazon.awscdk.Duration)
 - *Default:* Duration.minutes(5)
 
@@ -11721,6 +13021,10 @@ Default scaling cooldown for this AutoScalingGroup.
 ---
 
 ##### \`desiredCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.desiredCapacity\\"></a>
+
+\`\`\`java
+public java.lang.Number getDesiredCapacity()
+\`\`\`
 
 - *Type:* \`java.lang.Number\`
 - *Default:* minCapacity, and leave unchanged during deployment
@@ -11736,6 +13040,10 @@ instances to this number. It is recommended to leave this value blank.
 
 ##### \`groupMetrics\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.groupMetrics\\"></a>
 
+\`\`\`java
+public java.util.List<GroupMetrics> getGroupMetrics()
+\`\`\`
+
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.autoscaling.GroupMetrics\`](#software.amazon.awscdk.services.autoscaling.GroupMetrics)>
 - *Default:* no group metrics will be reported
 
@@ -11748,6 +13056,10 @@ Group metrics are reported in a granularity of 1 minute at no additional charge.
 
 ##### \`healthCheck\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.healthCheck\\"></a>
 
+\`\`\`java
+public HealthCheck getHealthCheck()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.autoscaling.HealthCheck\`](#software.amazon.awscdk.services.autoscaling.HealthCheck)
 - *Default:* HealthCheck.ec2 with no grace period
 
@@ -11756,6 +13068,10 @@ Configuration for health checks.
 ---
 
 ##### \`ignoreUnmodifiedSizeProperties\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.ignoreUnmodifiedSizeProperties\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getIgnoreUnmodifiedSizeProperties()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -11772,6 +13088,10 @@ on deployment.
 
 ##### \`instanceMonitoring\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.instanceMonitoring\\"></a>
 
+\`\`\`java
+public Monitoring getInstanceMonitoring()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.autoscaling.Monitoring\`](#software.amazon.awscdk.services.autoscaling.Monitoring)
 - *Default:* Monitoring.DETAILED
 
@@ -11786,6 +13106,10 @@ is charged a fee. When you disable detailed monitoring, CloudWatch generates met
 
 ##### \`keyName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.keyName\\"></a>
 
+\`\`\`java
+public java.lang.String getKeyName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* No SSH access will be possible.
 
@@ -11795,6 +13119,10 @@ Name of SSH keypair to grant access to instances.
 
 ##### \`maxCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.maxCapacity\\"></a>
 
+\`\`\`java
+public java.lang.Number getMaxCapacity()
+\`\`\`
+
 - *Type:* \`java.lang.Number\`
 - *Default:* desiredCapacity
 
@@ -11803,6 +13131,10 @@ Maximum number of instances in the fleet.
 ---
 
 ##### \`maxInstanceLifetime\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.maxInstanceLifetime\\"></a>
+
+\`\`\`java
+public Duration getMaxInstanceLifetime()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Duration\`](#software.amazon.awscdk.Duration)
 - *Default:* none
@@ -11822,6 +13154,10 @@ leave this property undefined.
 
 ##### \`minCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.minCapacity\\"></a>
 
+\`\`\`java
+public java.lang.Number getMinCapacity()
+\`\`\`
+
 - *Type:* \`java.lang.Number\`
 - *Default:* 1
 
@@ -11830,6 +13166,10 @@ Minimum number of instances in the fleet.
 ---
 
 ##### \`newInstancesProtectedFromScaleIn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.newInstancesProtectedFromScaleIn\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getNewInstancesProtectedFromScaleIn()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
@@ -11849,6 +13189,10 @@ an ECS Capacity Provider with managed termination protection.
 
 ##### \`notifications\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.notifications\\"></a>
 
+\`\`\`java
+public java.util.List<NotificationConfiguration> getNotifications()
+\`\`\`
+
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.autoscaling.NotificationConfiguration\`](#software.amazon.awscdk.services.autoscaling.NotificationConfiguration)>
 - *Default:* No fleet change notifications will be sent.
 
@@ -11859,6 +13203,10 @@ Configure autoscaling group to send notifications about fleet changes to an SNS 
 ---
 
 ##### \`signals\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.signals\\"></a>
+
+\`\`\`java
+public Signals getSignals()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.autoscaling.Signals\`](#software.amazon.awscdk.services.autoscaling.Signals)
 - *Default:* Do not wait for signals
@@ -11885,6 +13233,10 @@ https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services
 
 ##### \`spotPrice\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.spotPrice\\"></a>
 
+\`\`\`java
+public java.lang.String getSpotPrice()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* none
 
@@ -11896,6 +13248,10 @@ launched when the price you specify exceeds the current Spot market price.
 ---
 
 ##### \`updatePolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.updatePolicy\\"></a>
+
+\`\`\`java
+public UpdatePolicy getUpdatePolicy()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.autoscaling.UpdatePolicy\`](#software.amazon.awscdk.services.autoscaling.UpdatePolicy)
 - *Default:* \`UpdatePolicy.rollingUpdate()\` if using \`init\`, \`UpdatePolicy.none()\` otherwise
@@ -11912,6 +13268,10 @@ is done and only new instances are launched with the new config.
 
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.vpcSubnets\\"></a>
 
+\`\`\`java
+public SubnetSelection getVpcSubnets()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
 - *Default:* All Private subnets.
 
@@ -11921,6 +13281,10 @@ Where to place instances within the VPC.
 
 ##### \`instanceType\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.instanceType\\"></a>
 
+\`\`\`java
+public InstanceType getInstanceType()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)
 
 Instance type of the instances to start.
@@ -11928,6 +13292,10 @@ Instance type of the instances to start.
 ---
 
 ##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.bootstrapEnabled\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getBootstrapEnabled()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -11941,6 +13309,10 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 
 ##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.bootstrapOptions\\"></a>
 
+\`\`\`java
+public BootstrapOptions getBootstrapOptions()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.BootstrapOptions\`](#software.amazon.awscdk.services.eks.BootstrapOptions)
 - *Default:* none
 
@@ -11950,6 +13322,10 @@ EKS node bootstrapping options.
 
 ##### \`machineImageType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.machineImageType\\"></a>
 
+\`\`\`java
+public MachineImageType getMachineImageType()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.MachineImageType\`](#software.amazon.awscdk.services.eks.MachineImageType)
 - *Default:* MachineImageType.AMAZON_LINUX_2
 
@@ -11958,6 +13334,10 @@ Machine image type.
 ---
 
 ##### \`mapRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.mapRole\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getMapRole()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true if the cluster has kubectl enabled (which is the default).
@@ -11969,6 +13349,10 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 ---
 
 ##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.spotInterruptHandler\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getSpotInterruptHandler()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -11999,6 +13383,10 @@ AutoScalingGroupOptions.builder()
 
 ##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.bootstrapEnabled\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getBootstrapEnabled()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
 
@@ -12011,6 +13399,10 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 
 ##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.bootstrapOptions\\"></a>
 
+\`\`\`java
+public BootstrapOptions getBootstrapOptions()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.BootstrapOptions\`](#software.amazon.awscdk.services.eks.BootstrapOptions)
 - *Default:* default options
 
@@ -12020,6 +13412,10 @@ Allows options for node bootstrapping through EC2 user data.
 
 ##### \`machineImageType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.machineImageType\\"></a>
 
+\`\`\`java
+public MachineImageType getMachineImageType()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.MachineImageType\`](#software.amazon.awscdk.services.eks.MachineImageType)
 - *Default:* MachineImageType.AMAZON_LINUX_2
 
@@ -12028,6 +13424,10 @@ Allow options to specify different machine image type.
 ---
 
 ##### \`mapRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.mapRole\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getMapRole()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true if the cluster has kubectl enabled (which is the default).
@@ -12039,6 +13439,10 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 ---
 
 ##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.spotInterruptHandler\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getSpotInterruptHandler()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -12066,6 +13470,10 @@ AwsAuthMapping.builder()
 
 ##### \`groups\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuthMapping.property.groups\\"></a>
 
+\`\`\`java
+public java.util.List<java.lang.String> getGroups()
+\`\`\`
+
 - *Type:* java.util.List<\`java.lang.String\`>
 
 A list of groups within Kubernetes to which the role is mapped.
@@ -12075,6 +13483,10 @@ A list of groups within Kubernetes to which the role is mapped.
 ---
 
 ##### \`username\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuthMapping.property.username\\"></a>
+
+\`\`\`java
+public java.lang.String getUsername()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* By default, the user name is the ARN of the IAM role.
@@ -12098,6 +13510,10 @@ AwsAuthProps.builder()
 \`\`\`
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuthProps.property.cluster\\"></a>
+
+\`\`\`java
+public Cluster getCluster()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.Cluster\`](#software.amazon.awscdk.services.eks.Cluster)
 
@@ -12129,6 +13545,10 @@ BootstrapOptions.builder()
 
 ##### \`additionalArgs\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.additionalArgs\\"></a>
 
+\`\`\`java
+public java.lang.String getAdditionalArgs()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* none
 
@@ -12140,6 +13560,10 @@ Additional command line arguments to pass to the \`/etc/eks/bootstrap.sh\` comma
 
 ##### \`awsApiRetryAttempts\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.awsApiRetryAttempts\\"></a>
 
+\`\`\`java
+public java.lang.Number getAwsApiRetryAttempts()
+\`\`\`
+
 - *Type:* \`java.lang.Number\`
 - *Default:* 3
 
@@ -12148,6 +13572,10 @@ Number of retry attempts for AWS API call (DescribeCluster).
 ---
 
 ##### \`dnsClusterIp\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.dnsClusterIp\\"></a>
+
+\`\`\`java
+public java.lang.String getDnsClusterIp()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* 10.100.0.10 or 172.20.0.10 based on the IP
@@ -12159,6 +13587,10 @@ Overrides the IP address to use for DNS queries within the cluster.
 
 ##### \`dockerConfigJson\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.dockerConfigJson\\"></a>
 
+\`\`\`java
+public java.lang.String getDockerConfigJson()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* none
 
@@ -12168,6 +13600,10 @@ The contents of the \`/etc/docker/daemon.json\` file. Useful if you want a custo
 
 ##### \`enableDockerBridge\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.enableDockerBridge\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getEnableDockerBridge()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -12176,6 +13612,10 @@ Restores the docker default bridge network.
 ---
 
 ##### \`kubeletExtraArgs\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.kubeletExtraArgs\\"></a>
+
+\`\`\`java
+public java.lang.String getKubeletExtraArgs()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* none
@@ -12187,6 +13627,10 @@ Useful for adding labels or taints.
 ---
 
 ##### \`useMaxPods\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.useMaxPods\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getUseMaxPods()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -12218,6 +13662,10 @@ CfnAddonProps.builder()
 
 ##### \`addonName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.addonName\\"></a>
 
+\`\`\`java
+public java.lang.String getAddonName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Addon.AddonName\`.
@@ -12227,6 +13675,10 @@ CfnAddonProps.builder()
 ---
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -12238,6 +13690,10 @@ CfnAddonProps.builder()
 
 ##### \`addonVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.addonVersion\\"></a>
 
+\`\`\`java
+public java.lang.String getAddonVersion()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Addon.AddonVersion\`.
@@ -12247,6 +13703,10 @@ CfnAddonProps.builder()
 ---
 
 ##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.resolveConflicts\\"></a>
+
+\`\`\`java
+public java.lang.String getResolveConflicts()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -12258,6 +13718,10 @@ CfnAddonProps.builder()
 
 ##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.serviceAccountRoleArn\\"></a>
 
+\`\`\`java
+public java.lang.String getServiceAccountRoleArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Addon.ServiceAccountRoleArn\`.
@@ -12267,6 +13731,10 @@ CfnAddonProps.builder()
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.tags\\"></a>
+
+\`\`\`java
+public java.util.List<CfnTag> getTags()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.CfnTag\`](#software.amazon.awscdk.CfnTag)>
 
@@ -12303,6 +13771,10 @@ CfnClusterProps.builder()
 
 ##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.resourcesVpcConfig\\"></a>
 
+\`\`\`java
+public java.lang.Object getResourcesVpcConfig()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
 \`AWS::EKS::Cluster.ResourcesVpcConfig\`.
@@ -12312,6 +13784,10 @@ CfnClusterProps.builder()
 ---
 
 ##### \`roleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.roleArn\\"></a>
+
+\`\`\`java
+public java.lang.String getRoleArn()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -12323,6 +13799,10 @@ CfnClusterProps.builder()
 
 ##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.encryptionConfig\\"></a>
 
+\`\`\`java
+public java.lang.Object getEncryptionConfig()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
 
 \`AWS::EKS::Cluster.EncryptionConfig\`.
@@ -12332,6 +13812,10 @@ CfnClusterProps.builder()
 ---
 
 ##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.kubernetesNetworkConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getKubernetesNetworkConfig()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
@@ -12343,6 +13827,10 @@ CfnClusterProps.builder()
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.name\\"></a>
 
+\`\`\`java
+public java.lang.String getName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Cluster.Name\`.
@@ -12352,6 +13840,10 @@ CfnClusterProps.builder()
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -12386,6 +13878,10 @@ CfnFargateProfileProps.builder()
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.clusterName\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::FargateProfile.ClusterName\`.
@@ -12395,6 +13891,10 @@ CfnFargateProfileProps.builder()
 ---
 
 ##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.podExecutionRoleArn\\"></a>
+
+\`\`\`java
+public java.lang.String getPodExecutionRoleArn()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -12406,6 +13906,10 @@ CfnFargateProfileProps.builder()
 
 ##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.selectors\\"></a>
 
+\`\`\`java
+public java.lang.Object getSelectors()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty\`](#software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
 
 \`AWS::EKS::FargateProfile.Selectors\`.
@@ -12415,6 +13919,10 @@ CfnFargateProfileProps.builder()
 ---
 
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.fargateProfileName\\"></a>
+
+\`\`\`java
+public java.lang.String getFargateProfileName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -12426,6 +13934,10 @@ CfnFargateProfileProps.builder()
 
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.subnets\\"></a>
 
+\`\`\`java
+public java.util.List<java.lang.String> getSubnets()
+\`\`\`
+
 - *Type:* java.util.List<\`java.lang.String\`>
 
 \`AWS::EKS::FargateProfile.Subnets\`.
@@ -12435,6 +13947,10 @@ CfnFargateProfileProps.builder()
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.tags\\"></a>
+
+\`\`\`java
+public java.util.List<CfnTag> getTags()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.CfnTag\`](#software.amazon.awscdk.CfnTag)>
 
@@ -12484,6 +14000,10 @@ CfnNodegroupProps.builder()
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.clusterName\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Nodegroup.ClusterName\`.
@@ -12493,6 +14013,10 @@ CfnNodegroupProps.builder()
 ---
 
 ##### \`nodeRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.nodeRole\\"></a>
+
+\`\`\`java
+public java.lang.String getNodeRole()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -12504,6 +14028,10 @@ CfnNodegroupProps.builder()
 
 ##### \`subnets\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.subnets\\"></a>
 
+\`\`\`java
+public java.util.List<java.lang.String> getSubnets()
+\`\`\`
+
 - *Type:* java.util.List<\`java.lang.String\`>
 
 \`AWS::EKS::Nodegroup.Subnets\`.
@@ -12513,6 +14041,10 @@ CfnNodegroupProps.builder()
 ---
 
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.amiType\\"></a>
+
+\`\`\`java
+public java.lang.String getAmiType()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -12524,6 +14056,10 @@ CfnNodegroupProps.builder()
 
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.capacityType\\"></a>
 
+\`\`\`java
+public java.lang.String getCapacityType()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Nodegroup.CapacityType\`.
@@ -12533,6 +14069,10 @@ CfnNodegroupProps.builder()
 ---
 
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.diskSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getDiskSize()
+\`\`\`
 
 - *Type:* \`java.lang.Number\`
 
@@ -12544,6 +14084,10 @@ CfnNodegroupProps.builder()
 
 ##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.forceUpdateEnabled\\"></a>
 
+\`\`\`java
+public java.lang.Object getForceUpdateEnabled()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\` OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
 \`AWS::EKS::Nodegroup.ForceUpdateEnabled\`.
@@ -12553,6 +14097,10 @@ CfnNodegroupProps.builder()
 ---
 
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.instanceTypes\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getInstanceTypes()
+\`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
 
@@ -12564,6 +14112,10 @@ CfnNodegroupProps.builder()
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.labels\\"></a>
 
+\`\`\`java
+public java.lang.Object getLabels()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::EKS::Nodegroup.Labels\`.
@@ -12573,6 +14125,10 @@ CfnNodegroupProps.builder()
 ---
 
 ##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.launchTemplate\\"></a>
+
+\`\`\`java
+public java.lang.Object getLaunchTemplate()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
@@ -12584,6 +14140,10 @@ CfnNodegroupProps.builder()
 
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.nodegroupName\\"></a>
 
+\`\`\`java
+public java.lang.String getNodegroupName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`AWS::EKS::Nodegroup.NodegroupName\`.
@@ -12593,6 +14153,10 @@ CfnNodegroupProps.builder()
 ---
 
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.releaseVersion\\"></a>
+
+\`\`\`java
+public java.lang.String getReleaseVersion()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -12604,6 +14168,10 @@ CfnNodegroupProps.builder()
 
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.remoteAccess\\"></a>
 
+\`\`\`java
+public java.lang.Object getRemoteAccess()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
 \`AWS::EKS::Nodegroup.RemoteAccess\`.
@@ -12613,6 +14181,10 @@ CfnNodegroupProps.builder()
 ---
 
 ##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.scalingConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getScalingConfig()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
@@ -12624,6 +14196,10 @@ CfnNodegroupProps.builder()
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.tags\\"></a>
 
+\`\`\`java
+public java.lang.Object getTags()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::EKS::Nodegroup.Tags\`.
@@ -12634,6 +14210,10 @@ CfnNodegroupProps.builder()
 
 ##### \`taints\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.taints\\"></a>
 
+\`\`\`java
+public java.lang.Object getTaints()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
 
 \`AWS::EKS::Nodegroup.Taints\`.
@@ -12643,6 +14223,10 @@ CfnNodegroupProps.builder()
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -12682,6 +14266,10 @@ ClusterAttributes.builder()
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterName\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The physical name of the Cluster.
@@ -12689,6 +14277,10 @@ The physical name of the Cluster.
 ---
 
 ##### \`clusterCertificateAuthorityData\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterCertificateAuthorityData\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterCertificateAuthorityData()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* if not specified \`cluster.clusterCertificateAuthorityData\` will
@@ -12700,6 +14292,10 @@ The certificate-authority-data for your cluster.
 
 ##### \`clusterEncryptionConfigKeyArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterEncryptionConfigKeyArn\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterEncryptionConfigKeyArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* if not specified \`cluster.clusterEncryptionConfigKeyArn\` will
 throw an error
@@ -12710,6 +14306,10 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ##### \`clusterEndpoint\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterEndpoint\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterEndpoint()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* if not specified \`cluster.clusterEndpoint\` will throw an error.
 
@@ -12718,6 +14318,10 @@ The API Server endpoint URL.
 ---
 
 ##### \`clusterSecurityGroupId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterSecurityGroupId\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterSecurityGroupId()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* if not specified \`cluster.clusterSecurityGroupId\` will throw an
@@ -12729,6 +14333,10 @@ The cluster security group that was created by Amazon EKS for the cluster.
 
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlEnvironment\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 - *Default:* no additional variables
 
@@ -12737,6 +14345,10 @@ Environment variables to use when running \`kubectl\` against this cluster.
 ---
 
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlLayer\\"></a>
+
+\`\`\`java
+public ILayerVersion getKubectlLayer()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
 - *Default:* a layer bundled with this module.
@@ -12756,6 +14368,10 @@ The handler expects the layer to include the following executables:
 
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlMemory\\"></a>
 
+\`\`\`java
+public Size getKubectlMemory()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.Size\`](#software.amazon.awscdk.Size)
 - *Default:* Size.gibibytes(1)
 
@@ -12764,6 +14380,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`kubectlPrivateSubnetIds\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlPrivateSubnetIds\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getKubectlPrivateSubnetIds()
+\`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
 - *Default:* k8s endpoint is expected to be accessible publicly
@@ -12777,6 +14397,10 @@ endpoint is expected to be accessible publicly.
 
 ##### \`kubectlRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlRoleArn\\"></a>
 
+\`\`\`java
+public java.lang.String getKubectlRoleArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* if not specified, it not be possible to issue \`kubectl\` commands
 against an imported cluster.
@@ -12786,6 +14410,10 @@ An IAM role with cluster administrator and \\"system:masters\\" permissions.
 ---
 
 ##### \`kubectlSecurityGroupId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlSecurityGroupId\\"></a>
+
+\`\`\`java
+public java.lang.String getKubectlSecurityGroupId()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* k8s endpoint is expected to be accessible publicly
@@ -12799,6 +14427,10 @@ endpoint is expected to be accessible publicly.
 
 ##### \`openIdConnectProvider\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.openIdConnectProvider\\"></a>
 
+\`\`\`java
+public IOpenIdConnectProvider getOpenIdConnectProvider()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.iam.IOpenIdConnectProvider\`](#software.amazon.awscdk.services.iam.IOpenIdConnectProvider)
 - *Default:* if not specified \`cluster.openIdConnectProvider\` and \`cluster.addServiceAccount\` will throw an error.
 
@@ -12810,6 +14442,10 @@ or create a new provider using \`new eks.OpenIdConnectProvider\`
 ---
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -12824,6 +14460,10 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.securityGroupIds\\"></a>
 
+\`\`\`java
+public java.util.List<java.lang.String> getSecurityGroupIds()
+\`\`\`
+
 - *Type:* java.util.List<\`java.lang.String\`>
 - *Default:* if not specified, no additional security groups will be
 considered in \`cluster.connections\`.
@@ -12833,6 +14473,10 @@ Additional security groups associated with this cluster.
 ---
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.vpc\\"></a>
+
+\`\`\`java
+public IVpc getVpc()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
 - *Default:* if not specified \`cluster.vpc\` will throw an error
@@ -12875,6 +14519,10 @@ ClusterOptions.builder()
 
 ##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.version\\"></a>
 
+\`\`\`java
+public KubernetesVersion getVersion()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
 The Kubernetes version to run in the cluster.
@@ -12882,6 +14530,10 @@ The Kubernetes version to run in the cluster.
 ---
 
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* Automatically generated name
@@ -12892,6 +14544,10 @@ Name for the cluster.
 
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.outputClusterName\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getOutputClusterName()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -12900,6 +14556,10 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ---
 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.outputConfigCommand\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputConfigCommand()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -12913,6 +14573,10 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.role\\"></a>
 
+\`\`\`java
+public IRole getRole()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 - *Default:* A role is automatically created for you
 
@@ -12921,6 +14585,10 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ---
 
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.securityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getSecurityGroup()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -12931,6 +14599,10 @@ Security Group to use for Control Plane ENIs.
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.vpc\\"></a>
 
+\`\`\`java
+public IVpc getVpc()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
 
@@ -12939,6 +14611,10 @@ The VPC in which to create the Cluster.
 ---
 
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.vpcSubnets\\"></a>
+
+\`\`\`java
+public java.util.List<SubnetSelection> getVpcSubnets()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
 - *Default:* All public and private subnets
@@ -12959,6 +14635,10 @@ vpcSubnets: [
 
 ##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.clusterHandlerEnvironment\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getClusterHandlerEnvironment()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 - *Default:* No environment variables.
 
@@ -12968,6 +14648,10 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.coreDnsComputeType\\"></a>
 
+\`\`\`java
+public CoreDnsComputeType getCoreDnsComputeType()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.CoreDnsComputeType\`](#software.amazon.awscdk.services.eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
 
@@ -12976,6 +14660,10 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ---
 
 ##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.endpointAccess\\"></a>
+
+\`\`\`java
+public EndpointAccess getEndpointAccess()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -12988,6 +14676,10 @@ Configure access to the Kubernetes API server endpoint..
 
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.kubectlEnvironment\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 - *Default:* No environment variables.
 
@@ -12998,6 +14690,10 @@ Only relevant for kubectl enabled clusters.
 ---
 
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.kubectlLayer\\"></a>
+
+\`\`\`java
+public ILayerVersion getKubectlLayer()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -13026,6 +14722,10 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.kubectlMemory\\"></a>
 
+\`\`\`java
+public Size getKubectlMemory()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.Size\`](#software.amazon.awscdk.Size)
 - *Default:* Size.gibibytes(1)
 
@@ -13034,6 +14734,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`mastersRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.mastersRole\\"></a>
+
+\`\`\`java
+public IRole getMastersRole()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -13047,6 +14751,10 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.outputMastersRoleArn\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getOutputMastersRoleArn()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -13056,6 +14764,10 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.placeClusterHandlerInVpc\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getPlaceClusterHandlerInVpc()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -13064,6 +14776,10 @@ If set to true, the cluster handler functions will be placed in the private subn
 ---
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -13077,6 +14793,10 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 ---
 
 ##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.secretsEncryptionKey\\"></a>
+
+\`\`\`java
+public IKey getSecretsEncryptionKey()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.kms.IKey\`](#software.amazon.awscdk.services.kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
@@ -13124,6 +14844,10 @@ ClusterProps.builder()
 
 ##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.version\\"></a>
 
+\`\`\`java
+public KubernetesVersion getVersion()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
 The Kubernetes version to run in the cluster.
@@ -13131,6 +14855,10 @@ The Kubernetes version to run in the cluster.
 ---
 
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* Automatically generated name
@@ -13141,6 +14869,10 @@ Name for the cluster.
 
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.outputClusterName\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getOutputClusterName()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -13149,6 +14881,10 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ---
 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.outputConfigCommand\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputConfigCommand()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -13162,6 +14898,10 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.role\\"></a>
 
+\`\`\`java
+public IRole getRole()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 - *Default:* A role is automatically created for you
 
@@ -13170,6 +14910,10 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ---
 
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.securityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getSecurityGroup()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -13180,6 +14924,10 @@ Security Group to use for Control Plane ENIs.
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.vpc\\"></a>
 
+\`\`\`java
+public IVpc getVpc()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
 
@@ -13188,6 +14936,10 @@ The VPC in which to create the Cluster.
 ---
 
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.vpcSubnets\\"></a>
+
+\`\`\`java
+public java.util.List<SubnetSelection> getVpcSubnets()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
 - *Default:* All public and private subnets
@@ -13208,6 +14960,10 @@ vpcSubnets: [
 
 ##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.clusterHandlerEnvironment\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getClusterHandlerEnvironment()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 - *Default:* No environment variables.
 
@@ -13217,6 +14973,10 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.coreDnsComputeType\\"></a>
 
+\`\`\`java
+public CoreDnsComputeType getCoreDnsComputeType()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.CoreDnsComputeType\`](#software.amazon.awscdk.services.eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
 
@@ -13225,6 +14985,10 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ---
 
 ##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.endpointAccess\\"></a>
+
+\`\`\`java
+public EndpointAccess getEndpointAccess()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -13237,6 +15001,10 @@ Configure access to the Kubernetes API server endpoint..
 
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.kubectlEnvironment\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 - *Default:* No environment variables.
 
@@ -13247,6 +15015,10 @@ Only relevant for kubectl enabled clusters.
 ---
 
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.kubectlLayer\\"></a>
+
+\`\`\`java
+public ILayerVersion getKubectlLayer()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -13275,6 +15047,10 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.kubectlMemory\\"></a>
 
+\`\`\`java
+public Size getKubectlMemory()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.Size\`](#software.amazon.awscdk.Size)
 - *Default:* Size.gibibytes(1)
 
@@ -13283,6 +15059,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`mastersRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.mastersRole\\"></a>
+
+\`\`\`java
+public IRole getMastersRole()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -13296,6 +15076,10 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.outputMastersRoleArn\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getOutputMastersRoleArn()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -13305,6 +15089,10 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.placeClusterHandlerInVpc\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getPlaceClusterHandlerInVpc()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -13313,6 +15101,10 @@ If set to true, the cluster handler functions will be placed in the private subn
 ---
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -13327,6 +15119,10 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.secretsEncryptionKey\\"></a>
 
+\`\`\`java
+public IKey getSecretsEncryptionKey()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.kms.IKey\`](#software.amazon.awscdk.services.kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
   all etcd volumes used by Amazon EKS are encrypted at the disk-level
@@ -13337,6 +15133,10 @@ KMS secret for envelope encryption for Kubernetes secrets.
 ---
 
 ##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.defaultCapacity\\"></a>
+
+\`\`\`java
+public java.lang.Number getDefaultCapacity()
+\`\`\`
 
 - *Type:* \`java.lang.Number\`
 - *Default:* 2
@@ -13353,6 +15153,10 @@ to \`0\` is you wish to avoid the initial capacity allocation.
 
 ##### \`defaultCapacityInstance\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.defaultCapacityInstance\\"></a>
 
+\`\`\`java
+public InstanceType getDefaultCapacityInstance()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)
 - *Default:* m5.large
 
@@ -13364,6 +15168,10 @@ into account if \`defaultCapacity\` is > 0.
 ---
 
 ##### \`defaultCapacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.defaultCapacityType\\"></a>
+
+\`\`\`java
+public DefaultCapacityType getDefaultCapacityType()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.DefaultCapacityType\`](#software.amazon.awscdk.services.eks.DefaultCapacityType)
 - *Default:* NODEGROUP
@@ -13395,6 +15203,10 @@ CommonClusterOptions.builder()
 
 ##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.version\\"></a>
 
+\`\`\`java
+public KubernetesVersion getVersion()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
 The Kubernetes version to run in the cluster.
@@ -13402,6 +15214,10 @@ The Kubernetes version to run in the cluster.
 ---
 
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* Automatically generated name
@@ -13412,6 +15228,10 @@ Name for the cluster.
 
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.outputClusterName\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getOutputClusterName()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -13420,6 +15240,10 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ---
 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.outputConfigCommand\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputConfigCommand()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -13433,6 +15257,10 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.role\\"></a>
 
+\`\`\`java
+public IRole getRole()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 - *Default:* A role is automatically created for you
 
@@ -13441,6 +15269,10 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ---
 
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.securityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getSecurityGroup()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -13451,6 +15283,10 @@ Security Group to use for Control Plane ENIs.
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.vpc\\"></a>
 
+\`\`\`java
+public IVpc getVpc()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
 
@@ -13459,6 +15295,10 @@ The VPC in which to create the Cluster.
 ---
 
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.vpcSubnets\\"></a>
+
+\`\`\`java
+public java.util.List<SubnetSelection> getVpcSubnets()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
 - *Default:* All public and private subnets
@@ -13495,6 +15335,10 @@ EksOptimizedImageProps.builder()
 
 ##### \`cpuArch\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps.property.cpuArch\\"></a>
 
+\`\`\`java
+public CpuArch getCpuArch()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.CpuArch\`](#software.amazon.awscdk.services.eks.CpuArch)
 - *Default:* CpuArch.X86_64
 
@@ -13504,6 +15348,10 @@ What cpu architecture to retrieve the image for (arm64 or x86_64).
 
 ##### \`kubernetesVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps.property.kubernetesVersion\\"></a>
 
+\`\`\`java
+public java.lang.String getKubernetesVersion()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* The latest version
 
@@ -13512,6 +15360,10 @@ The Kubernetes version to use.
 ---
 
 ##### \`nodeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps.property.nodeType\\"></a>
+
+\`\`\`java
+public NodeType getNodeType()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.NodeType\`](#software.amazon.awscdk.services.eks.NodeType)
 - *Default:* NodeType.STANDARD
@@ -13538,6 +15390,10 @@ EncryptionConfigProperty.builder()
 
 ##### \`provider\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty.property.provider\\"></a>
 
+\`\`\`java
+public java.lang.Object getProvider()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.ProviderProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.ProviderProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
 
 \`CfnCluster.EncryptionConfigProperty.Provider\`.
@@ -13547,6 +15403,10 @@ EncryptionConfigProperty.builder()
 ---
 
 ##### \`resources\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty.property.resources\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getResources()
+\`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
 
@@ -13591,6 +15451,10 @@ FargateClusterProps.builder()
 
 ##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.version\\"></a>
 
+\`\`\`java
+public KubernetesVersion getVersion()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
 The Kubernetes version to run in the cluster.
@@ -13598,6 +15462,10 @@ The Kubernetes version to run in the cluster.
 ---
 
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* Automatically generated name
@@ -13608,6 +15476,10 @@ Name for the cluster.
 
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.outputClusterName\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getOutputClusterName()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -13616,6 +15488,10 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ---
 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.outputConfigCommand\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputConfigCommand()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -13629,6 +15505,10 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.role\\"></a>
 
+\`\`\`java
+public IRole getRole()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 - *Default:* A role is automatically created for you
 
@@ -13637,6 +15517,10 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ---
 
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.securityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getSecurityGroup()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -13647,6 +15531,10 @@ Security Group to use for Control Plane ENIs.
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.vpc\\"></a>
 
+\`\`\`java
+public IVpc getVpc()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
 
@@ -13655,6 +15543,10 @@ The VPC in which to create the Cluster.
 ---
 
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.vpcSubnets\\"></a>
+
+\`\`\`java
+public java.util.List<SubnetSelection> getVpcSubnets()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
 - *Default:* All public and private subnets
@@ -13675,6 +15567,10 @@ vpcSubnets: [
 
 ##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.clusterHandlerEnvironment\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getClusterHandlerEnvironment()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 - *Default:* No environment variables.
 
@@ -13684,6 +15580,10 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.coreDnsComputeType\\"></a>
 
+\`\`\`java
+public CoreDnsComputeType getCoreDnsComputeType()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.CoreDnsComputeType\`](#software.amazon.awscdk.services.eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
 
@@ -13692,6 +15592,10 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ---
 
 ##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.endpointAccess\\"></a>
+
+\`\`\`java
+public EndpointAccess getEndpointAccess()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -13704,6 +15608,10 @@ Configure access to the Kubernetes API server endpoint..
 
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.kubectlEnvironment\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 - *Default:* No environment variables.
 
@@ -13714,6 +15622,10 @@ Only relevant for kubectl enabled clusters.
 ---
 
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.kubectlLayer\\"></a>
+
+\`\`\`java
+public ILayerVersion getKubectlLayer()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -13742,6 +15654,10 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.kubectlMemory\\"></a>
 
+\`\`\`java
+public Size getKubectlMemory()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.Size\`](#software.amazon.awscdk.Size)
 - *Default:* Size.gibibytes(1)
 
@@ -13750,6 +15666,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`mastersRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.mastersRole\\"></a>
+
+\`\`\`java
+public IRole getMastersRole()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -13763,6 +15683,10 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.outputMastersRoleArn\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getOutputMastersRoleArn()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -13772,6 +15696,10 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.placeClusterHandlerInVpc\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getPlaceClusterHandlerInVpc()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -13780,6 +15708,10 @@ If set to true, the cluster handler functions will be placed in the private subn
 ---
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -13794,6 +15726,10 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.secretsEncryptionKey\\"></a>
 
+\`\`\`java
+public IKey getSecretsEncryptionKey()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.kms.IKey\`](#software.amazon.awscdk.services.kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
   all etcd volumes used by Amazon EKS are encrypted at the disk-level
@@ -13804,6 +15740,10 @@ KMS secret for envelope encryption for Kubernetes secrets.
 ---
 
 ##### \`defaultProfile\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.defaultProfile\\"></a>
+
+\`\`\`java
+public FargateProfileOptions getDefaultProfile()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.FargateProfileOptions\`](#software.amazon.awscdk.services.eks.FargateProfileOptions)
 - *Default:* A profile called \\"default\\" with 'default' and 'kube-system'
@@ -13833,6 +15773,10 @@ FargateProfileOptions.builder()
 
 ##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.selectors\\"></a>
 
+\`\`\`java
+public java.util.List<Selector> getSelectors()
+\`\`\`
+
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.eks.Selector\`](#software.amazon.awscdk.services.eks.Selector)>
 
 The selectors to match for pods to use this Fargate profile.
@@ -13847,6 +15791,10 @@ At least one selector is required and you may specify up to five selectors.
 
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.fargateProfileName\\"></a>
 
+\`\`\`java
+public java.lang.String getFargateProfileName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* generated
 
@@ -13855,6 +15803,10 @@ The name of the Fargate profile.
 ---
 
 ##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.podExecutionRole\\"></a>
+
+\`\`\`java
+public IRole getPodExecutionRole()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 - *Default:* a role will be automatically created
@@ -13871,6 +15823,10 @@ ECR image repositories.
 
 ##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.subnetSelection\\"></a>
 
+\`\`\`java
+public SubnetSelection getSubnetSelection()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
 - *Default:* all private subnets of the VPC are selected.
 
@@ -13883,6 +15839,10 @@ on Fargate are not assigned public IP addresses, so only private subnets
 ---
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.vpc\\"></a>
+
+\`\`\`java
+public IVpc getVpc()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
 - *Default:* all private subnets used by theEKS cluster
@@ -13915,6 +15875,10 @@ FargateProfileProps.builder()
 
 ##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.selectors\\"></a>
 
+\`\`\`java
+public java.util.List<Selector> getSelectors()
+\`\`\`
+
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.eks.Selector\`](#software.amazon.awscdk.services.eks.Selector)>
 
 The selectors to match for pods to use this Fargate profile.
@@ -13929,6 +15893,10 @@ At least one selector is required and you may specify up to five selectors.
 
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.fargateProfileName\\"></a>
 
+\`\`\`java
+public java.lang.String getFargateProfileName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* generated
 
@@ -13937,6 +15905,10 @@ The name of the Fargate profile.
 ---
 
 ##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.podExecutionRole\\"></a>
+
+\`\`\`java
+public IRole getPodExecutionRole()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 - *Default:* a role will be automatically created
@@ -13953,6 +15925,10 @@ ECR image repositories.
 
 ##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.subnetSelection\\"></a>
 
+\`\`\`java
+public SubnetSelection getSubnetSelection()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
 - *Default:* all private subnets of the VPC are selected.
 
@@ -13966,6 +15942,10 @@ on Fargate are not assigned public IP addresses, so only private subnets
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.vpc\\"></a>
 
+\`\`\`java
+public IVpc getVpc()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
 - *Default:* all private subnets used by theEKS cluster
 
@@ -13977,6 +15957,10 @@ By default, all private subnets are selected. You can customize this using
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.cluster\\"></a>
+
+\`\`\`java
+public Cluster getCluster()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.Cluster\`](#software.amazon.awscdk.services.eks.Cluster)
 
@@ -14010,6 +15994,10 @@ HelmChartOptions.builder()
 
 ##### \`chart\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.chart\\"></a>
 
+\`\`\`java
+public java.lang.String getChart()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The name of the chart.
@@ -14017,6 +16005,10 @@ The name of the chart.
 ---
 
 ##### \`createNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.createNamespace\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getCreateNamespace()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -14027,6 +16019,10 @@ create namespace if not exist.
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.namespace\\"></a>
 
+\`\`\`java
+public java.lang.String getNamespace()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* default
 
@@ -14036,6 +16032,10 @@ The Kubernetes namespace scope of the requests.
 
 ##### \`release\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.release\\"></a>
 
+\`\`\`java
+public java.lang.String getRelease()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
 
@@ -14044,6 +16044,10 @@ The name of the release.
 ---
 
 ##### \`repository\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.repository\\"></a>
+
+\`\`\`java
+public java.lang.String getRepository()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -14056,6 +16060,10 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.timeout\\"></a>
 
+\`\`\`java
+public Duration getTimeout()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.Duration\`](#software.amazon.awscdk.Duration)
 - *Default:* Duration.minutes(5)
 
@@ -14067,6 +16075,10 @@ Maximum 15 minutes.
 
 ##### \`values\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.values\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.Object> getValues()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
 - *Default:* No values are provided to the chart.
 
@@ -14076,6 +16088,10 @@ The values to be used by the chart.
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.version\\"></a>
 
+\`\`\`java
+public java.lang.String getVersion()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* If this is not specified, the latest version is installed
 
@@ -14084,6 +16100,10 @@ The chart version to install.
 ---
 
 ##### \`wait\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.wait\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getWait()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* Helm will not wait before marking release as successful
@@ -14117,6 +16137,10 @@ HelmChartProps.builder()
 
 ##### \`chart\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.chart\\"></a>
 
+\`\`\`java
+public java.lang.String getChart()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The name of the chart.
@@ -14124,6 +16148,10 @@ The name of the chart.
 ---
 
 ##### \`createNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.createNamespace\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getCreateNamespace()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -14134,6 +16162,10 @@ create namespace if not exist.
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.namespace\\"></a>
 
+\`\`\`java
+public java.lang.String getNamespace()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* default
 
@@ -14143,6 +16175,10 @@ The Kubernetes namespace scope of the requests.
 
 ##### \`release\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.release\\"></a>
 
+\`\`\`java
+public java.lang.String getRelease()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
 
@@ -14151,6 +16187,10 @@ The name of the release.
 ---
 
 ##### \`repository\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.repository\\"></a>
+
+\`\`\`java
+public java.lang.String getRepository()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -14163,6 +16203,10 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.timeout\\"></a>
 
+\`\`\`java
+public Duration getTimeout()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.Duration\`](#software.amazon.awscdk.Duration)
 - *Default:* Duration.minutes(5)
 
@@ -14174,6 +16218,10 @@ Maximum 15 minutes.
 
 ##### \`values\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.values\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.Object> getValues()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
 - *Default:* No values are provided to the chart.
 
@@ -14182,6 +16230,10 @@ The values to be used by the chart.
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* If this is not specified, the latest version is installed
@@ -14192,6 +16244,10 @@ The chart version to install.
 
 ##### \`wait\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.wait\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getWait()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* Helm will not wait before marking release as successful
 
@@ -14200,6 +16256,10 @@ Whether or not Helm should wait until all Pods, PVCs, Services, and minimum numb
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.cluster\\"></a>
+
+\`\`\`java
+public ICluster getCluster()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
 
@@ -14226,6 +16286,10 @@ KubernetesManifestOptions.builder()
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestOptions.property.prune\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getPrune()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* based on the prune option of the cluster, which is \`true\` unless
 otherwise specified.
@@ -14251,6 +16315,10 @@ empty.
 ---
 
 ##### \`skipValidation\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestOptions.property.skipValidation\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getSkipValidation()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
@@ -14279,6 +16347,10 @@ KubernetesManifestProps.builder()
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.prune\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getPrune()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* based on the prune option of the cluster, which is \`true\` unless
 otherwise specified.
@@ -14305,6 +16377,10 @@ empty.
 
 ##### \`skipValidation\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.skipValidation\\"></a>
 
+\`\`\`java
+public java.lang.Boolean getSkipValidation()
+\`\`\`
+
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
 
@@ -14313,6 +16389,10 @@ A flag to signify if the manifest validation should be skipped.
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.cluster\\"></a>
+
+\`\`\`java
+public ICluster getCluster()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
 
@@ -14323,6 +16403,10 @@ The EKS cluster to apply this manifest to.
 ---
 
 ##### \`manifest\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.manifest\\"></a>
+
+\`\`\`java
+public java.util.List<java.util.Map<java.lang.String, java.lang.Object>> getManifest()
+\`\`\`
 
 - *Type:* java.util.List<java.util.Map<java.lang.String, \`java.lang.Object\`>>
 
@@ -14337,6 +16421,10 @@ deleted, the resources in the manifest will be deleted through \`kubectl delete\
 ---
 
 ##### \`overwrite\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.overwrite\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOverwrite()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* false
@@ -14364,6 +16452,10 @@ KubernetesNetworkConfigProperty.builder()
 \`\`\`
 
 ##### \`serviceIpv4Cidr\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty.property.serviceIpv4Cidr\\"></a>
+
+\`\`\`java
+public java.lang.String getServiceIpv4Cidr()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -14394,6 +16486,10 @@ KubernetesObjectValueProps.builder()
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.cluster\\"></a>
 
+\`\`\`java
+public ICluster getCluster()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
 
 The EKS cluster to fetch attributes from.
@@ -14403,6 +16499,10 @@ The EKS cluster to fetch attributes from.
 ---
 
 ##### \`jsonPath\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.jsonPath\\"></a>
+
+\`\`\`java
+public java.lang.String getJsonPath()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -14414,6 +16514,10 @@ JSONPath to the specific value.
 
 ##### \`objectName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.objectName\\"></a>
 
+\`\`\`java
+public java.lang.String getObjectName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The name of the object to query.
@@ -14421,6 +16525,10 @@ The name of the object to query.
 ---
 
 ##### \`objectType\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.objectType\\"></a>
+
+\`\`\`java
+public java.lang.String getObjectType()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -14432,6 +16540,10 @@ The object type to query.
 
 ##### \`objectNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.objectNamespace\\"></a>
 
+\`\`\`java
+public java.lang.String getObjectNamespace()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* 'default'
 
@@ -14440,6 +16552,10 @@ The namespace the object belongs to.
 ---
 
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.timeout\\"></a>
+
+\`\`\`java
+public Duration getTimeout()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Duration\`](#software.amazon.awscdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -14469,6 +16585,10 @@ KubernetesPatchProps.builder()
 
 ##### \`applyPatch\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.applyPatch\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.Object> getApplyPatch()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
 
 The JSON object to pass to \`kubectl patch\` when the resource is created/updated.
@@ -14476,6 +16596,10 @@ The JSON object to pass to \`kubectl patch\` when the resource is created/update
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.cluster\\"></a>
+
+\`\`\`java
+public ICluster getCluster()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
 
@@ -14487,6 +16611,10 @@ The cluster to apply the patch to.
 
 ##### \`resourceName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.resourceName\\"></a>
 
+\`\`\`java
+public java.lang.String getResourceName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The full name of the resource to patch (e.g. \`deployment/coredns\`).
@@ -14495,6 +16623,10 @@ The full name of the resource to patch (e.g. \`deployment/coredns\`).
 
 ##### \`restorePatch\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.restorePatch\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.Object> getRestorePatch()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
 
 The JSON object to pass to \`kubectl patch\` when the resource is removed.
@@ -14502,6 +16634,10 @@ The JSON object to pass to \`kubectl patch\` when the resource is removed.
 ---
 
 ##### \`patchType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.patchType\\"></a>
+
+\`\`\`java
+public PatchType getPatchType()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.PatchType\`](#software.amazon.awscdk.services.eks.PatchType)
 - *Default:* PatchType.STRATEGIC
@@ -14513,6 +16649,10 @@ The default type used by \`kubectl patch\` is \\"strategic\\".
 ---
 
 ##### \`resourceNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.resourceNamespace\\"></a>
+
+\`\`\`java
+public java.lang.String getResourceNamespace()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* \\"default\\"
@@ -14538,6 +16678,10 @@ LabelProperty.builder()
 
 ##### \`key\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty.property.key\\"></a>
 
+\`\`\`java
+public java.lang.String getKey()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`CfnFargateProfile.LabelProperty.Key\`.
@@ -14547,6 +16691,10 @@ LabelProperty.builder()
 ---
 
 ##### \`value\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty.property.value\\"></a>
+
+\`\`\`java
+public java.lang.String getValue()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -14573,6 +16721,10 @@ LaunchTemplateSpec.builder()
 
 ##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.LaunchTemplateSpec.property.id\\"></a>
 
+\`\`\`java
+public java.lang.String getId()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The Launch template ID.
@@ -14580,6 +16732,10 @@ The Launch template ID.
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.LaunchTemplateSpec.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* the default version of the launch template
@@ -14606,6 +16762,10 @@ LaunchTemplateSpecificationProperty.builder()
 
 ##### \`id\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.id\\"></a>
 
+\`\`\`java
+public java.lang.String getId()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`CfnNodegroup.LaunchTemplateSpecificationProperty.Id\`.
@@ -14616,6 +16776,10 @@ LaunchTemplateSpecificationProperty.builder()
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.name\\"></a>
 
+\`\`\`java
+public java.lang.String getName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`CfnNodegroup.LaunchTemplateSpecificationProperty.Name\`.
@@ -14625,6 +16789,10 @@ LaunchTemplateSpecificationProperty.builder()
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -14665,6 +16833,10 @@ NodegroupOptions.builder()
 
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.amiType\\"></a>
 
+\`\`\`java
+public NodegroupAmiType getAmiType()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.NodegroupAmiType\`](#software.amazon.awscdk.services.eks.NodegroupAmiType)
 - *Default:* auto-determined from the instanceTypes property.
 
@@ -14674,6 +16846,10 @@ The AMI type for your node group.
 
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.capacityType\\"></a>
 
+\`\`\`java
+public CapacityType getCapacityType()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.CapacityType\`](#software.amazon.awscdk.services.eks.CapacityType)
 - *Default:* ON_DEMAND
 
@@ -14682,6 +16858,10 @@ The capacity type of the nodegroup.
 ---
 
 ##### \`desiredSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.desiredSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getDesiredSize()
+\`\`\`
 
 - *Type:* \`java.lang.Number\`
 - *Default:* 2
@@ -14695,6 +16875,10 @@ the nodewgroup will initially create \`minSize\` instances.
 
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.diskSize\\"></a>
 
+\`\`\`java
+public java.lang.Number getDiskSize()
+\`\`\`
+
 - *Type:* \`java.lang.Number\`
 - *Default:* 20
 
@@ -14703,6 +16887,10 @@ The root device disk size (in GiB) for your node group instances.
 ---
 
 ##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.forceUpdate\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getForceUpdate()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -14717,6 +16905,10 @@ running on the node.
 
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.instanceTypes\\"></a>
 
+\`\`\`java
+public java.util.List<InstanceType> getInstanceTypes()
+\`\`\`
+
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)>
 - *Default:* t3.medium will be used according to the cloudformation document.
 
@@ -14728,6 +16920,10 @@ The instance types to use for your node group.
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.labels\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getLabels()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 - *Default:* None
 
@@ -14736,6 +16932,10 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 ---
 
 ##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.launchTemplateSpec\\"></a>
+
+\`\`\`java
+public LaunchTemplateSpec getLaunchTemplateSpec()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.LaunchTemplateSpec\`](#software.amazon.awscdk.services.eks.LaunchTemplateSpec)
 - *Default:* no launch template
@@ -14748,6 +16948,10 @@ Launch template specification used for the nodegroup.
 
 ##### \`maxSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.maxSize\\"></a>
 
+\`\`\`java
+public java.lang.Number getMaxSize()
+\`\`\`
+
 - *Type:* \`java.lang.Number\`
 - *Default:* desiredSize
 
@@ -14758,6 +16962,10 @@ Managed node groups can support up to 100 nodes by default.
 ---
 
 ##### \`minSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.minSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getMinSize()
+\`\`\`
 
 - *Type:* \`java.lang.Number\`
 - *Default:* 1
@@ -14770,6 +16978,10 @@ This number must be greater than zero.
 
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.nodegroupName\\"></a>
 
+\`\`\`java
+public java.lang.String getNodegroupName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* resource ID
 
@@ -14778,6 +16990,10 @@ Name of the Nodegroup.
 ---
 
 ##### \`nodeRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.nodeRole\\"></a>
+
+\`\`\`java
+public IRole getNodeRole()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 - *Default:* None. Auto-generated if not specified.
@@ -14793,6 +17009,10 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.releaseVersion\\"></a>
 
+\`\`\`java
+public java.lang.String getReleaseVersion()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
 
@@ -14801,6 +17021,10 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 ---
 
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.remoteAccess\\"></a>
+
+\`\`\`java
+public NodegroupRemoteAccess getRemoteAccess()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.NodegroupRemoteAccess\`](#software.amazon.awscdk.services.eks.NodegroupRemoteAccess)
 - *Default:* disabled
@@ -14815,6 +17039,10 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.subnets\\"></a>
 
+\`\`\`java
+public SubnetSelection getSubnets()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
 - *Default:* private subnets
 
@@ -14828,6 +17056,10 @@ the name of your cluster.
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.tags\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getTags()
+\`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 - *Default:* None
@@ -14872,6 +17104,10 @@ NodegroupProps.builder()
 
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.amiType\\"></a>
 
+\`\`\`java
+public NodegroupAmiType getAmiType()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.NodegroupAmiType\`](#software.amazon.awscdk.services.eks.NodegroupAmiType)
 - *Default:* auto-determined from the instanceTypes property.
 
@@ -14881,6 +17117,10 @@ The AMI type for your node group.
 
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.capacityType\\"></a>
 
+\`\`\`java
+public CapacityType getCapacityType()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.CapacityType\`](#software.amazon.awscdk.services.eks.CapacityType)
 - *Default:* ON_DEMAND
 
@@ -14889,6 +17129,10 @@ The capacity type of the nodegroup.
 ---
 
 ##### \`desiredSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.desiredSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getDesiredSize()
+\`\`\`
 
 - *Type:* \`java.lang.Number\`
 - *Default:* 2
@@ -14902,6 +17146,10 @@ the nodewgroup will initially create \`minSize\` instances.
 
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.diskSize\\"></a>
 
+\`\`\`java
+public java.lang.Number getDiskSize()
+\`\`\`
+
 - *Type:* \`java.lang.Number\`
 - *Default:* 20
 
@@ -14910,6 +17158,10 @@ The root device disk size (in GiB) for your node group instances.
 ---
 
 ##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.forceUpdate\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getForceUpdate()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 - *Default:* true
@@ -14924,6 +17176,10 @@ running on the node.
 
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.instanceTypes\\"></a>
 
+\`\`\`java
+public java.util.List<InstanceType> getInstanceTypes()
+\`\`\`
+
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)>
 - *Default:* t3.medium will be used according to the cloudformation document.
 
@@ -14935,6 +17191,10 @@ The instance types to use for your node group.
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.labels\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getLabels()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 - *Default:* None
 
@@ -14943,6 +17203,10 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 ---
 
 ##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.launchTemplateSpec\\"></a>
+
+\`\`\`java
+public LaunchTemplateSpec getLaunchTemplateSpec()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.LaunchTemplateSpec\`](#software.amazon.awscdk.services.eks.LaunchTemplateSpec)
 - *Default:* no launch template
@@ -14955,6 +17219,10 @@ Launch template specification used for the nodegroup.
 
 ##### \`maxSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.maxSize\\"></a>
 
+\`\`\`java
+public java.lang.Number getMaxSize()
+\`\`\`
+
 - *Type:* \`java.lang.Number\`
 - *Default:* desiredSize
 
@@ -14965,6 +17233,10 @@ Managed node groups can support up to 100 nodes by default.
 ---
 
 ##### \`minSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.minSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getMinSize()
+\`\`\`
 
 - *Type:* \`java.lang.Number\`
 - *Default:* 1
@@ -14977,6 +17249,10 @@ This number must be greater than zero.
 
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.nodegroupName\\"></a>
 
+\`\`\`java
+public java.lang.String getNodegroupName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* resource ID
 
@@ -14985,6 +17261,10 @@ Name of the Nodegroup.
 ---
 
 ##### \`nodeRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.nodeRole\\"></a>
+
+\`\`\`java
+public IRole getNodeRole()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 - *Default:* None. Auto-generated if not specified.
@@ -15000,6 +17280,10 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.releaseVersion\\"></a>
 
+\`\`\`java
+public java.lang.String getReleaseVersion()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
 
@@ -15008,6 +17292,10 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 ---
 
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.remoteAccess\\"></a>
+
+\`\`\`java
+public NodegroupRemoteAccess getRemoteAccess()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.NodegroupRemoteAccess\`](#software.amazon.awscdk.services.eks.NodegroupRemoteAccess)
 - *Default:* disabled
@@ -15021,6 +17309,10 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 ---
 
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.subnets\\"></a>
+
+\`\`\`java
+public SubnetSelection getSubnets()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
 - *Default:* private subnets
@@ -15036,6 +17328,10 @@ the name of your cluster.
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.tags\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getTags()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 - *Default:* None
 
@@ -15048,6 +17344,10 @@ associated with the node group, such as the Amazon EC2 instances or subnets.
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.cluster\\"></a>
+
+\`\`\`java
+public ICluster getCluster()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
 
@@ -15074,6 +17374,10 @@ NodegroupRemoteAccess.builder()
 
 ##### \`sshKeyName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupRemoteAccess.property.sshKeyName\\"></a>
 
+\`\`\`java
+public java.lang.String getSshKeyName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The Amazon EC2 SSH key that provides access for SSH communication with the worker nodes in the managed node group.
@@ -15081,6 +17385,10 @@ The Amazon EC2 SSH key that provides access for SSH communication with the worke
 ---
 
 ##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupRemoteAccess.property.sourceSecurityGroups\\"></a>
+
+\`\`\`java
+public java.util.List<ISecurityGroup> getSourceSecurityGroups()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)>
 - *Default:* port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
@@ -15108,6 +17416,10 @@ OpenIdConnectProviderProps.builder()
 \`\`\`
 
 ##### \`url\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.OpenIdConnectProviderProps.property.url\\"></a>
+
+\`\`\`java
+public java.lang.String getUrl()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -15140,6 +17452,10 @@ ProviderProperty.builder()
 
 ##### \`keyArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.ProviderProperty.property.keyArn\\"></a>
 
+\`\`\`java
+public java.lang.String getKeyArn()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`CfnCluster.ProviderProperty.KeyArn\`.
@@ -15165,6 +17481,10 @@ RemoteAccessProperty.builder()
 
 ##### \`ec2SshKey\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty.property.ec2SshKey\\"></a>
 
+\`\`\`java
+public java.lang.String getEc2SshKey()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`CfnNodegroup.RemoteAccessProperty.Ec2SshKey\`.
@@ -15174,6 +17494,10 @@ RemoteAccessProperty.builder()
 ---
 
 ##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty.property.sourceSecurityGroups\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getSourceSecurityGroups()
+\`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
 
@@ -15200,6 +17524,10 @@ ResourcesVpcConfigProperty.builder()
 
 ##### \`subnetIds\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty.property.subnetIds\\"></a>
 
+\`\`\`java
+public java.util.List<java.lang.String> getSubnetIds()
+\`\`\`
+
 - *Type:* java.util.List<\`java.lang.String\`>
 
 \`CfnCluster.ResourcesVpcConfigProperty.SubnetIds\`.
@@ -15209,6 +17537,10 @@ ResourcesVpcConfigProperty.builder()
 ---
 
 ##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty.property.securityGroupIds\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getSecurityGroupIds()
+\`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
 
@@ -15236,6 +17568,10 @@ ScalingConfigProperty.builder()
 
 ##### \`desiredSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty.property.desiredSize\\"></a>
 
+\`\`\`java
+public java.lang.Number getDesiredSize()
+\`\`\`
+
 - *Type:* \`java.lang.Number\`
 
 \`CfnNodegroup.ScalingConfigProperty.DesiredSize\`.
@@ -15246,6 +17582,10 @@ ScalingConfigProperty.builder()
 
 ##### \`maxSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty.property.maxSize\\"></a>
 
+\`\`\`java
+public java.lang.Number getMaxSize()
+\`\`\`
+
 - *Type:* \`java.lang.Number\`
 
 \`CfnNodegroup.ScalingConfigProperty.MaxSize\`.
@@ -15255,6 +17595,10 @@ ScalingConfigProperty.builder()
 ---
 
 ##### \`minSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty.property.minSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getMinSize()
+\`\`\`
 
 - *Type:* \`java.lang.Number\`
 
@@ -15281,6 +17625,10 @@ Selector.builder()
 
 ##### \`namespace\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Selector.property.namespace\\"></a>
 
+\`\`\`java
+public java.lang.String getNamespace()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The Kubernetes namespace that the selector should match.
@@ -15292,6 +17640,10 @@ to target multiple namespaces.
 ---
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Selector.property.labels\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getLabels()
+\`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 - *Default:* all pods within the namespace will be selected.
@@ -15323,6 +17675,10 @@ SelectorProperty.builder()
 
 ##### \`namespace\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty.property.namespace\\"></a>
 
+\`\`\`java
+public java.lang.String getNamespace()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`CfnFargateProfile.SelectorProperty.Namespace\`.
@@ -15332,6 +17688,10 @@ SelectorProperty.builder()
 ---
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty.property.labels\\"></a>
+
+\`\`\`java
+public java.lang.Object getLabels()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty\`](#software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
 
@@ -15358,6 +17718,10 @@ ServiceAccountOptions.builder()
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountOptions.property.name\\"></a>
 
+\`\`\`java
+public java.lang.String getName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* If no name is given, it will use the id of the resource.
 
@@ -15366,6 +17730,10 @@ The name of the service account.
 ---
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountOptions.property.namespace\\"></a>
+
+\`\`\`java
+public java.lang.String getNamespace()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 - *Default:* \\"default\\"
@@ -15392,6 +17760,10 @@ ServiceAccountProps.builder()
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps.property.name\\"></a>
 
+\`\`\`java
+public java.lang.String getName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* If no name is given, it will use the id of the resource.
 
@@ -15401,6 +17773,10 @@ The name of the service account.
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps.property.namespace\\"></a>
 
+\`\`\`java
+public java.lang.String getNamespace()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* \\"default\\"
 
@@ -15409,6 +17785,10 @@ The namespace of the service account.
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps.property.cluster\\"></a>
+
+\`\`\`java
+public ICluster getCluster()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
 
@@ -15433,6 +17813,10 @@ ServiceLoadBalancerAddressOptions.builder()
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceLoadBalancerAddressOptions.property.namespace\\"></a>
 
+\`\`\`java
+public java.lang.String getNamespace()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 - *Default:* 'default'
 
@@ -15441,6 +17825,10 @@ The namespace the service belongs to.
 ---
 
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceLoadBalancerAddressOptions.property.timeout\\"></a>
+
+\`\`\`java
+public Duration getTimeout()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Duration\`](#software.amazon.awscdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -15467,6 +17855,10 @@ TaintProperty.builder()
 
 ##### \`effect\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty.property.effect\\"></a>
 
+\`\`\`java
+public java.lang.String getEffect()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`CfnNodegroup.TaintProperty.Effect\`.
@@ -15477,6 +17869,10 @@ TaintProperty.builder()
 
 ##### \`key\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty.property.key\\"></a>
 
+\`\`\`java
+public java.lang.String getKey()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 \`CfnNodegroup.TaintProperty.Key\`.
@@ -15486,6 +17882,10 @@ TaintProperty.builder()
 ---
 
 ##### \`value\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty.property.value\\"></a>
+
+\`\`\`java
+public java.lang.String getValue()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -15585,6 +17985,10 @@ CIDR blocks.
 
 ##### \`PRIVATE\` <a name=\\"software.amazon.awscdk.services.eks.EndpointAccess.property.PRIVATE\\"></a>
 
+\`\`\`java
+public EndpointAccess getPrivate()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
 
 The cluster endpoint is only accessible through your VPC.
@@ -15594,6 +17998,10 @@ Worker node traffic to the endpoint will stay within your VPC.
 ---
 
 ##### \`PUBLIC\` <a name=\\"software.amazon.awscdk.services.eks.EndpointAccess.property.PUBLIC\\"></a>
+
+\`\`\`java
+public EndpointAccess getPublic()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
 
@@ -15609,6 +18017,10 @@ access the public endpoint from.
 ---
 
 ##### \`PUBLIC_AND_PRIVATE\` <a name=\\"software.amazon.awscdk.services.eks.EndpointAccess.property.PUBLIC_AND_PRIVATE\\"></a>
+
+\`\`\`java
+public EndpointAccess getPublicAndPrivate()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
 
@@ -15650,6 +18062,10 @@ custom version number.
 
 ##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.version\\"></a>
 
+\`\`\`java
+public java.lang.String getVersion()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 cluster version number.
@@ -15660,6 +18076,10 @@ cluster version number.
 
 ##### \`V1_14\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_14\\"></a>
 
+\`\`\`java
+public KubernetesVersion getV114()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
 Kubernetes version 1.14.
@@ -15667,6 +18087,10 @@ Kubernetes version 1.14.
 ---
 
 ##### \`V1_15\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_15\\"></a>
+
+\`\`\`java
+public KubernetesVersion getV115()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
@@ -15676,6 +18100,10 @@ Kubernetes version 1.15.
 
 ##### \`V1_16\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_16\\"></a>
 
+\`\`\`java
+public KubernetesVersion getV116()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
 Kubernetes version 1.16.
@@ -15683,6 +18111,10 @@ Kubernetes version 1.16.
 ---
 
 ##### \`V1_17\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_17\\"></a>
+
+\`\`\`java
+public KubernetesVersion getV117()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
@@ -15692,6 +18124,10 @@ Kubernetes version 1.17.
 
 ##### \`V1_18\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_18\\"></a>
 
+\`\`\`java
+public KubernetesVersion getV118()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
 Kubernetes version 1.18.
@@ -15699,6 +18135,10 @@ Kubernetes version 1.18.
 ---
 
 ##### \`V1_19\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_19\\"></a>
+
+\`\`\`java
+public KubernetesVersion getV119()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
@@ -15811,6 +18251,10 @@ service account options.
 
 ##### \`node\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.node\\"></a>
 
+\`\`\`java
+public Node getNode()
+\`\`\`
+
 - *Type:* [\`software.constructs.Node\`](#software.constructs.Node)
 
 The tree node.
@@ -15818,6 +18262,10 @@ The tree node.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.env\\"></a>
+
+\`\`\`java
+public ResourceEnvironment getEnv()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.ResourceEnvironment\`](#software.amazon.awscdk.ResourceEnvironment)
 
@@ -15834,6 +18282,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.stack\\"></a>
 
+\`\`\`java
+public Stack getStack()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.Stack\`](#software.amazon.awscdk.Stack)
 
 The stack in which this resource is defined.
@@ -15842,11 +18294,19 @@ The stack in which this resource is defined.
 
 ##### \`connections\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.connections\\"></a>
 
+\`\`\`java
+public Connections getConnections()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.Connections\`](#software.amazon.awscdk.services.ec2.Connections)
 
 ---
 
 ##### \`clusterArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterArn\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterArn()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -15856,6 +18316,10 @@ The unique ARN assigned to the service by AWS in the form of arn:aws:eks:.
 
 ##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterCertificateAuthorityData\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterCertificateAuthorityData()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The certificate-authority-data for your cluster.
@@ -15863,6 +18327,10 @@ The certificate-authority-data for your cluster.
 ---
 
 ##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterEncryptionConfigKeyArn\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterEncryptionConfigKeyArn()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -15872,6 +18340,10 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterEndpoint\\"></a>
 
+\`\`\`java
+public java.lang.String getClusterEndpoint()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The API Server endpoint URL.
@@ -15879,6 +18351,10 @@ The API Server endpoint URL.
 ---
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -15888,6 +18364,10 @@ The physical name of the Cluster.
 
 ##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterSecurityGroup\\"></a>
 
+\`\`\`java
+public ISecurityGroup getClusterSecurityGroup()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
 
 The cluster security group that was created by Amazon EKS for the cluster.
@@ -15895,6 +18375,10 @@ The cluster security group that was created by Amazon EKS for the cluster.
 ---
 
 ##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterSecurityGroupId\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterSecurityGroupId()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -15904,6 +18388,10 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 
 ##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.openIdConnectProvider\\"></a>
 
+\`\`\`java
+public IOpenIdConnectProvider getOpenIdConnectProvider()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.iam.IOpenIdConnectProvider\`](#software.amazon.awscdk.services.iam.IOpenIdConnectProvider)
 
 The Open ID Connect Provider of the cluster used to configure Service Accounts.
@@ -15911,6 +18399,10 @@ The Open ID Connect Provider of the cluster used to configure Service Accounts.
 ---
 
 ##### \`prune\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune()
+\`\`\`
 
 - *Type:* \`java.lang.Boolean\`
 
@@ -15925,6 +18417,10 @@ apply\` operation with the \`--prune\` switch.
 
 ##### \`vpc\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.vpc\\"></a>
 
+\`\`\`java
+public IVpc getVpc()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
 
 The VPC in which this Cluster was created.
@@ -15933,6 +18429,10 @@ The VPC in which this Cluster was created.
 
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlEnvironment\\"></a>
 
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment()
+\`\`\`
+
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
 
 Custom environment variables when running \`kubectl\` against this cluster.
@@ -15940,6 +18440,10 @@ Custom environment variables when running \`kubectl\` against this cluster.
 ---
 
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlLayer\\"></a>
+
+\`\`\`java
+public ILayerVersion getKubectlLayer()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
 
@@ -15951,6 +18455,10 @@ If not defined, a default layer will be used.
 
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlMemory\\"></a>
 
+\`\`\`java
+public Size getKubectlMemory()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.Size\`](#software.amazon.awscdk.Size)
 
 Amount of memory to allocate to the provider's lambda function.
@@ -15958,6 +18466,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlPrivateSubnets\\"></a>
+
+\`\`\`java
+public java.util.List<ISubnet> getKubectlPrivateSubnets()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.ISubnet\`](#software.amazon.awscdk.services.ec2.ISubnet)>
 
@@ -15970,6 +18482,10 @@ publicly.
 
 ##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlRole\\"></a>
 
+\`\`\`java
+public IRole getKubectlRole()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
 
 An IAM role that can perform kubectl operations against this cluster.
@@ -15979,6 +18495,10 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 ---
 
 ##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlSecurityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getKubectlSecurityGroup()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
 
@@ -16002,6 +18522,10 @@ NodeGroup interface.
 
 ##### \`node\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.INodegroup.property.node\\"></a>
 
+\`\`\`java
+public Node getNode()
+\`\`\`
+
 - *Type:* [\`software.constructs.Node\`](#software.constructs.Node)
 
 The tree node.
@@ -16009,6 +18533,10 @@ The tree node.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.INodegroup.property.env\\"></a>
+
+\`\`\`java
+public ResourceEnvironment getEnv()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.ResourceEnvironment\`](#software.amazon.awscdk.ResourceEnvironment)
 
@@ -16025,6 +18553,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.INodegroup.property.stack\\"></a>
 
+\`\`\`java
+public Stack getStack()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.Stack\`](#software.amazon.awscdk.Stack)
 
 The stack in which this resource is defined.
@@ -16032,6 +18564,10 @@ The stack in which this resource is defined.
 ---
 
 ##### \`nodegroupName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.INodegroup.property.nodegroupName\\"></a>
+
+\`\`\`java
+public java.lang.String getNodegroupName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -16488,11 +19024,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.attr_arn\\"></a>
 
+\`\`\`python
+attr_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.tags\\"></a>
+
+\`\`\`python
+tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.TagManager\`](#aws_cdk.core.TagManager)
 
@@ -16504,6 +19048,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repository_catalog_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_catalog_data\\"></a>
 
+\`\`\`python
+repository_catalog_data: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -16514,6 +19062,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -16523,6 +19075,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -16535,6 +19091,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -16611,11 +19171,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.attr_registry_id\\"></a>
 
+\`\`\`python
+attr_registry_id: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.policy_text\\"></a>
+
+\`\`\`python
+policy_text: typing.Any
+\`\`\`
 
 - *Type:* \`typing.Any\`
 
@@ -16628,6 +19196,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -16704,11 +19276,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.attr_registry_id\\"></a>
 
+\`\`\`python
+attr_registry_id: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.replication_configuration\\"></a>
+
+\`\`\`python
+replication_configuration: typing.Union[IResolvable, ReplicationConfigurationProperty]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -16721,6 +19301,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -16863,17 +19447,29 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.attr_arn\\"></a>
 
+\`\`\`python
+attr_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`attr_repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.attr_repository_uri\\"></a>
 
+\`\`\`python
+attr_repository_uri: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.tags\\"></a>
+
+\`\`\`python
+tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.TagManager\`](#aws_cdk.core.TagManager)
 
@@ -16885,6 +19481,10 @@ tree inspector to collect and process attributes.
 
 ##### \`encryption_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.encryption_configuration\\"></a>
 
+\`\`\`python
+encryption_configuration: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -16894,6 +19494,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`image_scanning_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.image_scanning_configuration\\"></a>
+
+\`\`\`python
+image_scanning_configuration: typing.Any
+\`\`\`
 
 - *Type:* \`typing.Any\`
 
@@ -16905,6 +19509,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -16914,6 +19522,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.image_tag_mutability\\"></a>
+
+\`\`\`python
+image_tag_mutability: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -16925,6 +19537,10 @@ tree inspector to collect and process attributes.
 
 ##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.lifecycle_policy\\"></a>
 
+\`\`\`python
+lifecycle_policy: typing.Union[IResolvable, LifecyclePolicyProperty]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
 \`AWS::ECR::Repository.LifecyclePolicy\`.
@@ -16934,6 +19550,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -16946,6 +19566,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -17275,6 +19899,10 @@ aws_cdk.aws_ecr.Repository.from_repository_name(
 
 ##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.property.repository_arn\\"></a>
 
+\`\`\`python
+repository_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The ARN of the repository.
@@ -17282,6 +19910,10 @@ The ARN of the repository.
 ---
 
 ##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -17742,6 +20374,10 @@ Optional image tag.
 
 ##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_arn\\"></a>
 
+\`\`\`python
+repository_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The ARN of the repository.
@@ -17750,6 +20386,10 @@ The ARN of the repository.
 
 ##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_name\\"></a>
 
+\`\`\`python
+repository_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The name of the repository.
@@ -17757,6 +20397,10 @@ The name of the repository.
 ---
 
 ##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_uri\\"></a>
+
+\`\`\`python
+repository_uri: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -17790,6 +20434,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 
 ##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_catalog_data\\"></a>
 
+\`\`\`python
+repository_catalog_data: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -17799,6 +20447,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 ---
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -17810,6 +20462,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 
 ##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -17819,6 +20475,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.tags\\"></a>
+
+\`\`\`python
+tags: typing.List[CfnTag]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -17846,6 +20506,10 @@ aws_cdk.aws_ecr.CfnRegistryPolicyProps(
 
 ##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.property.policy_text\\"></a>
 
+\`\`\`python
+policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::RegistryPolicy.PolicyText\`.
@@ -17871,6 +20535,10 @@ aws_cdk.aws_ecr.CfnReplicationConfigurationProps(
 \`\`\`
 
 ##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.property.replication_configuration\\"></a>
+
+\`\`\`python
+replication_configuration: typing.Union[IResolvable, ReplicationConfigurationProperty]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -17904,6 +20572,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 
 ##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.encryption_configuration\\"></a>
 
+\`\`\`python
+encryption_configuration: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -17913,6 +20585,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 ---
 
 ##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.image_scanning_configuration\\"></a>
+
+\`\`\`python
+image_scanning_configuration: typing.Any
+\`\`\`
 
 - *Type:* \`typing.Any\`
 
@@ -17924,6 +20600,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 
 ##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.image_tag_mutability\\"></a>
 
+\`\`\`python
+image_tag_mutability: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::ECR::Repository.ImageTagMutability\`.
@@ -17933,6 +20613,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 ---
 
 ##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.lifecycle_policy\\"></a>
+
+\`\`\`python
+lifecycle_policy: typing.Union[IResolvable, LifecyclePolicyProperty]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
@@ -17944,6 +20628,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.repository_name\\"></a>
 
+\`\`\`python
+repository_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::ECR::Repository.RepositoryName\`.
@@ -17954,6 +20642,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 
 ##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -17963,6 +20655,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.tags\\"></a>
+
+\`\`\`python
+tags: typing.List[CfnTag]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -17989,6 +20685,10 @@ aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty(
 
 ##### \`lifecycle_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.property.lifecycle_policy_text\\"></a>
 
+\`\`\`python
+lifecycle_policy_text: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnRepository.LifecyclePolicyProperty.LifecyclePolicyText\`.
@@ -17998,6 +20698,10 @@ aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty(
 ---
 
 ##### \`registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.property.registry_id\\"></a>
+
+\`\`\`python
+registry_id: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -18028,6 +20732,10 @@ aws_cdk.aws_ecr.LifecycleRule(
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.description\\"></a>
 
+\`\`\`python
+description: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* No description
 
@@ -18036,6 +20744,10 @@ Describes the purpose of the rule.
 ---
 
 ##### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.max_image_age\\"></a>
+
+\`\`\`python
+max_image_age: Duration
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.Duration\`](#aws_cdk.core.Duration)
 
@@ -18047,6 +20759,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ##### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.max_image_count\\"></a>
 
+\`\`\`python
+max_image_count: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 
 The maximum number of images to retain.
@@ -18056,6 +20772,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 ---
 
 ##### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.rule_priority\\"></a>
+
+\`\`\`python
+rule_priority: typing.Union[int, float]
+\`\`\`
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* Automatically assigned
@@ -18075,6 +20795,10 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ##### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.tag_prefix_list\\"></a>
 
+\`\`\`python
+tag_prefix_list: typing.List[str]
+\`\`\`
+
 - *Type:* typing.List[\`str\`]
 
 Select images that have ALL the given prefixes in their tag.
@@ -18084,6 +20808,10 @@ Only if tagStatus == TagStatus.Tagged
 ---
 
 ##### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.tag_status\\"></a>
+
+\`\`\`python
+tag_status: TagStatus
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ecr.TagStatus\`](#aws_cdk.aws_ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -18115,6 +20843,10 @@ aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions(
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
+\`\`\`python
+description: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* No description
 
@@ -18123,6 +20855,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.event_pattern\\"></a>
+
+\`\`\`python
+event_pattern: EventPattern
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -18139,6 +20875,10 @@ on top of that filtering.
 
 ##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.rule_name\\"></a>
 
+\`\`\`python
+rule_name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -18148,6 +20888,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
+\`\`\`python
+target: IRuleTarget
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -18156,6 +20900,10 @@ The target to register for the event.
 ---
 
 ##### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.image_tag\\"></a>
+
+\`\`\`python
+image_tag: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -18184,6 +20932,10 @@ aws_cdk.aws_ecr.OnImageScanCompletedOptions(
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
+\`\`\`python
+description: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* No description
 
@@ -18192,6 +20944,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.event_pattern\\"></a>
+
+\`\`\`python
+event_pattern: EventPattern
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -18208,6 +20964,10 @@ on top of that filtering.
 
 ##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.rule_name\\"></a>
 
+\`\`\`python
+rule_name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -18217,6 +20977,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
+\`\`\`python
+target: IRuleTarget
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -18225,6 +20989,10 @@ The target to register for the event.
 ---
 
 ##### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.image_tags\\"></a>
+
+\`\`\`python
+image_tags: typing.List[str]
+\`\`\`
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -18251,6 +21019,10 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty(
 
 ##### \`rules\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
+\`\`\`python
+rules: typing.Union[IResolvable, typing.List[typing.Union[IResolvable, ReplicationRuleProperty]]]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), typing.List[typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty)]]]
 
 \`CfnReplicationConfiguration.ReplicationConfigurationProperty.Rules\`.
@@ -18276,6 +21048,10 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty(
 
 ##### \`region\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
+\`\`\`python
+region: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnReplicationConfiguration.ReplicationDestinationProperty.Region\`.
@@ -18285,6 +21061,10 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty(
 ---
 
 ##### \`registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registry_id\\"></a>
+
+\`\`\`python
+registry_id: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -18310,6 +21090,10 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty(
 
 ##### \`destinations\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
+\`\`\`python
+destinations: typing.Union[IResolvable, typing.List[typing.Union[IResolvable, ReplicationDestinationProperty]]]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), typing.List[typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)]]]
 
 \`CfnReplicationConfiguration.ReplicationRuleProperty.Destinations\`.
@@ -18333,11 +21117,19 @@ aws_cdk.aws_ecr.RepositoryAttributes(
 
 ##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.property.repository_arn\\"></a>
 
+\`\`\`python
+repository_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -18362,6 +21154,10 @@ aws_cdk.aws_ecr.RepositoryProps(
 
 ##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.image_scan_on_push\\"></a>
 
+\`\`\`python
+image_scan_on_push: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -18370,6 +21166,10 @@ Enable the scan on push when creating the repository.
 ---
 
 ##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.image_tag_mutability\\"></a>
+
+\`\`\`python
+image_tag_mutability: TagMutability
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ecr.TagMutability\`](#aws_cdk.aws_ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -18382,6 +21182,10 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.lifecycle_registry_id\\"></a>
 
+\`\`\`python
+lifecycle_registry_id: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* The default registry is assumed.
 
@@ -18393,6 +21197,10 @@ The AWS account ID associated with the registry that contains the repository.
 
 ##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.lifecycle_rules\\"></a>
 
+\`\`\`python
+lifecycle_rules: typing.List[LifecycleRule]
+\`\`\`
+
 - *Type:* typing.List[[\`aws_cdk.aws_ecr.LifecycleRule\`](#aws_cdk.aws_ecr.LifecycleRule)]
 - *Default:* No life cycle rules
 
@@ -18402,6 +21210,10 @@ Life cycle rules to apply to this registry.
 
 ##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.removal_policy\\"></a>
 
+\`\`\`python
+removal_policy: RemovalPolicy
+\`\`\`
+
 - *Type:* [\`aws_cdk.core.RemovalPolicy\`](#aws_cdk.core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
 
@@ -18410,6 +21222,10 @@ Determine what happens to the repository when the resource/stack is deleted.
 ---
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name.
@@ -18853,6 +21669,10 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 ##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.node\\"></a>
 
+\`\`\`python
+node: ConstructNode
+\`\`\`
+
 - *Type:* [\`aws_cdk.core.ConstructNode\`](#aws_cdk.core.ConstructNode)
 
 The construct tree node for this construct.
@@ -18860,6 +21680,10 @@ The construct tree node for this construct.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.env\\"></a>
+
+\`\`\`python
+env: ResourceEnvironment
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.ResourceEnvironment\`](#aws_cdk.core.ResourceEnvironment)
 
@@ -18876,6 +21700,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.stack\\"></a>
 
+\`\`\`python
+stack: Stack
+\`\`\`
+
 - *Type:* [\`aws_cdk.core.Stack\`](#aws_cdk.core.Stack)
 
 The stack in which this resource is defined.
@@ -18883,6 +21711,10 @@ The stack in which this resource is defined.
 ---
 
 ##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_arn\\"></a>
+
+\`\`\`python
+repository_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -18892,6 +21724,10 @@ The ARN of the repository.
 
 ##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_name\\"></a>
 
+\`\`\`python
+repository_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The name of the repository.
@@ -18899,6 +21735,10 @@ The name of the repository.
 ---
 
 ##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_uri\\"></a>
+
+\`\`\`python
+repository_uri: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -19177,11 +22017,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.attr_arn\\"></a>
 
+\`\`\`python
+attr_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.tags\\"></a>
+
+\`\`\`python
+tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.TagManager\`](#aws_cdk.core.TagManager)
 
@@ -19193,6 +22041,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repository_catalog_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_catalog_data\\"></a>
 
+\`\`\`python
+repository_catalog_data: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -19203,6 +22055,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -19212,6 +22068,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -19224,6 +22084,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -19300,11 +22164,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.attr_registry_id\\"></a>
 
+\`\`\`python
+attr_registry_id: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.policy_text\\"></a>
+
+\`\`\`python
+policy_text: typing.Any
+\`\`\`
 
 - *Type:* \`typing.Any\`
 
@@ -19317,6 +22189,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -19393,11 +22269,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.attr_registry_id\\"></a>
 
+\`\`\`python
+attr_registry_id: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.replication_configuration\\"></a>
+
+\`\`\`python
+replication_configuration: typing.Union[IResolvable, ReplicationConfigurationProperty]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -19410,6 +22294,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -19552,17 +22440,29 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.attr_arn\\"></a>
 
+\`\`\`python
+attr_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`attr_repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.attr_repository_uri\\"></a>
 
+\`\`\`python
+attr_repository_uri: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.tags\\"></a>
+
+\`\`\`python
+tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.TagManager\`](#aws_cdk.core.TagManager)
 
@@ -19574,6 +22474,10 @@ tree inspector to collect and process attributes.
 
 ##### \`encryption_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.encryption_configuration\\"></a>
 
+\`\`\`python
+encryption_configuration: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -19583,6 +22487,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`image_scanning_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.image_scanning_configuration\\"></a>
+
+\`\`\`python
+image_scanning_configuration: typing.Any
+\`\`\`
 
 - *Type:* \`typing.Any\`
 
@@ -19594,6 +22502,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repository_policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -19603,6 +22515,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.image_tag_mutability\\"></a>
+
+\`\`\`python
+image_tag_mutability: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -19614,6 +22530,10 @@ tree inspector to collect and process attributes.
 
 ##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.lifecycle_policy\\"></a>
 
+\`\`\`python
+lifecycle_policy: typing.Union[IResolvable, LifecyclePolicyProperty]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
 \`AWS::ECR::Repository.LifecyclePolicy\`.
@@ -19623,6 +22543,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -19635,6 +22559,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -19964,6 +22892,10 @@ aws_cdk.aws_ecr.Repository.from_repository_name(
 
 ##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.property.repository_arn\\"></a>
 
+\`\`\`python
+repository_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The ARN of the repository.
@@ -19971,6 +22903,10 @@ The ARN of the repository.
 ---
 
 ##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.Repository.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -20431,6 +23367,10 @@ Optional image tag.
 
 ##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_arn\\"></a>
 
+\`\`\`python
+repository_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The ARN of the repository.
@@ -20439,6 +23379,10 @@ The ARN of the repository.
 
 ##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_name\\"></a>
 
+\`\`\`python
+repository_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The name of the repository.
@@ -20446,6 +23390,10 @@ The name of the repository.
 ---
 
 ##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryBase.property.repository_uri\\"></a>
+
+\`\`\`python
+repository_uri: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -20479,6 +23427,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 
 ##### \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_catalog_data\\"></a>
 
+\`\`\`python
+repository_catalog_data: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -20488,6 +23440,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 ---
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -20499,6 +23455,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 
 ##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -20508,6 +23468,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.tags\\"></a>
+
+\`\`\`python
+tags: typing.List[CfnTag]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -20535,6 +23499,10 @@ aws_cdk.aws_ecr.CfnRegistryPolicyProps(
 
 ##### \`policy_text\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicyProps.property.policy_text\\"></a>
 
+\`\`\`python
+policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::RegistryPolicy.PolicyText\`.
@@ -20560,6 +23528,10 @@ aws_cdk.aws_ecr.CfnReplicationConfigurationProps(
 \`\`\`
 
 ##### \`replication_configuration\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfigurationProps.property.replication_configuration\\"></a>
+
+\`\`\`python
+replication_configuration: typing.Union[IResolvable, ReplicationConfigurationProperty]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)]
 
@@ -20593,6 +23565,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 
 ##### \`encryption_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.encryption_configuration\\"></a>
 
+\`\`\`python
+encryption_configuration: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -20602,6 +23578,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 ---
 
 ##### \`image_scanning_configuration\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.image_scanning_configuration\\"></a>
+
+\`\`\`python
+image_scanning_configuration: typing.Any
+\`\`\`
 
 - *Type:* \`typing.Any\`
 
@@ -20613,6 +23593,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 
 ##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.image_tag_mutability\\"></a>
 
+\`\`\`python
+image_tag_mutability: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::ECR::Repository.ImageTagMutability\`.
@@ -20622,6 +23606,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 ---
 
 ##### \`lifecycle_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.lifecycle_policy\\"></a>
+
+\`\`\`python
+lifecycle_policy: typing.Union[IResolvable, LifecyclePolicyProperty]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty\`](#aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty)]
 
@@ -20633,6 +23621,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.repository_name\\"></a>
 
+\`\`\`python
+repository_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::ECR::Repository.RepositoryName\`.
@@ -20643,6 +23635,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 
 ##### \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -20652,6 +23648,10 @@ aws_cdk.aws_ecr.CfnRepositoryProps(
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepositoryProps.property.tags\\"></a>
+
+\`\`\`python
+tags: typing.List[CfnTag]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -20678,6 +23678,10 @@ aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty(
 
 ##### \`lifecycle_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.property.lifecycle_policy_text\\"></a>
 
+\`\`\`python
+lifecycle_policy_text: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnRepository.LifecyclePolicyProperty.LifecyclePolicyText\`.
@@ -20687,6 +23691,10 @@ aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty(
 ---
 
 ##### \`registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnRepository.LifecyclePolicyProperty.property.registry_id\\"></a>
+
+\`\`\`python
+registry_id: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -20717,6 +23725,10 @@ aws_cdk.aws_ecr.LifecycleRule(
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.description\\"></a>
 
+\`\`\`python
+description: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* No description
 
@@ -20725,6 +23737,10 @@ Describes the purpose of the rule.
 ---
 
 ##### \`max_image_age\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.max_image_age\\"></a>
+
+\`\`\`python
+max_image_age: Duration
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.Duration\`](#aws_cdk.core.Duration)
 
@@ -20736,6 +23752,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ##### \`max_image_count\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.max_image_count\\"></a>
 
+\`\`\`python
+max_image_count: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 
 The maximum number of images to retain.
@@ -20745,6 +23765,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 ---
 
 ##### \`rule_priority\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.rule_priority\\"></a>
+
+\`\`\`python
+rule_priority: typing.Union[int, float]
+\`\`\`
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* Automatically assigned
@@ -20764,6 +23788,10 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ##### \`tag_prefix_list\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.tag_prefix_list\\"></a>
 
+\`\`\`python
+tag_prefix_list: typing.List[str]
+\`\`\`
+
 - *Type:* typing.List[\`str\`]
 
 Select images that have ALL the given prefixes in their tag.
@@ -20773,6 +23801,10 @@ Only if tagStatus == TagStatus.Tagged
 ---
 
 ##### \`tag_status\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.LifecycleRule.property.tag_status\\"></a>
+
+\`\`\`python
+tag_status: TagStatus
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ecr.TagStatus\`](#aws_cdk.aws_ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -20804,6 +23836,10 @@ aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions(
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
+\`\`\`python
+description: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* No description
 
@@ -20812,6 +23848,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.event_pattern\\"></a>
+
+\`\`\`python
+event_pattern: EventPattern
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -20828,6 +23868,10 @@ on top of that filtering.
 
 ##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.rule_name\\"></a>
 
+\`\`\`python
+rule_name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -20837,6 +23881,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
+\`\`\`python
+target: IRuleTarget
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -20845,6 +23893,10 @@ The target to register for the event.
 ---
 
 ##### \`image_tag\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.property.image_tag\\"></a>
+
+\`\`\`python
+image_tag: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* Watch changes to all tags
@@ -20873,6 +23925,10 @@ aws_cdk.aws_ecr.OnImageScanCompletedOptions(
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
+\`\`\`python
+description: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* No description
 
@@ -20881,6 +23937,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`event_pattern\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.event_pattern\\"></a>
+
+\`\`\`python
+event_pattern: EventPattern
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_events.EventPattern\`](#aws_cdk.aws_events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -20897,6 +23957,10 @@ on top of that filtering.
 
 ##### \`rule_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.rule_name\\"></a>
 
+\`\`\`python
+rule_name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -20906,6 +23970,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
+\`\`\`python
+target: IRuleTarget
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_events.IRuleTarget\`](#aws_cdk.aws_events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -20914,6 +23982,10 @@ The target to register for the event.
 ---
 
 ##### \`image_tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.OnImageScanCompletedOptions.property.image_tags\\"></a>
+
+\`\`\`python
+image_tags: typing.List[str]
+\`\`\`
 
 - *Type:* typing.List[\`str\`]
 - *Default:* Watch the changes to the repository with all image tags
@@ -20940,6 +24012,10 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty(
 
 ##### \`rules\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
+\`\`\`python
+rules: typing.Union[IResolvable, typing.List[typing.Union[IResolvable, ReplicationRuleProperty]]]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), typing.List[typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty)]]]
 
 \`CfnReplicationConfiguration.ReplicationConfigurationProperty.Rules\`.
@@ -20965,6 +24041,10 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty(
 
 ##### \`region\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
+\`\`\`python
+region: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnReplicationConfiguration.ReplicationDestinationProperty.Region\`.
@@ -20974,6 +24054,10 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty(
 ---
 
 ##### \`registry_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registry_id\\"></a>
+
+\`\`\`python
+registry_id: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -20999,6 +24083,10 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty(
 
 ##### \`destinations\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
+\`\`\`python
+destinations: typing.Union[IResolvable, typing.List[typing.Union[IResolvable, ReplicationDestinationProperty]]]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), typing.List[typing.Union[[\`aws_cdk.core.IResolvable\`](#aws_cdk.core.IResolvable), [\`aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#aws_cdk.aws_ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)]]]
 
 \`CfnReplicationConfiguration.ReplicationRuleProperty.Destinations\`.
@@ -21022,11 +24110,19 @@ aws_cdk.aws_ecr.RepositoryAttributes(
 
 ##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.property.repository_arn\\"></a>
 
+\`\`\`python
+repository_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryAttributes.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -21051,6 +24147,10 @@ aws_cdk.aws_ecr.RepositoryProps(
 
 ##### \`image_scan_on_push\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.image_scan_on_push\\"></a>
 
+\`\`\`python
+image_scan_on_push: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -21059,6 +24159,10 @@ Enable the scan on push when creating the repository.
 ---
 
 ##### \`image_tag_mutability\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.image_tag_mutability\\"></a>
+
+\`\`\`python
+image_tag_mutability: TagMutability
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ecr.TagMutability\`](#aws_cdk.aws_ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -21071,6 +24175,10 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ##### \`lifecycle_registry_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.lifecycle_registry_id\\"></a>
 
+\`\`\`python
+lifecycle_registry_id: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* The default registry is assumed.
 
@@ -21082,6 +24190,10 @@ The AWS account ID associated with the registry that contains the repository.
 
 ##### \`lifecycle_rules\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.lifecycle_rules\\"></a>
 
+\`\`\`python
+lifecycle_rules: typing.List[LifecycleRule]
+\`\`\`
+
 - *Type:* typing.List[[\`aws_cdk.aws_ecr.LifecycleRule\`](#aws_cdk.aws_ecr.LifecycleRule)]
 - *Default:* No life cycle rules
 
@@ -21091,6 +24203,10 @@ Life cycle rules to apply to this registry.
 
 ##### \`removal_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.removal_policy\\"></a>
 
+\`\`\`python
+removal_policy: RemovalPolicy
+\`\`\`
+
 - *Type:* [\`aws_cdk.core.RemovalPolicy\`](#aws_cdk.core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
 
@@ -21099,6 +24215,10 @@ Determine what happens to the repository when the resource/stack is deleted.
 ---
 
 ##### \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.RepositoryProps.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name.
@@ -21542,6 +24662,10 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 ##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.node\\"></a>
 
+\`\`\`python
+node: ConstructNode
+\`\`\`
+
 - *Type:* [\`aws_cdk.core.ConstructNode\`](#aws_cdk.core.ConstructNode)
 
 The construct tree node for this construct.
@@ -21549,6 +24673,10 @@ The construct tree node for this construct.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.env\\"></a>
+
+\`\`\`python
+env: ResourceEnvironment
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.ResourceEnvironment\`](#aws_cdk.core.ResourceEnvironment)
 
@@ -21565,6 +24693,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.stack\\"></a>
 
+\`\`\`python
+stack: Stack
+\`\`\`
+
 - *Type:* [\`aws_cdk.core.Stack\`](#aws_cdk.core.Stack)
 
 The stack in which this resource is defined.
@@ -21572,6 +24704,10 @@ The stack in which this resource is defined.
 ---
 
 ##### \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_arn\\"></a>
+
+\`\`\`python
+repository_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -21581,6 +24717,10 @@ The ARN of the repository.
 
 ##### \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_name\\"></a>
 
+\`\`\`python
+repository_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The name of the repository.
@@ -21588,6 +24728,10 @@ The name of the repository.
 ---
 
 ##### \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_uri\\"></a>
+
+\`\`\`python
+repository_uri: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -23144,11 +26288,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.attr_arn\\"></a>
 
+\`\`\`python
+attr_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.tags\\"></a>
+
+\`\`\`python
+tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws_cdk.TagManager\`](#aws_cdk.TagManager)
 
@@ -23160,6 +26312,10 @@ tree inspector to collect and process attributes.
 
 ##### \`addon_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.addon_name\\"></a>
 
+\`\`\`python
+addon_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Addon.AddonName\`.
@@ -23169,6 +26325,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.cluster_name\\"></a>
+
+\`\`\`python
+cluster_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -23180,6 +26340,10 @@ tree inspector to collect and process attributes.
 
 ##### \`addon_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.addon_version\\"></a>
 
+\`\`\`python
+addon_version: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Addon.AddonVersion\`.
@@ -23190,6 +26354,10 @@ tree inspector to collect and process attributes.
 
 ##### \`resolve_conflicts\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.resolve_conflicts\\"></a>
 
+\`\`\`python
+resolve_conflicts: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Addon.ResolveConflicts\`.
@@ -23199,6 +26367,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`service_account_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddon.property.service_account_role_arn\\"></a>
+
+\`\`\`python
+service_account_role_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -23211,6 +26383,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnAddon.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -23342,11 +26518,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.attr_arn\\"></a>
 
+\`\`\`python
+attr_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`attr_certificate_authority_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.attr_certificate_authority_data\\"></a>
+
+\`\`\`python
+attr_certificate_authority_data: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -23354,11 +26538,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_cluster_security_group_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.attr_cluster_security_group_id\\"></a>
 
+\`\`\`python
+attr_cluster_security_group_id: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`attr_encryption_config_key_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.attr_encryption_config_key_arn\\"></a>
+
+\`\`\`python
+attr_encryption_config_key_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -23366,17 +26558,29 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_endpoint\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.attr_endpoint\\"></a>
 
+\`\`\`python
+attr_endpoint: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`attr_open_id_connect_issuer_url\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.attr_open_id_connect_issuer_url\\"></a>
 
+\`\`\`python
+attr_open_id_connect_issuer_url: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`resources_vpc_config\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.resources_vpc_config\\"></a>
+
+\`\`\`python
+resources_vpc_config: typing.Union[ResourcesVpcConfigProperty, IResolvable]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -23388,6 +26592,10 @@ tree inspector to collect and process attributes.
 
 ##### \`role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.role_arn\\"></a>
 
+\`\`\`python
+role_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Cluster.RoleArn\`.
@@ -23397,6 +26605,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`encryption_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.encryption_config\\"></a>
+
+\`\`\`python
+encryption_config: typing.Union[IResolvable, typing.List[typing.Union[EncryptionConfigProperty, IResolvable]]]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
@@ -23408,6 +26620,10 @@ tree inspector to collect and process attributes.
 
 ##### \`kubernetes_network_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.kubernetes_network_config\\"></a>
 
+\`\`\`python
+kubernetes_network_config: typing.Union[KubernetesNetworkConfigProperty, IResolvable]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
 \`AWS::EKS::Cluster.KubernetesNetworkConfig\`.
@@ -23418,6 +26634,10 @@ tree inspector to collect and process attributes.
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.name\\"></a>
 
+\`\`\`python
+name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Cluster.Name\`.
@@ -23427,6 +26647,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.property.version\\"></a>
+
+\`\`\`python
+version: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -23439,6 +26663,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnCluster.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -23570,11 +26798,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.attr_arn\\"></a>
 
+\`\`\`python
+attr_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.tags\\"></a>
+
+\`\`\`python
+tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws_cdk.TagManager\`](#aws_cdk.TagManager)
 
@@ -23586,6 +26822,10 @@ tree inspector to collect and process attributes.
 
 ##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.cluster_name\\"></a>
 
+\`\`\`python
+cluster_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::FargateProfile.ClusterName\`.
@@ -23595,6 +26835,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`pod_execution_role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.pod_execution_role_arn\\"></a>
+
+\`\`\`python
+pod_execution_role_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -23606,6 +26850,10 @@ tree inspector to collect and process attributes.
 
 ##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.selectors\\"></a>
 
+\`\`\`python
+selectors: typing.Union[IResolvable, typing.List[typing.Union[SelectorProperty, IResolvable]]]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
 \`AWS::EKS::FargateProfile.Selectors\`.
@@ -23616,6 +26864,10 @@ tree inspector to collect and process attributes.
 
 ##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.fargate_profile_name\\"></a>
 
+\`\`\`python
+fargate_profile_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::FargateProfile.FargateProfileName\`.
@@ -23625,6 +26877,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.subnets\\"></a>
+
+\`\`\`python
+subnets: typing.List[str]
+\`\`\`
 
 - *Type:* typing.List[\`str\`]
 
@@ -23637,6 +26893,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -23889,11 +27149,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.attr_arn\\"></a>
 
+\`\`\`python
+attr_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`attr_cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.attr_cluster_name\\"></a>
+
+\`\`\`python
+attr_cluster_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -23901,11 +27169,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attr_nodegroup_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.attr_nodegroup_name\\"></a>
 
+\`\`\`python
+attr_nodegroup_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.tags\\"></a>
+
+\`\`\`python
+tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws_cdk.TagManager\`](#aws_cdk.TagManager)
 
@@ -23917,6 +27193,10 @@ tree inspector to collect and process attributes.
 
 ##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.cluster_name\\"></a>
 
+\`\`\`python
+cluster_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Nodegroup.ClusterName\`.
@@ -23926,6 +27206,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`labels\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.labels\\"></a>
+
+\`\`\`python
+labels: typing.Any
+\`\`\`
 
 - *Type:* \`typing.Any\`
 
@@ -23937,6 +27221,10 @@ tree inspector to collect and process attributes.
 
 ##### \`node_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.node_role\\"></a>
 
+\`\`\`python
+node_role: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Nodegroup.NodeRole\`.
@@ -23946,6 +27234,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`subnets\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.subnets\\"></a>
+
+\`\`\`python
+subnets: typing.List[str]
+\`\`\`
 
 - *Type:* typing.List[\`str\`]
 
@@ -23957,6 +27249,10 @@ tree inspector to collect and process attributes.
 
 ##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.ami_type\\"></a>
 
+\`\`\`python
+ami_type: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Nodegroup.AmiType\`.
@@ -23966,6 +27262,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.capacity_type\\"></a>
+
+\`\`\`python
+capacity_type: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -23977,6 +27277,10 @@ tree inspector to collect and process attributes.
 
 ##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.disk_size\\"></a>
 
+\`\`\`python
+disk_size: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 
 \`AWS::EKS::Nodegroup.DiskSize\`.
@@ -23986,6 +27290,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`force_update_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.force_update_enabled\\"></a>
+
+\`\`\`python
+force_update_enabled: typing.Union[bool, IResolvable]
+\`\`\`
 
 - *Type:* typing.Union[\`bool\`, [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -23997,6 +27305,10 @@ tree inspector to collect and process attributes.
 
 ##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.instance_types\\"></a>
 
+\`\`\`python
+instance_types: typing.List[str]
+\`\`\`
+
 - *Type:* typing.List[\`str\`]
 
 \`AWS::EKS::Nodegroup.InstanceTypes\`.
@@ -24006,6 +27318,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`launch_template\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.launch_template\\"></a>
+
+\`\`\`python
+launch_template: typing.Union[LaunchTemplateSpecificationProperty, IResolvable]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -24017,6 +27333,10 @@ tree inspector to collect and process attributes.
 
 ##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.nodegroup_name\\"></a>
 
+\`\`\`python
+nodegroup_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Nodegroup.NodegroupName\`.
@@ -24026,6 +27346,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.release_version\\"></a>
+
+\`\`\`python
+release_version: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -24037,6 +27361,10 @@ tree inspector to collect and process attributes.
 
 ##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.remote_access\\"></a>
 
+\`\`\`python
+remote_access: typing.Union[RemoteAccessProperty, IResolvable]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
 \`AWS::EKS::Nodegroup.RemoteAccess\`.
@@ -24046,6 +27374,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`scaling_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.scaling_config\\"></a>
+
+\`\`\`python
+scaling_config: typing.Union[ScalingConfigProperty, IResolvable]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -24057,6 +27389,10 @@ tree inspector to collect and process attributes.
 
 ##### \`taints\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.taints\\"></a>
 
+\`\`\`python
+taints: typing.Union[IResolvable, typing.List[typing.Union[TaintProperty, IResolvable]]]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.TaintProperty\`](#aws_cdk.aws_eks.CfnNodegroup.TaintProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
 \`AWS::EKS::Nodegroup.Taints\`.
@@ -24066,6 +27402,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.version\\"></a>
+
+\`\`\`python
+version: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -24078,6 +27418,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`python
+CFN_RESOURCE_TYPE_NAME: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -25552,6 +28896,10 @@ The VPC in which this Cluster was created.
 
 ##### \`admin_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.admin_role\\"></a>
 
+\`\`\`python
+admin_role: Role
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_iam.Role\`](#aws_cdk.aws_iam.Role)
 
 An IAM role with administrative permissions to create or update the cluster.
@@ -25562,6 +28910,10 @@ This role also has \`systems:master\` permissions.
 
 ##### \`aws_auth\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.aws_auth\\"></a>
 
+\`\`\`python
+aws_auth: AwsAuth
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.AwsAuth\`](#aws_cdk.aws_eks.AwsAuth)
 
 Lazily creates the AwsAuth resource, which manages AWS authentication mapping.
@@ -25569,6 +28921,10 @@ Lazily creates the AwsAuth resource, which manages AWS authentication mapping.
 ---
 
 ##### \`cluster_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_arn\\"></a>
+
+\`\`\`python
+cluster_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -25578,6 +28934,10 @@ The AWS generated ARN for the Cluster resource.
 
 ##### \`cluster_certificate_authority_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_certificate_authority_data\\"></a>
 
+\`\`\`python
+cluster_certificate_authority_data: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The certificate-authority-data for your cluster.
@@ -25586,6 +28946,10 @@ The certificate-authority-data for your cluster.
 
 ##### \`cluster_encryption_config_key_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_encryption_config_key_arn\\"></a>
 
+\`\`\`python
+cluster_encryption_config_key_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 Amazon Resource Name (ARN) or alias of the customer master key (CMK).
@@ -25593,6 +28957,10 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 ---
 
 ##### \`cluster_endpoint\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_endpoint\\"></a>
+
+\`\`\`python
+cluster_endpoint: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -25604,6 +28972,10 @@ This is the URL inside the kubeconfig file to use with kubectl
 
 ##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_name\\"></a>
 
+\`\`\`python
+cluster_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The Name of the created EKS Cluster.
@@ -25611,6 +28983,10 @@ The Name of the created EKS Cluster.
 ---
 
 ##### \`cluster_open_id_connect_issuer\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_open_id_connect_issuer\\"></a>
+
+\`\`\`python
+cluster_open_id_connect_issuer: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -25624,6 +29000,10 @@ stock \`CfnCluster\`), this is \`undefined\`.
 
 ##### \`cluster_open_id_connect_issuer_url\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_open_id_connect_issuer_url\\"></a>
 
+\`\`\`python
+cluster_open_id_connect_issuer_url: str
+\`\`\`
+
 - *Type:* \`str\`
 
 If this cluster is kubectl-enabled, returns the OpenID Connect issuer url.
@@ -25636,6 +29016,10 @@ stock \`CfnCluster\`), this is \`undefined\`.
 
 ##### \`cluster_security_group\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_security_group\\"></a>
 
+\`\`\`python
+cluster_security_group: ISecurityGroup
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 
 The cluster security group that was created by Amazon EKS for the cluster.
@@ -25643,6 +29027,10 @@ The cluster security group that was created by Amazon EKS for the cluster.
 ---
 
 ##### \`cluster_security_group_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.cluster_security_group_id\\"></a>
+
+\`\`\`python
+cluster_security_group_id: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -25652,6 +29040,10 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 
 ##### \`connections\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.connections\\"></a>
 
+\`\`\`python
+connections: Connections
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.Connections\`](#aws_cdk.aws_ec2.Connections)
 
 Manages connection rules (Security Group Rules) for the cluster.
@@ -25659,6 +29051,10 @@ Manages connection rules (Security Group Rules) for the cluster.
 ---
 
 ##### \`open_id_connect_provider\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.open_id_connect_provider\\"></a>
+
+\`\`\`python
+open_id_connect_provider: IOpenIdConnectProvider
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IOpenIdConnectProvider\`](#aws_cdk.aws_iam.IOpenIdConnectProvider)
 
@@ -25670,6 +29066,10 @@ A provider will only be defined if this property is accessed (lazy initializatio
 
 ##### \`prune\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.prune\\"></a>
 
+\`\`\`python
+prune: bool
+\`\`\`
+
 - *Type:* \`bool\`
 
 Determines if Kubernetes resources can be pruned automatically.
@@ -25677,6 +29077,10 @@ Determines if Kubernetes resources can be pruned automatically.
 ---
 
 ##### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.role\\"></a>
+
+\`\`\`python
+role: IRole
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
@@ -25686,6 +29090,10 @@ IAM role assumed by the EKS Control Plane.
 
 ##### \`vpc\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.vpc\\"></a>
 
+\`\`\`python
+vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 
 The VPC in which this Cluster was created.
@@ -25693,6 +29101,10 @@ The VPC in which this Cluster was created.
 ---
 
 ##### \`default_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.default_capacity\\"></a>
+
+\`\`\`python
+default_capacity: AutoScalingGroup
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_autoscaling.AutoScalingGroup\`](#aws_cdk.aws_autoscaling.AutoScalingGroup)
 
@@ -25705,6 +29117,10 @@ This will be \`undefined\` if the \`defaultCapacityType\` is not \`EC2\` or
 
 ##### \`default_nodegroup\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.default_nodegroup\\"></a>
 
+\`\`\`python
+default_nodegroup: Nodegroup
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.Nodegroup\`](#aws_cdk.aws_eks.Nodegroup)
 
 The node group that hosts the default capacity for this cluster.
@@ -25716,6 +29132,10 @@ This will be \`undefined\` if the \`defaultCapacityType\` is \`EC2\` or
 
 ##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.kubectl_environment\\"></a>
 
+\`\`\`python
+kubectl_environment: typing.Mapping[str]
+\`\`\`
+
 - *Type:* typing.Mapping[\`str\`]
 
 Custom environment variables when running \`kubectl\` against this cluster.
@@ -25723,6 +29143,10 @@ Custom environment variables when running \`kubectl\` against this cluster.
 ---
 
 ##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.kubectl_layer\\"></a>
+
+\`\`\`python
+kubectl_layer: ILayerVersion
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 
@@ -25735,6 +29159,10 @@ undefined, a SAR app that contains this layer will be used.
 
 ##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.kubectl_memory\\"></a>
 
+\`\`\`python
+kubectl_memory: Size
+\`\`\`
+
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 
 The amount of memory allocated to the kubectl provider's lambda function.
@@ -25742,6 +29170,10 @@ The amount of memory allocated to the kubectl provider's lambda function.
 ---
 
 ##### \`kubectl_private_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.kubectl_private_subnets\\"></a>
+
+\`\`\`python
+kubectl_private_subnets: typing.List[ISubnet]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.ISubnet\`](#aws_cdk.aws_ec2.ISubnet)]
 - *Default:* If not specified, the k8s endpoint is expected to be accessible
@@ -25753,6 +29185,10 @@ Subnets to host the \`kubectl\` compute resources.
 
 ##### \`kubectl_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.kubectl_role\\"></a>
 
+\`\`\`python
+kubectl_role: IRole
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
 An IAM role that can perform kubectl operations against this cluster.
@@ -25762,6 +29198,10 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 ---
 
 ##### \`kubectl_security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Cluster.property.kubectl_security_group\\"></a>
+
+\`\`\`python
+kubectl_security_group: ISecurityGroup
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 - *Default:* If not specified, the k8s endpoint is expected to be accessible
@@ -26182,6 +29622,10 @@ The EKS cluster to apply the Fargate profile to.
 
 ##### \`fargate_profile_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.property.fargate_profile_arn\\"></a>
 
+\`\`\`python
+fargate_profile_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The full Amazon Resource Name (ARN) of the Fargate profile.
@@ -26190,6 +29634,10 @@ The full Amazon Resource Name (ARN) of the Fargate profile.
 
 ##### \`fargate_profile_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.property.fargate_profile_name\\"></a>
 
+\`\`\`python
+fargate_profile_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The name of the Fargate profile.
@@ -26197,6 +29645,10 @@ The name of the Fargate profile.
 ---
 
 ##### \`pod_execution_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.property.pod_execution_role\\"></a>
+
+\`\`\`python
+pod_execution_role: IRole
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
@@ -26209,6 +29661,10 @@ ECR image repositories.
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfile.property.tags\\"></a>
+
+\`\`\`python
+tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws_cdk.TagManager\`](#aws_cdk.TagManager)
 
@@ -26357,6 +29813,10 @@ The EKS cluster to apply this configuration to.
 
 ##### \`RESOURCE_TYPE\` <a name=\\"aws_cdk.aws_eks.HelmChart.property.RESOURCE_TYPE\\"></a>
 
+\`\`\`python
+RESOURCE_TYPE: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The CloudFormation resource type.
@@ -26479,6 +29939,10 @@ in the cluster with the same name, the operation will fail.
 
 ##### \`RESOURCE_TYPE\` <a name=\\"aws_cdk.aws_eks.KubernetesManifest.property.RESOURCE_TYPE\\"></a>
 
+\`\`\`python
+RESOURCE_TYPE: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The CloudFormation reosurce type.
@@ -26582,6 +30046,10 @@ Timeout for waiting on a value.
 
 ##### \`value\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValue.property.value\\"></a>
 
+\`\`\`python
+value: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The value as a string token.
@@ -26591,6 +30059,10 @@ The value as a string token.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`RESOURCE_TYPE\` <a name=\\"aws_cdk.aws_eks.KubernetesObjectValue.property.RESOURCE_TYPE\\"></a>
+
+\`\`\`python
+RESOURCE_TYPE: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -26959,6 +30431,10 @@ aws_eks.Nodegroup.from_nodegroup_name(
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.property.cluster\\"></a>
 
+\`\`\`python
+cluster: ICluster
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
 the Amazon EKS cluster resource.
@@ -26966,6 +30442,10 @@ the Amazon EKS cluster resource.
 ---
 
 ##### \`nodegroup_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.property.nodegroup_arn\\"></a>
+
+\`\`\`python
+nodegroup_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -26975,6 +30455,10 @@ ARN of the nodegroup.
 
 ##### \`nodegroup_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.property.nodegroup_name\\"></a>
 
+\`\`\`python
+nodegroup_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 Nodegroup name.
@@ -26982,6 +30466,10 @@ Nodegroup name.
 ---
 
 ##### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Nodegroup.property.role\\"></a>
+
+\`\`\`python
+role: IRole
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
@@ -27131,6 +30619,10 @@ def add_to_principal_policy(
 
 ##### \`assume_role_action\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.property.assume_role_action\\"></a>
 
+\`\`\`python
+assume_role_action: str
+\`\`\`
+
 - *Type:* \`str\`
 
 When this Principal is used in an AssumeRole policy, the action to use.
@@ -27138,6 +30630,10 @@ When this Principal is used in an AssumeRole policy, the action to use.
 ---
 
 ##### \`grant_principal\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.property.grant_principal\\"></a>
+
+\`\`\`python
+grant_principal: IPrincipal
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IPrincipal\`](#aws_cdk.aws_iam.IPrincipal)
 
@@ -27147,6 +30643,10 @@ The principal to grant permissions to.
 
 ##### \`policy_fragment\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.property.policy_fragment\\"></a>
 
+\`\`\`python
+policy_fragment: PrincipalPolicyFragment
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_iam.PrincipalPolicyFragment\`](#aws_cdk.aws_iam.PrincipalPolicyFragment)
 
 Return the policy fragment that identifies this principal in a Policy.
@@ -27154,6 +30654,10 @@ Return the policy fragment that identifies this principal in a Policy.
 ---
 
 ##### \`role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.property.role\\"></a>
+
+\`\`\`python
+role: IRole
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
@@ -27163,6 +30667,10 @@ The role which is linked to the service account.
 
 ##### \`service_account_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.property.service_account_name\\"></a>
 
+\`\`\`python
+service_account_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The name of the service account.
@@ -27170,6 +30678,10 @@ The name of the service account.
 ---
 
 ##### \`service_account_namespace\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccount.property.service_account_namespace\\"></a>
+
+\`\`\`python
+service_account_namespace: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -27221,6 +30733,10 @@ aws_eks.AutoScalingGroupCapacityOptions(
 
 ##### \`allow_all_outbound\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.allow_all_outbound\\"></a>
 
+\`\`\`python
+allow_all_outbound: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* true
 
@@ -27230,6 +30746,10 @@ Whether the instances can initiate connections to anywhere by default.
 
 ##### \`associate_public_ip_address\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.associate_public_ip_address\\"></a>
 
+\`\`\`python
+associate_public_ip_address: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* Use subnet setting.
 
@@ -27238,6 +30758,10 @@ Whether instances in the Auto Scaling Group should have public IP addresses asso
 ---
 
 ##### \`auto_scaling_group_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.auto_scaling_group_name\\"></a>
+
+\`\`\`python
+auto_scaling_group_name: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* Auto generated by CloudFormation
@@ -27249,6 +30773,10 @@ This name must be unique per Region per account.
 ---
 
 ##### \`block_devices\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.block_devices\\"></a>
+
+\`\`\`python
+block_devices: typing.List[BlockDevice]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.aws_autoscaling.BlockDevice\`](#aws_cdk.aws_autoscaling.BlockDevice)]
 - *Default:* Uses the block device mapping of the AMI
@@ -27266,6 +30794,10 @@ instance store volumes to attach to an instance when it is launched.
 
 ##### \`cooldown\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.cooldown\\"></a>
 
+\`\`\`python
+cooldown: Duration
+\`\`\`
+
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
 
@@ -27274,6 +30806,10 @@ Default scaling cooldown for this AutoScalingGroup.
 ---
 
 ##### \`desired_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.desired_capacity\\"></a>
+
+\`\`\`python
+desired_capacity: typing.Union[int, float]
+\`\`\`
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* minCapacity, and leave unchanged during deployment
@@ -27289,6 +30825,10 @@ instances to this number. It is recommended to leave this value blank.
 
 ##### \`group_metrics\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.group_metrics\\"></a>
 
+\`\`\`python
+group_metrics: typing.List[GroupMetrics]
+\`\`\`
+
 - *Type:* typing.List[[\`aws_cdk.aws_autoscaling.GroupMetrics\`](#aws_cdk.aws_autoscaling.GroupMetrics)]
 - *Default:* no group metrics will be reported
 
@@ -27301,6 +30841,10 @@ Group metrics are reported in a granularity of 1 minute at no additional charge.
 
 ##### \`health_check\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.health_check\\"></a>
 
+\`\`\`python
+health_check: HealthCheck
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_autoscaling.HealthCheck\`](#aws_cdk.aws_autoscaling.HealthCheck)
 - *Default:* HealthCheck.ec2 with no grace period
 
@@ -27309,6 +30853,10 @@ Configuration for health checks.
 ---
 
 ##### \`ignore_unmodified_size_properties\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.ignore_unmodified_size_properties\\"></a>
+
+\`\`\`python
+ignore_unmodified_size_properties: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -27325,6 +30873,10 @@ on deployment.
 
 ##### \`instance_monitoring\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.instance_monitoring\\"></a>
 
+\`\`\`python
+instance_monitoring: Monitoring
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_autoscaling.Monitoring\`](#aws_cdk.aws_autoscaling.Monitoring)
 - *Default:* Monitoring.DETAILED
 
@@ -27339,6 +30891,10 @@ is charged a fee. When you disable detailed monitoring, CloudWatch generates met
 
 ##### \`key_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.key_name\\"></a>
 
+\`\`\`python
+key_name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* No SSH access will be possible.
 
@@ -27348,6 +30904,10 @@ Name of SSH keypair to grant access to instances.
 
 ##### \`max_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.max_capacity\\"></a>
 
+\`\`\`python
+max_capacity: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* desiredCapacity
 
@@ -27356,6 +30916,10 @@ Maximum number of instances in the fleet.
 ---
 
 ##### \`max_instance_lifetime\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.max_instance_lifetime\\"></a>
+
+\`\`\`python
+max_instance_lifetime: Duration
+\`\`\`
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* none
@@ -27375,6 +30939,10 @@ leave this property undefined.
 
 ##### \`min_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.min_capacity\\"></a>
 
+\`\`\`python
+min_capacity: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 1
 
@@ -27383,6 +30951,10 @@ Minimum number of instances in the fleet.
 ---
 
 ##### \`new_instances_protected_from_scale_in\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.new_instances_protected_from_scale_in\\"></a>
+
+\`\`\`python
+new_instances_protected_from_scale_in: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -27402,6 +30974,10 @@ an ECS Capacity Provider with managed termination protection.
 
 ##### \`notifications\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.notifications\\"></a>
 
+\`\`\`python
+notifications: typing.List[NotificationConfiguration]
+\`\`\`
+
 - *Type:* typing.List[[\`aws_cdk.aws_autoscaling.NotificationConfiguration\`](#aws_cdk.aws_autoscaling.NotificationConfiguration)]
 - *Default:* No fleet change notifications will be sent.
 
@@ -27412,6 +30988,10 @@ Configure autoscaling group to send notifications about fleet changes to an SNS 
 ---
 
 ##### \`signals\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.signals\\"></a>
+
+\`\`\`python
+signals: Signals
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_autoscaling.Signals\`](#aws_cdk.aws_autoscaling.Signals)
 - *Default:* Do not wait for signals
@@ -27438,6 +31018,10 @@ https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services
 
 ##### \`spot_price\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.spot_price\\"></a>
 
+\`\`\`python
+spot_price: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* none
 
@@ -27449,6 +31033,10 @@ launched when the price you specify exceeds the current Spot market price.
 ---
 
 ##### \`update_policy\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.update_policy\\"></a>
+
+\`\`\`python
+update_policy: UpdatePolicy
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_autoscaling.UpdatePolicy\`](#aws_cdk.aws_autoscaling.UpdatePolicy)
 - *Default:* \`UpdatePolicy.rollingUpdate()\` if using \`init\`, \`UpdatePolicy.none()\` otherwise
@@ -27465,6 +31053,10 @@ is done and only new instances are launched with the new config.
 
 ##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.vpc_subnets\\"></a>
 
+\`\`\`python
+vpc_subnets: SubnetSelection
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* All Private subnets.
 
@@ -27474,6 +31066,10 @@ Where to place instances within the VPC.
 
 ##### \`instance_type\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.instance_type\\"></a>
 
+\`\`\`python
+instance_type: InstanceType
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)
 
 Instance type of the instances to start.
@@ -27481,6 +31077,10 @@ Instance type of the instances to start.
 ---
 
 ##### \`bootstrap_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.bootstrap_enabled\\"></a>
+
+\`\`\`python
+bootstrap_enabled: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -27494,6 +31094,10 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 
 ##### \`bootstrap_options\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.bootstrap_options\\"></a>
 
+\`\`\`python
+bootstrap_options: BootstrapOptions
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.BootstrapOptions\`](#aws_cdk.aws_eks.BootstrapOptions)
 - *Default:* none
 
@@ -27503,6 +31107,10 @@ EKS node bootstrapping options.
 
 ##### \`machine_image_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.machine_image_type\\"></a>
 
+\`\`\`python
+machine_image_type: MachineImageType
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.MachineImageType\`](#aws_cdk.aws_eks.MachineImageType)
 - *Default:* MachineImageType.AMAZON_LINUX_2
 
@@ -27511,6 +31119,10 @@ Machine image type.
 ---
 
 ##### \`map_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.map_role\\"></a>
+
+\`\`\`python
+map_role: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true if the cluster has kubectl enabled (which is the default).
@@ -27522,6 +31134,10 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 ---
 
 ##### \`spot_interrupt_handler\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupCapacityOptions.property.spot_interrupt_handler\\"></a>
+
+\`\`\`python
+spot_interrupt_handler: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -27552,6 +31168,10 @@ aws_eks.AutoScalingGroupOptions(
 
 ##### \`bootstrap_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.property.bootstrap_enabled\\"></a>
 
+\`\`\`python
+bootstrap_enabled: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* true
 
@@ -27564,6 +31184,10 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 
 ##### \`bootstrap_options\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.property.bootstrap_options\\"></a>
 
+\`\`\`python
+bootstrap_options: BootstrapOptions
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.BootstrapOptions\`](#aws_cdk.aws_eks.BootstrapOptions)
 - *Default:* default options
 
@@ -27573,6 +31197,10 @@ Allows options for node bootstrapping through EC2 user data.
 
 ##### \`machine_image_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.property.machine_image_type\\"></a>
 
+\`\`\`python
+machine_image_type: MachineImageType
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.MachineImageType\`](#aws_cdk.aws_eks.MachineImageType)
 - *Default:* MachineImageType.AMAZON_LINUX_2
 
@@ -27581,6 +31209,10 @@ Allow options to specify different machine image type.
 ---
 
 ##### \`map_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.property.map_role\\"></a>
+
+\`\`\`python
+map_role: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true if the cluster has kubectl enabled (which is the default).
@@ -27592,6 +31224,10 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 ---
 
 ##### \`spot_interrupt_handler\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AutoScalingGroupOptions.property.spot_interrupt_handler\\"></a>
+
+\`\`\`python
+spot_interrupt_handler: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -27619,6 +31255,10 @@ aws_eks.AwsAuthMapping(
 
 ##### \`groups\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.property.groups\\"></a>
 
+\`\`\`python
+groups: typing.List[str]
+\`\`\`
+
 - *Type:* typing.List[\`str\`]
 
 A list of groups within Kubernetes to which the role is mapped.
@@ -27628,6 +31268,10 @@ A list of groups within Kubernetes to which the role is mapped.
 ---
 
 ##### \`username\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthMapping.property.username\\"></a>
+
+\`\`\`python
+username: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* By default, the user name is the ARN of the IAM role.
@@ -27651,6 +31295,10 @@ aws_eks.AwsAuthProps(
 \`\`\`
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.AwsAuthProps.property.cluster\\"></a>
+
+\`\`\`python
+cluster: Cluster
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.Cluster\`](#aws_cdk.aws_eks.Cluster)
 
@@ -27682,6 +31330,10 @@ aws_eks.BootstrapOptions(
 
 ##### \`additional_args\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.additional_args\\"></a>
 
+\`\`\`python
+additional_args: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* none
 
@@ -27693,6 +31345,10 @@ Additional command line arguments to pass to the \`/etc/eks/bootstrap.sh\` comma
 
 ##### \`aws_api_retry_attempts\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.aws_api_retry_attempts\\"></a>
 
+\`\`\`python
+aws_api_retry_attempts: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 3
 
@@ -27701,6 +31357,10 @@ Number of retry attempts for AWS API call (DescribeCluster).
 ---
 
 ##### \`dns_cluster_ip\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.dns_cluster_ip\\"></a>
+
+\`\`\`python
+dns_cluster_ip: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* 10.100.0.10 or 172.20.0.10 based on the IP
@@ -27712,6 +31372,10 @@ Overrides the IP address to use for DNS queries within the cluster.
 
 ##### \`docker_config_json\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.docker_config_json\\"></a>
 
+\`\`\`python
+docker_config_json: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* none
 
@@ -27721,6 +31385,10 @@ The contents of the \`/etc/docker/daemon.json\` file. Useful if you want a custo
 
 ##### \`enable_docker_bridge\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.enable_docker_bridge\\"></a>
 
+\`\`\`python
+enable_docker_bridge: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -27729,6 +31397,10 @@ Restores the docker default bridge network.
 ---
 
 ##### \`kubelet_extra_args\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.kubelet_extra_args\\"></a>
+
+\`\`\`python
+kubelet_extra_args: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* none
@@ -27740,6 +31412,10 @@ Useful for adding labels or taints.
 ---
 
 ##### \`use_max_pods\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.BootstrapOptions.property.use_max_pods\\"></a>
+
+\`\`\`python
+use_max_pods: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -27771,6 +31447,10 @@ aws_eks.CfnAddonProps(
 
 ##### \`addon_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.property.addon_name\\"></a>
 
+\`\`\`python
+addon_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Addon.AddonName\`.
@@ -27780,6 +31460,10 @@ aws_eks.CfnAddonProps(
 ---
 
 ##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.property.cluster_name\\"></a>
+
+\`\`\`python
+cluster_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -27791,6 +31475,10 @@ aws_eks.CfnAddonProps(
 
 ##### \`addon_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.property.addon_version\\"></a>
 
+\`\`\`python
+addon_version: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Addon.AddonVersion\`.
@@ -27800,6 +31488,10 @@ aws_eks.CfnAddonProps(
 ---
 
 ##### \`resolve_conflicts\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.property.resolve_conflicts\\"></a>
+
+\`\`\`python
+resolve_conflicts: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -27811,6 +31503,10 @@ aws_eks.CfnAddonProps(
 
 ##### \`service_account_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.property.service_account_role_arn\\"></a>
 
+\`\`\`python
+service_account_role_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Addon.ServiceAccountRoleArn\`.
@@ -27820,6 +31516,10 @@ aws_eks.CfnAddonProps(
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnAddonProps.property.tags\\"></a>
+
+\`\`\`python
+tags: typing.List[CfnTag]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.CfnTag\`](#aws_cdk.CfnTag)]
 
@@ -27852,6 +31552,10 @@ aws_eks.CfnClusterProps(
 
 ##### \`resources_vpc_config\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.property.resources_vpc_config\\"></a>
 
+\`\`\`python
+resources_vpc_config: typing.Union[ResourcesVpcConfigProperty, IResolvable]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
 \`AWS::EKS::Cluster.ResourcesVpcConfig\`.
@@ -27861,6 +31565,10 @@ aws_eks.CfnClusterProps(
 ---
 
 ##### \`role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.property.role_arn\\"></a>
+
+\`\`\`python
+role_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -27872,6 +31580,10 @@ aws_eks.CfnClusterProps(
 
 ##### \`encryption_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.property.encryption_config\\"></a>
 
+\`\`\`python
+encryption_config: typing.Union[IResolvable, typing.List[typing.Union[EncryptionConfigProperty, IResolvable]]]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
 \`AWS::EKS::Cluster.EncryptionConfig\`.
@@ -27881,6 +31593,10 @@ aws_eks.CfnClusterProps(
 ---
 
 ##### \`kubernetes_network_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.property.kubernetes_network_config\\"></a>
+
+\`\`\`python
+kubernetes_network_config: typing.Union[KubernetesNetworkConfigProperty, IResolvable]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -27892,6 +31608,10 @@ aws_eks.CfnClusterProps(
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.property.name\\"></a>
 
+\`\`\`python
+name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Cluster.Name\`.
@@ -27901,6 +31621,10 @@ aws_eks.CfnClusterProps(
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnClusterProps.property.version\\"></a>
+
+\`\`\`python
+version: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -27933,6 +31657,10 @@ aws_eks.CfnFargateProfileProps(
 
 ##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.property.cluster_name\\"></a>
 
+\`\`\`python
+cluster_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::FargateProfile.ClusterName\`.
@@ -27942,6 +31670,10 @@ aws_eks.CfnFargateProfileProps(
 ---
 
 ##### \`pod_execution_role_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.property.pod_execution_role_arn\\"></a>
+
+\`\`\`python
+pod_execution_role_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -27953,6 +31685,10 @@ aws_eks.CfnFargateProfileProps(
 
 ##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.property.selectors\\"></a>
 
+\`\`\`python
+selectors: typing.Union[IResolvable, typing.List[typing.Union[SelectorProperty, IResolvable]]]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
 \`AWS::EKS::FargateProfile.Selectors\`.
@@ -27962,6 +31698,10 @@ aws_eks.CfnFargateProfileProps(
 ---
 
 ##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.property.fargate_profile_name\\"></a>
+
+\`\`\`python
+fargate_profile_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -27973,6 +31713,10 @@ aws_eks.CfnFargateProfileProps(
 
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.property.subnets\\"></a>
 
+\`\`\`python
+subnets: typing.List[str]
+\`\`\`
+
 - *Type:* typing.List[\`str\`]
 
 \`AWS::EKS::FargateProfile.Subnets\`.
@@ -27982,6 +31726,10 @@ aws_eks.CfnFargateProfileProps(
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfileProps.property.tags\\"></a>
+
+\`\`\`python
+tags: typing.List[CfnTag]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.CfnTag\`](#aws_cdk.CfnTag)]
 
@@ -28025,6 +31773,10 @@ aws_eks.CfnNodegroupProps(
 
 ##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.cluster_name\\"></a>
 
+\`\`\`python
+cluster_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Nodegroup.ClusterName\`.
@@ -28034,6 +31786,10 @@ aws_eks.CfnNodegroupProps(
 ---
 
 ##### \`node_role\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.node_role\\"></a>
+
+\`\`\`python
+node_role: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -28045,6 +31801,10 @@ aws_eks.CfnNodegroupProps(
 
 ##### \`subnets\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.subnets\\"></a>
 
+\`\`\`python
+subnets: typing.List[str]
+\`\`\`
+
 - *Type:* typing.List[\`str\`]
 
 \`AWS::EKS::Nodegroup.Subnets\`.
@@ -28054,6 +31814,10 @@ aws_eks.CfnNodegroupProps(
 ---
 
 ##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.ami_type\\"></a>
+
+\`\`\`python
+ami_type: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -28065,6 +31829,10 @@ aws_eks.CfnNodegroupProps(
 
 ##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.capacity_type\\"></a>
 
+\`\`\`python
+capacity_type: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Nodegroup.CapacityType\`.
@@ -28074,6 +31842,10 @@ aws_eks.CfnNodegroupProps(
 ---
 
 ##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.disk_size\\"></a>
+
+\`\`\`python
+disk_size: typing.Union[int, float]
+\`\`\`
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -28085,6 +31857,10 @@ aws_eks.CfnNodegroupProps(
 
 ##### \`force_update_enabled\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.force_update_enabled\\"></a>
 
+\`\`\`python
+force_update_enabled: typing.Union[bool, IResolvable]
+\`\`\`
+
 - *Type:* typing.Union[\`bool\`, [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
 \`AWS::EKS::Nodegroup.ForceUpdateEnabled\`.
@@ -28094,6 +31870,10 @@ aws_eks.CfnNodegroupProps(
 ---
 
 ##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.instance_types\\"></a>
+
+\`\`\`python
+instance_types: typing.List[str]
+\`\`\`
 
 - *Type:* typing.List[\`str\`]
 
@@ -28105,6 +31885,10 @@ aws_eks.CfnNodegroupProps(
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.labels\\"></a>
 
+\`\`\`python
+labels: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::EKS::Nodegroup.Labels\`.
@@ -28114,6 +31898,10 @@ aws_eks.CfnNodegroupProps(
 ---
 
 ##### \`launch_template\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.launch_template\\"></a>
+
+\`\`\`python
+launch_template: typing.Union[LaunchTemplateSpecificationProperty, IResolvable]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -28125,6 +31913,10 @@ aws_eks.CfnNodegroupProps(
 
 ##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.nodegroup_name\\"></a>
 
+\`\`\`python
+nodegroup_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`AWS::EKS::Nodegroup.NodegroupName\`.
@@ -28134,6 +31926,10 @@ aws_eks.CfnNodegroupProps(
 ---
 
 ##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.release_version\\"></a>
+
+\`\`\`python
+release_version: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -28145,6 +31941,10 @@ aws_eks.CfnNodegroupProps(
 
 ##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.remote_access\\"></a>
 
+\`\`\`python
+remote_access: typing.Union[RemoteAccessProperty, IResolvable]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
 \`AWS::EKS::Nodegroup.RemoteAccess\`.
@@ -28154,6 +31954,10 @@ aws_eks.CfnNodegroupProps(
 ---
 
 ##### \`scaling_config\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.scaling_config\\"></a>
+
+\`\`\`python
+scaling_config: typing.Union[ScalingConfigProperty, IResolvable]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
@@ -28165,6 +31969,10 @@ aws_eks.CfnNodegroupProps(
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.tags\\"></a>
 
+\`\`\`python
+tags: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::EKS::Nodegroup.Tags\`.
@@ -28175,6 +31983,10 @@ aws_eks.CfnNodegroupProps(
 
 ##### \`taints\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.taints\\"></a>
 
+\`\`\`python
+taints: typing.Union[IResolvable, typing.List[typing.Union[TaintProperty, IResolvable]]]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnNodegroup.TaintProperty\`](#aws_cdk.aws_eks.CfnNodegroup.TaintProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
 \`AWS::EKS::Nodegroup.Taints\`.
@@ -28184,6 +31996,10 @@ aws_eks.CfnNodegroupProps(
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroupProps.property.version\\"></a>
+
+\`\`\`python
+version: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -28223,6 +32039,10 @@ aws_eks.ClusterAttributes(
 
 ##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.cluster_name\\"></a>
 
+\`\`\`python
+cluster_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The physical name of the Cluster.
@@ -28230,6 +32050,10 @@ The physical name of the Cluster.
 ---
 
 ##### \`cluster_certificate_authority_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.cluster_certificate_authority_data\\"></a>
+
+\`\`\`python
+cluster_certificate_authority_data: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* if not specified \`cluster.clusterCertificateAuthorityData\` will
@@ -28241,6 +32065,10 @@ The certificate-authority-data for your cluster.
 
 ##### \`cluster_encryption_config_key_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.cluster_encryption_config_key_arn\\"></a>
 
+\`\`\`python
+cluster_encryption_config_key_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* if not specified \`cluster.clusterEncryptionConfigKeyArn\` will
 throw an error
@@ -28251,6 +32079,10 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ##### \`cluster_endpoint\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.cluster_endpoint\\"></a>
 
+\`\`\`python
+cluster_endpoint: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* if not specified \`cluster.clusterEndpoint\` will throw an error.
 
@@ -28259,6 +32091,10 @@ The API Server endpoint URL.
 ---
 
 ##### \`cluster_security_group_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.cluster_security_group_id\\"></a>
+
+\`\`\`python
+cluster_security_group_id: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* if not specified \`cluster.clusterSecurityGroupId\` will throw an
@@ -28270,6 +32106,10 @@ The cluster security group that was created by Amazon EKS for the cluster.
 
 ##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.kubectl_environment\\"></a>
 
+\`\`\`python
+kubectl_environment: typing.Mapping[str]
+\`\`\`
+
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* no additional variables
 
@@ -28278,6 +32118,10 @@ Environment variables to use when running \`kubectl\` against this cluster.
 ---
 
 ##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.kubectl_layer\\"></a>
+
+\`\`\`python
+kubectl_layer: ILayerVersion
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 - *Default:* a layer bundled with this module.
@@ -28297,6 +32141,10 @@ The handler expects the layer to include the following executables:
 
 ##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.kubectl_memory\\"></a>
 
+\`\`\`python
+kubectl_memory: Size
+\`\`\`
+
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 - *Default:* Size.gibibytes(1)
 
@@ -28305,6 +32153,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`kubectl_private_subnet_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.kubectl_private_subnet_ids\\"></a>
+
+\`\`\`python
+kubectl_private_subnet_ids: typing.List[str]
+\`\`\`
 
 - *Type:* typing.List[\`str\`]
 - *Default:* k8s endpoint is expected to be accessible publicly
@@ -28318,6 +32170,10 @@ endpoint is expected to be accessible publicly.
 
 ##### \`kubectl_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.kubectl_role_arn\\"></a>
 
+\`\`\`python
+kubectl_role_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* if not specified, it not be possible to issue \`kubectl\` commands
 against an imported cluster.
@@ -28327,6 +32183,10 @@ An IAM role with cluster administrator and \\"system:masters\\" permissions.
 ---
 
 ##### \`kubectl_security_group_id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.kubectl_security_group_id\\"></a>
+
+\`\`\`python
+kubectl_security_group_id: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* k8s endpoint is expected to be accessible publicly
@@ -28340,6 +32200,10 @@ endpoint is expected to be accessible publicly.
 
 ##### \`open_id_connect_provider\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.open_id_connect_provider\\"></a>
 
+\`\`\`python
+open_id_connect_provider: IOpenIdConnectProvider
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_iam.IOpenIdConnectProvider\`](#aws_cdk.aws_iam.IOpenIdConnectProvider)
 - *Default:* if not specified \`cluster.openIdConnectProvider\` and \`cluster.addServiceAccount\` will throw an error.
 
@@ -28351,6 +32215,10 @@ or create a new provider using \`new eks.OpenIdConnectProvider\`
 ---
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.prune\\"></a>
+
+\`\`\`python
+prune: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -28365,6 +32233,10 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ##### \`security_group_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.security_group_ids\\"></a>
 
+\`\`\`python
+security_group_ids: typing.List[str]
+\`\`\`
+
 - *Type:* typing.List[\`str\`]
 - *Default:* if not specified, no additional security groups will be
 considered in \`cluster.connections\`.
@@ -28374,6 +32246,10 @@ Additional security groups associated with this cluster.
 ---
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterAttributes.property.vpc\\"></a>
+
+\`\`\`python
+vpc: IVpc
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* if not specified \`cluster.vpc\` will throw an error
@@ -28416,6 +32292,10 @@ aws_eks.ClusterOptions(
 
 ##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.version\\"></a>
 
+\`\`\`python
+version: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
 The Kubernetes version to run in the cluster.
@@ -28423,6 +32303,10 @@ The Kubernetes version to run in the cluster.
 ---
 
 ##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.cluster_name\\"></a>
+
+\`\`\`python
+cluster_name: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name
@@ -28433,6 +32317,10 @@ Name for the cluster.
 
 ##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.output_cluster_name\\"></a>
 
+\`\`\`python
+output_cluster_name: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -28441,6 +32329,10 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ---
 
 ##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.output_config_command\\"></a>
+
+\`\`\`python
+output_config_command: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -28454,6 +32346,10 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.role\\"></a>
 
+\`\`\`python
+role: IRole
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* A role is automatically created for you
 
@@ -28462,6 +32358,10 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ---
 
 ##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.security_group\\"></a>
+
+\`\`\`python
+security_group: ISecurityGroup
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -28472,6 +32372,10 @@ Security Group to use for Control Plane ENIs.
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.vpc\\"></a>
 
+\`\`\`python
+vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
 
@@ -28480,6 +32384,10 @@ The VPC in which to create the Cluster.
 ---
 
 ##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.vpc_subnets\\"></a>
+
+\`\`\`python
+vpc_subnets: typing.List[SubnetSelection]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
 - *Default:* All public and private subnets
@@ -28500,6 +32408,10 @@ vpcSubnets: [
 
 ##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.cluster_handler_environment\\"></a>
 
+\`\`\`python
+cluster_handler_environment: typing.Mapping[str]
+\`\`\`
+
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
 
@@ -28509,6 +32421,10 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.core_dns_compute_type\\"></a>
 
+\`\`\`python
+core_dns_compute_type: CoreDnsComputeType
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
 
@@ -28517,6 +32433,10 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ---
 
 ##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.endpoint_access\\"></a>
+
+\`\`\`python
+endpoint_access: EndpointAccess
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -28529,6 +32449,10 @@ Configure access to the Kubernetes API server endpoint..
 
 ##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.kubectl_environment\\"></a>
 
+\`\`\`python
+kubectl_environment: typing.Mapping[str]
+\`\`\`
+
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
 
@@ -28539,6 +32463,10 @@ Only relevant for kubectl enabled clusters.
 ---
 
 ##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.kubectl_layer\\"></a>
+
+\`\`\`python
+kubectl_layer: ILayerVersion
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -28567,6 +32495,10 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.kubectl_memory\\"></a>
 
+\`\`\`python
+kubectl_memory: Size
+\`\`\`
+
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 - *Default:* Size.gibibytes(1)
 
@@ -28575,6 +32507,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.masters_role\\"></a>
+
+\`\`\`python
+masters_role: IRole
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -28588,6 +32524,10 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.output_masters_role_arn\\"></a>
 
+\`\`\`python
+output_masters_role_arn: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -28597,6 +32537,10 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.place_cluster_handler_in_vpc\\"></a>
 
+\`\`\`python
+place_cluster_handler_in_vpc: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -28605,6 +32549,10 @@ If set to true, the cluster handler functions will be placed in the private subn
 ---
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.prune\\"></a>
+
+\`\`\`python
+prune: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -28618,6 +32566,10 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 ---
 
 ##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterOptions.property.secrets_encryption_key\\"></a>
+
+\`\`\`python
+secrets_encryption_key: IKey
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
@@ -28665,6 +32617,10 @@ aws_eks.ClusterProps(
 
 ##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.version\\"></a>
 
+\`\`\`python
+version: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
 The Kubernetes version to run in the cluster.
@@ -28672,6 +32628,10 @@ The Kubernetes version to run in the cluster.
 ---
 
 ##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.cluster_name\\"></a>
+
+\`\`\`python
+cluster_name: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name
@@ -28682,6 +32642,10 @@ Name for the cluster.
 
 ##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.output_cluster_name\\"></a>
 
+\`\`\`python
+output_cluster_name: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -28690,6 +32654,10 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ---
 
 ##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.output_config_command\\"></a>
+
+\`\`\`python
+output_config_command: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -28703,6 +32671,10 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.role\\"></a>
 
+\`\`\`python
+role: IRole
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* A role is automatically created for you
 
@@ -28711,6 +32683,10 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ---
 
 ##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.security_group\\"></a>
+
+\`\`\`python
+security_group: ISecurityGroup
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -28721,6 +32697,10 @@ Security Group to use for Control Plane ENIs.
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.vpc\\"></a>
 
+\`\`\`python
+vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
 
@@ -28729,6 +32709,10 @@ The VPC in which to create the Cluster.
 ---
 
 ##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.vpc_subnets\\"></a>
+
+\`\`\`python
+vpc_subnets: typing.List[SubnetSelection]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
 - *Default:* All public and private subnets
@@ -28749,6 +32733,10 @@ vpcSubnets: [
 
 ##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.cluster_handler_environment\\"></a>
 
+\`\`\`python
+cluster_handler_environment: typing.Mapping[str]
+\`\`\`
+
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
 
@@ -28758,6 +32746,10 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.core_dns_compute_type\\"></a>
 
+\`\`\`python
+core_dns_compute_type: CoreDnsComputeType
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
 
@@ -28766,6 +32758,10 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ---
 
 ##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.endpoint_access\\"></a>
+
+\`\`\`python
+endpoint_access: EndpointAccess
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -28778,6 +32774,10 @@ Configure access to the Kubernetes API server endpoint..
 
 ##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.kubectl_environment\\"></a>
 
+\`\`\`python
+kubectl_environment: typing.Mapping[str]
+\`\`\`
+
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
 
@@ -28788,6 +32788,10 @@ Only relevant for kubectl enabled clusters.
 ---
 
 ##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.kubectl_layer\\"></a>
+
+\`\`\`python
+kubectl_layer: ILayerVersion
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -28816,6 +32820,10 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.kubectl_memory\\"></a>
 
+\`\`\`python
+kubectl_memory: Size
+\`\`\`
+
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 - *Default:* Size.gibibytes(1)
 
@@ -28824,6 +32832,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.masters_role\\"></a>
+
+\`\`\`python
+masters_role: IRole
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -28837,6 +32849,10 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.output_masters_role_arn\\"></a>
 
+\`\`\`python
+output_masters_role_arn: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -28846,6 +32862,10 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.place_cluster_handler_in_vpc\\"></a>
 
+\`\`\`python
+place_cluster_handler_in_vpc: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -28854,6 +32874,10 @@ If set to true, the cluster handler functions will be placed in the private subn
 ---
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.prune\\"></a>
+
+\`\`\`python
+prune: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -28868,6 +32892,10 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.secrets_encryption_key\\"></a>
 
+\`\`\`python
+secrets_encryption_key: IKey
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
   all etcd volumes used by Amazon EKS are encrypted at the disk-level
@@ -28878,6 +32906,10 @@ KMS secret for envelope encryption for Kubernetes secrets.
 ---
 
 ##### \`default_capacity\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.default_capacity\\"></a>
+
+\`\`\`python
+default_capacity: typing.Union[int, float]
+\`\`\`
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 2
@@ -28894,6 +32926,10 @@ to \`0\` is you wish to avoid the initial capacity allocation.
 
 ##### \`default_capacity_instance\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.default_capacity_instance\\"></a>
 
+\`\`\`python
+default_capacity_instance: InstanceType
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)
 - *Default:* m5.large
 
@@ -28905,6 +32941,10 @@ into account if \`defaultCapacity\` is > 0.
 ---
 
 ##### \`default_capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ClusterProps.property.default_capacity_type\\"></a>
+
+\`\`\`python
+default_capacity_type: DefaultCapacityType
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.DefaultCapacityType\`](#aws_cdk.aws_eks.DefaultCapacityType)
 - *Default:* NODEGROUP
@@ -28936,6 +32976,10 @@ aws_eks.CommonClusterOptions(
 
 ##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.version\\"></a>
 
+\`\`\`python
+version: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
 The Kubernetes version to run in the cluster.
@@ -28943,6 +32987,10 @@ The Kubernetes version to run in the cluster.
 ---
 
 ##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.cluster_name\\"></a>
+
+\`\`\`python
+cluster_name: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name
@@ -28953,6 +33001,10 @@ Name for the cluster.
 
 ##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.output_cluster_name\\"></a>
 
+\`\`\`python
+output_cluster_name: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -28961,6 +33013,10 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ---
 
 ##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.output_config_command\\"></a>
+
+\`\`\`python
+output_config_command: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -28974,6 +33030,10 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.role\\"></a>
 
+\`\`\`python
+role: IRole
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* A role is automatically created for you
 
@@ -28982,6 +33042,10 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ---
 
 ##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.security_group\\"></a>
+
+\`\`\`python
+security_group: ISecurityGroup
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -28992,6 +33056,10 @@ Security Group to use for Control Plane ENIs.
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.vpc\\"></a>
 
+\`\`\`python
+vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
 
@@ -29000,6 +33068,10 @@ The VPC in which to create the Cluster.
 ---
 
 ##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CommonClusterOptions.property.vpc_subnets\\"></a>
+
+\`\`\`python
+vpc_subnets: typing.List[SubnetSelection]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
 - *Default:* All public and private subnets
@@ -29036,6 +33108,10 @@ aws_eks.EksOptimizedImageProps(
 
 ##### \`cpu_arch\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.property.cpu_arch\\"></a>
 
+\`\`\`python
+cpu_arch: CpuArch
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.CpuArch\`](#aws_cdk.aws_eks.CpuArch)
 - *Default:* CpuArch.X86_64
 
@@ -29045,6 +33121,10 @@ What cpu architecture to retrieve the image for (arm64 or x86_64).
 
 ##### \`kubernetes_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.property.kubernetes_version\\"></a>
 
+\`\`\`python
+kubernetes_version: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* The latest version
 
@@ -29053,6 +33133,10 @@ The Kubernetes version to use.
 ---
 
 ##### \`node_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.EksOptimizedImageProps.property.node_type\\"></a>
+
+\`\`\`python
+node_type: NodeType
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.NodeType\`](#aws_cdk.aws_eks.NodeType)
 - *Default:* NodeType.STANDARD
@@ -29078,6 +33162,10 @@ aws_eks.CfnCluster.EncryptionConfigProperty(
 
 ##### \`provider\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty.property.provider\\"></a>
 
+\`\`\`python
+provider: typing.Union[ProviderProperty, IResolvable]
+\`\`\`
+
 - *Type:* typing.Union[[\`aws_cdk.aws_eks.CfnCluster.ProviderProperty\`](#aws_cdk.aws_eks.CfnCluster.ProviderProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]
 
 \`CfnCluster.EncryptionConfigProperty.Provider\`.
@@ -29087,6 +33175,10 @@ aws_eks.CfnCluster.EncryptionConfigProperty(
 ---
 
 ##### \`resources\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.EncryptionConfigProperty.property.resources\\"></a>
+
+\`\`\`python
+resources: typing.List[str]
+\`\`\`
 
 - *Type:* typing.List[\`str\`]
 
@@ -29131,6 +33223,10 @@ aws_eks.FargateClusterProps(
 
 ##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.version\\"></a>
 
+\`\`\`python
+version: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
 The Kubernetes version to run in the cluster.
@@ -29138,6 +33234,10 @@ The Kubernetes version to run in the cluster.
 ---
 
 ##### \`cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.cluster_name\\"></a>
+
+\`\`\`python
+cluster_name: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* Automatically generated name
@@ -29148,6 +33248,10 @@ Name for the cluster.
 
 ##### \`output_cluster_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.output_cluster_name\\"></a>
 
+\`\`\`python
+output_cluster_name: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -29156,6 +33260,10 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ---
 
 ##### \`output_config_command\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.output_config_command\\"></a>
+
+\`\`\`python
+output_config_command: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -29169,6 +33277,10 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ##### \`role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.role\\"></a>
 
+\`\`\`python
+role: IRole
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* A role is automatically created for you
 
@@ -29177,6 +33289,10 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ---
 
 ##### \`security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.security_group\\"></a>
+
+\`\`\`python
+security_group: ISecurityGroup
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -29187,6 +33303,10 @@ Security Group to use for Control Plane ENIs.
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.vpc\\"></a>
 
+\`\`\`python
+vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
 
@@ -29195,6 +33315,10 @@ The VPC in which to create the Cluster.
 ---
 
 ##### \`vpc_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.vpc_subnets\\"></a>
+
+\`\`\`python
+vpc_subnets: typing.List[SubnetSelection]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)]
 - *Default:* All public and private subnets
@@ -29215,6 +33339,10 @@ vpcSubnets: [
 
 ##### \`cluster_handler_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.cluster_handler_environment\\"></a>
 
+\`\`\`python
+cluster_handler_environment: typing.Mapping[str]
+\`\`\`
+
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
 
@@ -29224,6 +33352,10 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ##### \`core_dns_compute_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.core_dns_compute_type\\"></a>
 
+\`\`\`python
+core_dns_compute_type: CoreDnsComputeType
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.CoreDnsComputeType\`](#aws_cdk.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
 
@@ -29232,6 +33364,10 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ---
 
 ##### \`endpoint_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.endpoint_access\\"></a>
+
+\`\`\`python
+endpoint_access: EndpointAccess
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -29244,6 +33380,10 @@ Configure access to the Kubernetes API server endpoint..
 
 ##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.kubectl_environment\\"></a>
 
+\`\`\`python
+kubectl_environment: typing.Mapping[str]
+\`\`\`
+
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* No environment variables.
 
@@ -29254,6 +33394,10 @@ Only relevant for kubectl enabled clusters.
 ---
 
 ##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.kubectl_layer\\"></a>
+
+\`\`\`python
+kubectl_layer: ILayerVersion
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -29282,6 +33426,10 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.kubectl_memory\\"></a>
 
+\`\`\`python
+kubectl_memory: Size
+\`\`\`
+
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 - *Default:* Size.gibibytes(1)
 
@@ -29290,6 +33438,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`masters_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.masters_role\\"></a>
+
+\`\`\`python
+masters_role: IRole
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -29303,6 +33455,10 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ##### \`output_masters_role_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.output_masters_role_arn\\"></a>
 
+\`\`\`python
+output_masters_role_arn: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -29312,6 +33468,10 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ##### \`place_cluster_handler_in_vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.place_cluster_handler_in_vpc\\"></a>
 
+\`\`\`python
+place_cluster_handler_in_vpc: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -29320,6 +33480,10 @@ If set to true, the cluster handler functions will be placed in the private subn
 ---
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.prune\\"></a>
+
+\`\`\`python
+prune: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -29334,6 +33498,10 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ##### \`secrets_encryption_key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.secrets_encryption_key\\"></a>
 
+\`\`\`python
+secrets_encryption_key: IKey
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_kms.IKey\`](#aws_cdk.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
   all etcd volumes used by Amazon EKS are encrypted at the disk-level
@@ -29344,6 +33512,10 @@ KMS secret for envelope encryption for Kubernetes secrets.
 ---
 
 ##### \`default_profile\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateClusterProps.property.default_profile\\"></a>
+
+\`\`\`python
+default_profile: FargateProfileOptions
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.FargateProfileOptions\`](#aws_cdk.aws_eks.FargateProfileOptions)
 - *Default:* A profile called \\"default\\" with 'default' and 'kube-system'
@@ -29373,6 +33545,10 @@ aws_eks.FargateProfileOptions(
 
 ##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.property.selectors\\"></a>
 
+\`\`\`python
+selectors: typing.List[Selector]
+\`\`\`
+
 - *Type:* typing.List[[\`aws_cdk.aws_eks.Selector\`](#aws_cdk.aws_eks.Selector)]
 
 The selectors to match for pods to use this Fargate profile.
@@ -29387,6 +33563,10 @@ At least one selector is required and you may specify up to five selectors.
 
 ##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.property.fargate_profile_name\\"></a>
 
+\`\`\`python
+fargate_profile_name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* generated
 
@@ -29395,6 +33575,10 @@ The name of the Fargate profile.
 ---
 
 ##### \`pod_execution_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.property.pod_execution_role\\"></a>
+
+\`\`\`python
+pod_execution_role: IRole
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role will be automatically created
@@ -29411,6 +33595,10 @@ ECR image repositories.
 
 ##### \`subnet_selection\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.property.subnet_selection\\"></a>
 
+\`\`\`python
+subnet_selection: SubnetSelection
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* all private subnets of the VPC are selected.
 
@@ -29423,6 +33611,10 @@ on Fargate are not assigned public IP addresses, so only private subnets
 ---
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileOptions.property.vpc\\"></a>
+
+\`\`\`python
+vpc: IVpc
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* all private subnets used by theEKS cluster
@@ -29455,6 +33647,10 @@ aws_eks.FargateProfileProps(
 
 ##### \`selectors\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.property.selectors\\"></a>
 
+\`\`\`python
+selectors: typing.List[Selector]
+\`\`\`
+
 - *Type:* typing.List[[\`aws_cdk.aws_eks.Selector\`](#aws_cdk.aws_eks.Selector)]
 
 The selectors to match for pods to use this Fargate profile.
@@ -29469,6 +33665,10 @@ At least one selector is required and you may specify up to five selectors.
 
 ##### \`fargate_profile_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.property.fargate_profile_name\\"></a>
 
+\`\`\`python
+fargate_profile_name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* generated
 
@@ -29477,6 +33677,10 @@ The name of the Fargate profile.
 ---
 
 ##### \`pod_execution_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.property.pod_execution_role\\"></a>
+
+\`\`\`python
+pod_execution_role: IRole
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* a role will be automatically created
@@ -29493,6 +33697,10 @@ ECR image repositories.
 
 ##### \`subnet_selection\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.property.subnet_selection\\"></a>
 
+\`\`\`python
+subnet_selection: SubnetSelection
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* all private subnets of the VPC are selected.
 
@@ -29506,6 +33714,10 @@ on Fargate are not assigned public IP addresses, so only private subnets
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.property.vpc\\"></a>
 
+\`\`\`python
+vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 - *Default:* all private subnets used by theEKS cluster
 
@@ -29517,6 +33729,10 @@ By default, all private subnets are selected. You can customize this using
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.FargateProfileProps.property.cluster\\"></a>
+
+\`\`\`python
+cluster: Cluster
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.Cluster\`](#aws_cdk.aws_eks.Cluster)
 
@@ -29550,6 +33766,10 @@ aws_eks.HelmChartOptions(
 
 ##### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.chart\\"></a>
 
+\`\`\`python
+chart: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The name of the chart.
@@ -29557,6 +33777,10 @@ The name of the chart.
 ---
 
 ##### \`create_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.create_namespace\\"></a>
+
+\`\`\`python
+create_namespace: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -29567,6 +33791,10 @@ create namespace if not exist.
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.namespace\\"></a>
 
+\`\`\`python
+namespace: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* default
 
@@ -29576,6 +33804,10 @@ The Kubernetes namespace scope of the requests.
 
 ##### \`release\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.release\\"></a>
 
+\`\`\`python
+release: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
 
@@ -29584,6 +33816,10 @@ The name of the release.
 ---
 
 ##### \`repository\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.repository\\"></a>
+
+\`\`\`python
+repository: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -29596,6 +33832,10 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.timeout\\"></a>
 
+\`\`\`python
+timeout: Duration
+\`\`\`
+
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
 
@@ -29607,6 +33847,10 @@ Maximum 15 minutes.
 
 ##### \`values\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.values\\"></a>
 
+\`\`\`python
+values: typing.Mapping[typing.Any]
+\`\`\`
+
 - *Type:* typing.Mapping[\`typing.Any\`]
 - *Default:* No values are provided to the chart.
 
@@ -29616,6 +33860,10 @@ The values to be used by the chart.
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.version\\"></a>
 
+\`\`\`python
+version: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* If this is not specified, the latest version is installed
 
@@ -29624,6 +33872,10 @@ The chart version to install.
 ---
 
 ##### \`wait\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartOptions.property.wait\\"></a>
+
+\`\`\`python
+wait: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* Helm will not wait before marking release as successful
@@ -29657,6 +33909,10 @@ aws_eks.HelmChartProps(
 
 ##### \`chart\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.chart\\"></a>
 
+\`\`\`python
+chart: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The name of the chart.
@@ -29664,6 +33920,10 @@ The name of the chart.
 ---
 
 ##### \`create_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.create_namespace\\"></a>
+
+\`\`\`python
+create_namespace: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -29674,6 +33934,10 @@ create namespace if not exist.
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.namespace\\"></a>
 
+\`\`\`python
+namespace: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* default
 
@@ -29683,6 +33947,10 @@ The Kubernetes namespace scope of the requests.
 
 ##### \`release\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.release\\"></a>
 
+\`\`\`python
+release: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
 
@@ -29691,6 +33959,10 @@ The name of the release.
 ---
 
 ##### \`repository\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.repository\\"></a>
+
+\`\`\`python
+repository: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -29703,6 +33975,10 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.timeout\\"></a>
 
+\`\`\`python
+timeout: Duration
+\`\`\`
+
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
 
@@ -29714,6 +33990,10 @@ Maximum 15 minutes.
 
 ##### \`values\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.values\\"></a>
 
+\`\`\`python
+values: typing.Mapping[typing.Any]
+\`\`\`
+
 - *Type:* typing.Mapping[\`typing.Any\`]
 - *Default:* No values are provided to the chart.
 
@@ -29722,6 +34002,10 @@ The values to be used by the chart.
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.version\\"></a>
+
+\`\`\`python
+version: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* If this is not specified, the latest version is installed
@@ -29732,6 +34016,10 @@ The chart version to install.
 
 ##### \`wait\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.wait\\"></a>
 
+\`\`\`python
+wait: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* Helm will not wait before marking release as successful
 
@@ -29740,6 +34028,10 @@ Whether or not Helm should wait until all Pods, PVCs, Services, and minimum numb
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.HelmChartProps.property.cluster\\"></a>
+
+\`\`\`python
+cluster: ICluster
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -29766,6 +34058,10 @@ aws_eks.KubernetesManifestOptions(
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestOptions.property.prune\\"></a>
 
+\`\`\`python
+prune: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* based on the prune option of the cluster, which is \`true\` unless
 otherwise specified.
@@ -29791,6 +34087,10 @@ empty.
 ---
 
 ##### \`skip_validation\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestOptions.property.skip_validation\\"></a>
+
+\`\`\`python
+skip_validation: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -29819,6 +34119,10 @@ aws_eks.KubernetesManifestProps(
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.property.prune\\"></a>
 
+\`\`\`python
+prune: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* based on the prune option of the cluster, which is \`true\` unless
 otherwise specified.
@@ -29845,6 +34149,10 @@ empty.
 
 ##### \`skip_validation\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.property.skip_validation\\"></a>
 
+\`\`\`python
+skip_validation: bool
+\`\`\`
+
 - *Type:* \`bool\`
 - *Default:* false
 
@@ -29853,6 +34161,10 @@ A flag to signify if the manifest validation should be skipped.
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.property.cluster\\"></a>
+
+\`\`\`python
+cluster: ICluster
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -29863,6 +34175,10 @@ The EKS cluster to apply this manifest to.
 ---
 
 ##### \`manifest\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.property.manifest\\"></a>
+
+\`\`\`python
+manifest: typing.List[typing.Mapping[typing.Any]]
+\`\`\`
 
 - *Type:* typing.List[typing.Mapping[\`typing.Any\`]]
 
@@ -29877,6 +34193,10 @@ deleted, the resources in the manifest will be deleted through \`kubectl delete\
 ---
 
 ##### \`overwrite\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesManifestProps.property.overwrite\\"></a>
+
+\`\`\`python
+overwrite: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* false
@@ -29904,6 +34224,10 @@ aws_eks.CfnCluster.KubernetesNetworkConfigProperty(
 \`\`\`
 
 ##### \`service_ipv4_cidr\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.KubernetesNetworkConfigProperty.property.service_ipv4_cidr\\"></a>
+
+\`\`\`python
+service_ipv4_cidr: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -29934,6 +34258,10 @@ aws_eks.KubernetesObjectValueProps(
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.property.cluster\\"></a>
 
+\`\`\`python
+cluster: ICluster
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
 The EKS cluster to fetch attributes from.
@@ -29943,6 +34271,10 @@ The EKS cluster to fetch attributes from.
 ---
 
 ##### \`json_path\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.property.json_path\\"></a>
+
+\`\`\`python
+json_path: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -29954,6 +34286,10 @@ JSONPath to the specific value.
 
 ##### \`object_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.property.object_name\\"></a>
 
+\`\`\`python
+object_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The name of the object to query.
@@ -29961,6 +34297,10 @@ The name of the object to query.
 ---
 
 ##### \`object_type\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.property.object_type\\"></a>
+
+\`\`\`python
+object_type: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -29972,6 +34312,10 @@ The object type to query.
 
 ##### \`object_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.property.object_namespace\\"></a>
 
+\`\`\`python
+object_namespace: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* 'default'
 
@@ -29980,6 +34324,10 @@ The namespace the object belongs to.
 ---
 
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesObjectValueProps.property.timeout\\"></a>
+
+\`\`\`python
+timeout: Duration
+\`\`\`
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -30009,6 +34357,10 @@ aws_eks.KubernetesPatchProps(
 
 ##### \`apply_patch\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.property.apply_patch\\"></a>
 
+\`\`\`python
+apply_patch: typing.Mapping[typing.Any]
+\`\`\`
+
 - *Type:* typing.Mapping[\`typing.Any\`]
 
 The JSON object to pass to \`kubectl patch\` when the resource is created/updated.
@@ -30016,6 +34368,10 @@ The JSON object to pass to \`kubectl patch\` when the resource is created/update
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.property.cluster\\"></a>
+
+\`\`\`python
+cluster: ICluster
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -30027,6 +34383,10 @@ The cluster to apply the patch to.
 
 ##### \`resource_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.property.resource_name\\"></a>
 
+\`\`\`python
+resource_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The full name of the resource to patch (e.g. \`deployment/coredns\`).
@@ -30035,6 +34395,10 @@ The full name of the resource to patch (e.g. \`deployment/coredns\`).
 
 ##### \`restore_patch\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.property.restore_patch\\"></a>
 
+\`\`\`python
+restore_patch: typing.Mapping[typing.Any]
+\`\`\`
+
 - *Type:* typing.Mapping[\`typing.Any\`]
 
 The JSON object to pass to \`kubectl patch\` when the resource is removed.
@@ -30042,6 +34406,10 @@ The JSON object to pass to \`kubectl patch\` when the resource is removed.
 ---
 
 ##### \`patch_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.property.patch_type\\"></a>
+
+\`\`\`python
+patch_type: PatchType
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.PatchType\`](#aws_cdk.aws_eks.PatchType)
 - *Default:* PatchType.STRATEGIC
@@ -30053,6 +34421,10 @@ The default type used by \`kubectl patch\` is \\"strategic\\".
 ---
 
 ##### \`resource_namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.KubernetesPatchProps.property.resource_namespace\\"></a>
+
+\`\`\`python
+resource_namespace: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* \\"default\\"
@@ -30078,6 +34450,10 @@ aws_eks.CfnFargateProfile.LabelProperty(
 
 ##### \`key\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.LabelProperty.property.key\\"></a>
 
+\`\`\`python
+key: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnFargateProfile.LabelProperty.Key\`.
@@ -30087,6 +34463,10 @@ aws_eks.CfnFargateProfile.LabelProperty(
 ---
 
 ##### \`value\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.LabelProperty.property.value\\"></a>
+
+\`\`\`python
+value: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -30113,6 +34493,10 @@ aws_eks.LaunchTemplateSpec(
 
 ##### \`id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.LaunchTemplateSpec.property.id\\"></a>
 
+\`\`\`python
+id: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The Launch template ID.
@@ -30120,6 +34504,10 @@ The Launch template ID.
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.LaunchTemplateSpec.property.version\\"></a>
+
+\`\`\`python
+version: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* the default version of the launch template
@@ -30146,6 +34534,10 @@ aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty(
 
 ##### \`id\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.id\\"></a>
 
+\`\`\`python
+id: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnNodegroup.LaunchTemplateSpecificationProperty.Id\`.
@@ -30156,6 +34548,10 @@ aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty(
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.name\\"></a>
 
+\`\`\`python
+name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnNodegroup.LaunchTemplateSpecificationProperty.Name\`.
@@ -30165,6 +34561,10 @@ aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty(
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.version\\"></a>
+
+\`\`\`python
+version: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -30205,6 +34605,10 @@ aws_eks.NodegroupOptions(
 
 ##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.ami_type\\"></a>
 
+\`\`\`python
+ami_type: NodegroupAmiType
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.NodegroupAmiType\`](#aws_cdk.aws_eks.NodegroupAmiType)
 - *Default:* auto-determined from the instanceTypes property.
 
@@ -30214,6 +34618,10 @@ The AMI type for your node group.
 
 ##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.capacity_type\\"></a>
 
+\`\`\`python
+capacity_type: CapacityType
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.CapacityType\`](#aws_cdk.aws_eks.CapacityType)
 - *Default:* ON_DEMAND
 
@@ -30222,6 +34630,10 @@ The capacity type of the nodegroup.
 ---
 
 ##### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.desired_size\\"></a>
+
+\`\`\`python
+desired_size: typing.Union[int, float]
+\`\`\`
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 2
@@ -30235,6 +34647,10 @@ the nodewgroup will initially create \`minSize\` instances.
 
 ##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.disk_size\\"></a>
 
+\`\`\`python
+disk_size: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 20
 
@@ -30243,6 +34659,10 @@ The root device disk size (in GiB) for your node group instances.
 ---
 
 ##### \`force_update\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.force_update\\"></a>
+
+\`\`\`python
+force_update: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -30257,6 +34677,10 @@ running on the node.
 
 ##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.instance_types\\"></a>
 
+\`\`\`python
+instance_types: typing.List[InstanceType]
+\`\`\`
+
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)]
 - *Default:* t3.medium will be used according to the cloudformation document.
 
@@ -30268,6 +34692,10 @@ The instance types to use for your node group.
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.labels\\"></a>
 
+\`\`\`python
+labels: typing.Mapping[str]
+\`\`\`
+
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* None
 
@@ -30276,6 +34704,10 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 ---
 
 ##### \`launch_template_spec\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.launch_template_spec\\"></a>
+
+\`\`\`python
+launch_template_spec: LaunchTemplateSpec
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.LaunchTemplateSpec\`](#aws_cdk.aws_eks.LaunchTemplateSpec)
 - *Default:* no launch template
@@ -30288,6 +34720,10 @@ Launch template specification used for the nodegroup.
 
 ##### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.max_size\\"></a>
 
+\`\`\`python
+max_size: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* desiredSize
 
@@ -30298,6 +34734,10 @@ Managed node groups can support up to 100 nodes by default.
 ---
 
 ##### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.min_size\\"></a>
+
+\`\`\`python
+min_size: typing.Union[int, float]
+\`\`\`
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 1
@@ -30310,6 +34750,10 @@ This number must be greater than zero.
 
 ##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.nodegroup_name\\"></a>
 
+\`\`\`python
+nodegroup_name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* resource ID
 
@@ -30318,6 +34762,10 @@ Name of the Nodegroup.
 ---
 
 ##### \`node_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.node_role\\"></a>
+
+\`\`\`python
+node_role: IRole
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* None. Auto-generated if not specified.
@@ -30333,6 +34781,10 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 
 ##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.release_version\\"></a>
 
+\`\`\`python
+release_version: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
 
@@ -30341,6 +34793,10 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 ---
 
 ##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.remote_access\\"></a>
+
+\`\`\`python
+remote_access: NodegroupRemoteAccess
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.NodegroupRemoteAccess\`](#aws_cdk.aws_eks.NodegroupRemoteAccess)
 - *Default:* disabled
@@ -30355,6 +34811,10 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.subnets\\"></a>
 
+\`\`\`python
+subnets: SubnetSelection
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* private subnets
 
@@ -30368,6 +34828,10 @@ the name of your cluster.
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupOptions.property.tags\\"></a>
+
+\`\`\`python
+tags: typing.Mapping[str]
+\`\`\`
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* None
@@ -30412,6 +34876,10 @@ aws_eks.NodegroupProps(
 
 ##### \`ami_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.ami_type\\"></a>
 
+\`\`\`python
+ami_type: NodegroupAmiType
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.NodegroupAmiType\`](#aws_cdk.aws_eks.NodegroupAmiType)
 - *Default:* auto-determined from the instanceTypes property.
 
@@ -30421,6 +34889,10 @@ The AMI type for your node group.
 
 ##### \`capacity_type\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.capacity_type\\"></a>
 
+\`\`\`python
+capacity_type: CapacityType
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.CapacityType\`](#aws_cdk.aws_eks.CapacityType)
 - *Default:* ON_DEMAND
 
@@ -30429,6 +34901,10 @@ The capacity type of the nodegroup.
 ---
 
 ##### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.desired_size\\"></a>
+
+\`\`\`python
+desired_size: typing.Union[int, float]
+\`\`\`
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 2
@@ -30442,6 +34918,10 @@ the nodewgroup will initially create \`minSize\` instances.
 
 ##### \`disk_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.disk_size\\"></a>
 
+\`\`\`python
+disk_size: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 20
 
@@ -30450,6 +34930,10 @@ The root device disk size (in GiB) for your node group instances.
 ---
 
 ##### \`force_update\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.force_update\\"></a>
+
+\`\`\`python
+force_update: bool
+\`\`\`
 
 - *Type:* \`bool\`
 - *Default:* true
@@ -30464,6 +34948,10 @@ running on the node.
 
 ##### \`instance_types\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.instance_types\\"></a>
 
+\`\`\`python
+instance_types: typing.List[InstanceType]
+\`\`\`
+
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.InstanceType\`](#aws_cdk.aws_ec2.InstanceType)]
 - *Default:* t3.medium will be used according to the cloudformation document.
 
@@ -30475,6 +34963,10 @@ The instance types to use for your node group.
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.labels\\"></a>
 
+\`\`\`python
+labels: typing.Mapping[str]
+\`\`\`
+
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* None
 
@@ -30483,6 +34975,10 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 ---
 
 ##### \`launch_template_spec\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.launch_template_spec\\"></a>
+
+\`\`\`python
+launch_template_spec: LaunchTemplateSpec
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.LaunchTemplateSpec\`](#aws_cdk.aws_eks.LaunchTemplateSpec)
 - *Default:* no launch template
@@ -30495,6 +34991,10 @@ Launch template specification used for the nodegroup.
 
 ##### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.max_size\\"></a>
 
+\`\`\`python
+max_size: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* desiredSize
 
@@ -30505,6 +35005,10 @@ Managed node groups can support up to 100 nodes by default.
 ---
 
 ##### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.min_size\\"></a>
+
+\`\`\`python
+min_size: typing.Union[int, float]
+\`\`\`
 
 - *Type:* \`typing.Union[int, float]\`
 - *Default:* 1
@@ -30517,6 +35021,10 @@ This number must be greater than zero.
 
 ##### \`nodegroup_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.nodegroup_name\\"></a>
 
+\`\`\`python
+nodegroup_name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* resource ID
 
@@ -30525,6 +35033,10 @@ Name of the Nodegroup.
 ---
 
 ##### \`node_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.node_role\\"></a>
+
+\`\`\`python
+node_role: IRole
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 - *Default:* None. Auto-generated if not specified.
@@ -30540,6 +35052,10 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 
 ##### \`release_version\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.release_version\\"></a>
 
+\`\`\`python
+release_version: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
 
@@ -30548,6 +35064,10 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 ---
 
 ##### \`remote_access\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.remote_access\\"></a>
+
+\`\`\`python
+remote_access: NodegroupRemoteAccess
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.NodegroupRemoteAccess\`](#aws_cdk.aws_eks.NodegroupRemoteAccess)
 - *Default:* disabled
@@ -30561,6 +35081,10 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 ---
 
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.subnets\\"></a>
+
+\`\`\`python
+subnets: SubnetSelection
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ec2.SubnetSelection\`](#aws_cdk.aws_ec2.SubnetSelection)
 - *Default:* private subnets
@@ -30576,6 +35100,10 @@ the name of your cluster.
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.tags\\"></a>
 
+\`\`\`python
+tags: typing.Mapping[str]
+\`\`\`
+
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* None
 
@@ -30588,6 +35116,10 @@ associated with the node group, such as the Amazon EC2 instances or subnets.
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.NodegroupProps.property.cluster\\"></a>
+
+\`\`\`python
+cluster: ICluster
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -30614,6 +35146,10 @@ aws_eks.NodegroupRemoteAccess(
 
 ##### \`ssh_key_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.NodegroupRemoteAccess.property.ssh_key_name\\"></a>
 
+\`\`\`python
+ssh_key_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The Amazon EC2 SSH key that provides access for SSH communication with the worker nodes in the managed node group.
@@ -30621,6 +35157,10 @@ The Amazon EC2 SSH key that provides access for SSH communication with the worke
 ---
 
 ##### \`source_security_groups\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.NodegroupRemoteAccess.property.source_security_groups\\"></a>
+
+\`\`\`python
+source_security_groups: typing.List[ISecurityGroup]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)]
 - *Default:* port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
@@ -30648,6 +35188,10 @@ aws_eks.OpenIdConnectProviderProps(
 \`\`\`
 
 ##### \`url\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.OpenIdConnectProviderProps.property.url\\"></a>
+
+\`\`\`python
+url: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -30680,6 +35224,10 @@ aws_eks.CfnCluster.ProviderProperty(
 
 ##### \`key_arn\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.ProviderProperty.property.key_arn\\"></a>
 
+\`\`\`python
+key_arn: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnCluster.ProviderProperty.KeyArn\`.
@@ -30705,6 +35253,10 @@ aws_eks.CfnNodegroup.RemoteAccessProperty(
 
 ##### \`ec2_ssh_key\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty.property.ec2_ssh_key\\"></a>
 
+\`\`\`python
+ec2_ssh_key: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnNodegroup.RemoteAccessProperty.Ec2SshKey\`.
@@ -30714,6 +35266,10 @@ aws_eks.CfnNodegroup.RemoteAccessProperty(
 ---
 
 ##### \`source_security_groups\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.RemoteAccessProperty.property.source_security_groups\\"></a>
+
+\`\`\`python
+source_security_groups: typing.List[str]
+\`\`\`
 
 - *Type:* typing.List[\`str\`]
 
@@ -30740,6 +35296,10 @@ aws_eks.CfnCluster.ResourcesVpcConfigProperty(
 
 ##### \`subnet_ids\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty.property.subnet_ids\\"></a>
 
+\`\`\`python
+subnet_ids: typing.List[str]
+\`\`\`
+
 - *Type:* typing.List[\`str\`]
 
 \`CfnCluster.ResourcesVpcConfigProperty.SubnetIds\`.
@@ -30749,6 +35309,10 @@ aws_eks.CfnCluster.ResourcesVpcConfigProperty(
 ---
 
 ##### \`security_group_ids\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnCluster.ResourcesVpcConfigProperty.property.security_group_ids\\"></a>
+
+\`\`\`python
+security_group_ids: typing.List[str]
+\`\`\`
 
 - *Type:* typing.List[\`str\`]
 
@@ -30776,6 +35340,10 @@ aws_eks.CfnNodegroup.ScalingConfigProperty(
 
 ##### \`desired_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty.property.desired_size\\"></a>
 
+\`\`\`python
+desired_size: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 
 \`CfnNodegroup.ScalingConfigProperty.DesiredSize\`.
@@ -30786,6 +35354,10 @@ aws_eks.CfnNodegroup.ScalingConfigProperty(
 
 ##### \`max_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty.property.max_size\\"></a>
 
+\`\`\`python
+max_size: typing.Union[int, float]
+\`\`\`
+
 - *Type:* \`typing.Union[int, float]\`
 
 \`CfnNodegroup.ScalingConfigProperty.MaxSize\`.
@@ -30795,6 +35367,10 @@ aws_eks.CfnNodegroup.ScalingConfigProperty(
 ---
 
 ##### \`min_size\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.ScalingConfigProperty.property.min_size\\"></a>
+
+\`\`\`python
+min_size: typing.Union[int, float]
+\`\`\`
 
 - *Type:* \`typing.Union[int, float]\`
 
@@ -30821,6 +35397,10 @@ aws_eks.Selector(
 
 ##### \`namespace\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.Selector.property.namespace\\"></a>
 
+\`\`\`python
+namespace: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The Kubernetes namespace that the selector should match.
@@ -30832,6 +35412,10 @@ to target multiple namespaces.
 ---
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.Selector.property.labels\\"></a>
+
+\`\`\`python
+labels: typing.Mapping[str]
+\`\`\`
 
 - *Type:* typing.Mapping[\`str\`]
 - *Default:* all pods within the namespace will be selected.
@@ -30861,6 +35445,10 @@ aws_eks.CfnFargateProfile.SelectorProperty(
 
 ##### \`namespace\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty.property.namespace\\"></a>
 
+\`\`\`python
+namespace: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnFargateProfile.SelectorProperty.Namespace\`.
@@ -30870,6 +35458,10 @@ aws_eks.CfnFargateProfile.SelectorProperty(
 ---
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.SelectorProperty.property.labels\\"></a>
+
+\`\`\`python
+labels: typing.Union[IResolvable, typing.List[typing.Union[LabelProperty, IResolvable]]]
+\`\`\`
 
 - *Type:* typing.Union[[\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable), typing.List[typing.Union[[\`aws_cdk.aws_eks.CfnFargateProfile.LabelProperty\`](#aws_cdk.aws_eks.CfnFargateProfile.LabelProperty), [\`aws_cdk.IResolvable\`](#aws_cdk.IResolvable)]]]
 
@@ -30896,6 +35488,10 @@ aws_eks.ServiceAccountOptions(
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.property.name\\"></a>
 
+\`\`\`python
+name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* If no name is given, it will use the id of the resource.
 
@@ -30904,6 +35500,10 @@ The name of the service account.
 ---
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountOptions.property.namespace\\"></a>
+
+\`\`\`python
+namespace: str
+\`\`\`
 
 - *Type:* \`str\`
 - *Default:* \\"default\\"
@@ -30930,6 +35530,10 @@ aws_eks.ServiceAccountProps(
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.property.name\\"></a>
 
+\`\`\`python
+name: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* If no name is given, it will use the id of the resource.
 
@@ -30939,6 +35543,10 @@ The name of the service account.
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.property.namespace\\"></a>
 
+\`\`\`python
+namespace: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* \\"default\\"
 
@@ -30947,6 +35555,10 @@ The namespace of the service account.
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ServiceAccountProps.property.cluster\\"></a>
+
+\`\`\`python
+cluster: ICluster
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.ICluster\`](#aws_cdk.aws_eks.ICluster)
 
@@ -30971,6 +35583,10 @@ aws_eks.ServiceLoadBalancerAddressOptions(
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceLoadBalancerAddressOptions.property.namespace\\"></a>
 
+\`\`\`python
+namespace: str
+\`\`\`
+
 - *Type:* \`str\`
 - *Default:* 'default'
 
@@ -30979,6 +35595,10 @@ The namespace the service belongs to.
 ---
 
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ServiceLoadBalancerAddressOptions.property.timeout\\"></a>
+
+\`\`\`python
+timeout: Duration
+\`\`\`
 
 - *Type:* [\`aws_cdk.Duration\`](#aws_cdk.Duration)
 - *Default:* Duration.minutes(5)
@@ -31005,6 +35625,10 @@ aws_eks.CfnNodegroup.TaintProperty(
 
 ##### \`effect\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.TaintProperty.property.effect\\"></a>
 
+\`\`\`python
+effect: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnNodegroup.TaintProperty.Effect\`.
@@ -31015,6 +35639,10 @@ aws_eks.CfnNodegroup.TaintProperty(
 
 ##### \`key\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.TaintProperty.property.key\\"></a>
 
+\`\`\`python
+key: str
+\`\`\`
+
 - *Type:* \`str\`
 
 \`CfnNodegroup.TaintProperty.Key\`.
@@ -31024,6 +35652,10 @@ aws_eks.CfnNodegroup.TaintProperty(
 ---
 
 ##### \`value\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.CfnNodegroup.TaintProperty.property.value\\"></a>
+
+\`\`\`python
+value: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -31127,6 +35759,10 @@ CIDR blocks.
 
 ##### \`PRIVATE\` <a name=\\"aws_cdk.aws_eks.EndpointAccess.property.PRIVATE\\"></a>
 
+\`\`\`python
+PRIVATE: EndpointAccess
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 
 The cluster endpoint is only accessible through your VPC.
@@ -31136,6 +35772,10 @@ Worker node traffic to the endpoint will stay within your VPC.
 ---
 
 ##### \`PUBLIC\` <a name=\\"aws_cdk.aws_eks.EndpointAccess.property.PUBLIC\\"></a>
+
+\`\`\`python
+PUBLIC: EndpointAccess
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 
@@ -31151,6 +35791,10 @@ access the public endpoint from.
 ---
 
 ##### \`PUBLIC_AND_PRIVATE\` <a name=\\"aws_cdk.aws_eks.EndpointAccess.property.PUBLIC_AND_PRIVATE\\"></a>
+
+\`\`\`python
+PUBLIC_AND_PRIVATE: EndpointAccess
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 
@@ -31194,6 +35838,10 @@ custom version number.
 
 ##### \`version\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.version\\"></a>
 
+\`\`\`python
+version: str
+\`\`\`
+
 - *Type:* \`str\`
 
 cluster version number.
@@ -31204,6 +35852,10 @@ cluster version number.
 
 ##### \`V1_14\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_14\\"></a>
 
+\`\`\`python
+V1_14: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
 Kubernetes version 1.14.
@@ -31211,6 +35863,10 @@ Kubernetes version 1.14.
 ---
 
 ##### \`V1_15\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_15\\"></a>
+
+\`\`\`python
+V1_15: KubernetesVersion
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -31220,6 +35876,10 @@ Kubernetes version 1.15.
 
 ##### \`V1_16\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_16\\"></a>
 
+\`\`\`python
+V1_16: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
 Kubernetes version 1.16.
@@ -31227,6 +35887,10 @@ Kubernetes version 1.16.
 ---
 
 ##### \`V1_17\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_17\\"></a>
+
+\`\`\`python
+V1_17: KubernetesVersion
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -31236,6 +35900,10 @@ Kubernetes version 1.17.
 
 ##### \`V1_18\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_18\\"></a>
 
+\`\`\`python
+V1_18: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
 Kubernetes version 1.18.
@@ -31243,6 +35911,10 @@ Kubernetes version 1.18.
 ---
 
 ##### \`V1_19\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_19\\"></a>
+
+\`\`\`python
+V1_19: KubernetesVersion
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -31461,6 +36133,10 @@ The namespace of the service account.
 
 ##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.node\\"></a>
 
+\`\`\`python
+node: Node
+\`\`\`
+
 - *Type:* [\`constructs.Node\`](#constructs.Node)
 
 The tree node.
@@ -31468,6 +36144,10 @@ The tree node.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.env\\"></a>
+
+\`\`\`python
+env: ResourceEnvironment
+\`\`\`
 
 - *Type:* [\`aws_cdk.ResourceEnvironment\`](#aws_cdk.ResourceEnvironment)
 
@@ -31484,6 +36164,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.stack\\"></a>
 
+\`\`\`python
+stack: Stack
+\`\`\`
+
 - *Type:* [\`aws_cdk.Stack\`](#aws_cdk.Stack)
 
 The stack in which this resource is defined.
@@ -31492,11 +36176,19 @@ The stack in which this resource is defined.
 
 ##### \`connections\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.connections\\"></a>
 
+\`\`\`python
+connections: Connections
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.Connections\`](#aws_cdk.aws_ec2.Connections)
 
 ---
 
 ##### \`cluster_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_arn\\"></a>
+
+\`\`\`python
+cluster_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -31506,6 +36198,10 @@ The unique ARN assigned to the service by AWS in the form of arn:aws:eks:.
 
 ##### \`cluster_certificate_authority_data\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_certificate_authority_data\\"></a>
 
+\`\`\`python
+cluster_certificate_authority_data: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The certificate-authority-data for your cluster.
@@ -31513,6 +36209,10 @@ The certificate-authority-data for your cluster.
 ---
 
 ##### \`cluster_encryption_config_key_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_encryption_config_key_arn\\"></a>
+
+\`\`\`python
+cluster_encryption_config_key_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -31522,6 +36222,10 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ##### \`cluster_endpoint\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_endpoint\\"></a>
 
+\`\`\`python
+cluster_endpoint: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The API Server endpoint URL.
@@ -31529,6 +36233,10 @@ The API Server endpoint URL.
 ---
 
 ##### \`cluster_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_name\\"></a>
+
+\`\`\`python
+cluster_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -31538,6 +36246,10 @@ The physical name of the Cluster.
 
 ##### \`cluster_security_group\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_security_group\\"></a>
 
+\`\`\`python
+cluster_security_group: ISecurityGroup
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 
 The cluster security group that was created by Amazon EKS for the cluster.
@@ -31545,6 +36257,10 @@ The cluster security group that was created by Amazon EKS for the cluster.
 ---
 
 ##### \`cluster_security_group_id\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.cluster_security_group_id\\"></a>
+
+\`\`\`python
+cluster_security_group_id: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -31554,6 +36270,10 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 
 ##### \`open_id_connect_provider\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.open_id_connect_provider\\"></a>
 
+\`\`\`python
+open_id_connect_provider: IOpenIdConnectProvider
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_iam.IOpenIdConnectProvider\`](#aws_cdk.aws_iam.IOpenIdConnectProvider)
 
 The Open ID Connect Provider of the cluster used to configure Service Accounts.
@@ -31561,6 +36281,10 @@ The Open ID Connect Provider of the cluster used to configure Service Accounts.
 ---
 
 ##### \`prune\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.prune\\"></a>
+
+\`\`\`python
+prune: bool
+\`\`\`
 
 - *Type:* \`bool\`
 
@@ -31575,6 +36299,10 @@ apply\` operation with the \`--prune\` switch.
 
 ##### \`vpc\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.vpc\\"></a>
 
+\`\`\`python
+vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_ec2.IVpc\`](#aws_cdk.aws_ec2.IVpc)
 
 The VPC in which this Cluster was created.
@@ -31583,6 +36311,10 @@ The VPC in which this Cluster was created.
 
 ##### \`kubectl_environment\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.kubectl_environment\\"></a>
 
+\`\`\`python
+kubectl_environment: typing.Mapping[str]
+\`\`\`
+
 - *Type:* typing.Mapping[\`str\`]
 
 Custom environment variables when running \`kubectl\` against this cluster.
@@ -31590,6 +36322,10 @@ Custom environment variables when running \`kubectl\` against this cluster.
 ---
 
 ##### \`kubectl_layer\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.kubectl_layer\\"></a>
+
+\`\`\`python
+kubectl_layer: ILayerVersion
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_lambda.ILayerVersion\`](#aws_cdk.aws_lambda.ILayerVersion)
 
@@ -31601,6 +36337,10 @@ If not defined, a default layer will be used.
 
 ##### \`kubectl_memory\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.kubectl_memory\\"></a>
 
+\`\`\`python
+kubectl_memory: Size
+\`\`\`
+
 - *Type:* [\`aws_cdk.Size\`](#aws_cdk.Size)
 
 Amount of memory to allocate to the provider's lambda function.
@@ -31608,6 +36348,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`kubectl_private_subnets\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.kubectl_private_subnets\\"></a>
+
+\`\`\`python
+kubectl_private_subnets: typing.List[ISubnet]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.aws_ec2.ISubnet\`](#aws_cdk.aws_ec2.ISubnet)]
 
@@ -31620,6 +36364,10 @@ publicly.
 
 ##### \`kubectl_role\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.kubectl_role\\"></a>
 
+\`\`\`python
+kubectl_role: IRole
+\`\`\`
+
 - *Type:* [\`aws_cdk.aws_iam.IRole\`](#aws_cdk.aws_iam.IRole)
 
 An IAM role that can perform kubectl operations against this cluster.
@@ -31629,6 +36377,10 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 ---
 
 ##### \`kubectl_security_group\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_eks.ICluster.property.kubectl_security_group\\"></a>
+
+\`\`\`python
+kubectl_security_group: ISecurityGroup
+\`\`\`
 
 - *Type:* [\`aws_cdk.aws_ec2.ISecurityGroup\`](#aws_cdk.aws_ec2.ISecurityGroup)
 
@@ -31652,6 +36404,10 @@ NodeGroup interface.
 
 ##### \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.INodegroup.property.node\\"></a>
 
+\`\`\`python
+node: Node
+\`\`\`
+
 - *Type:* [\`constructs.Node\`](#constructs.Node)
 
 The tree node.
@@ -31659,6 +36415,10 @@ The tree node.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.INodegroup.property.env\\"></a>
+
+\`\`\`python
+env: ResourceEnvironment
+\`\`\`
 
 - *Type:* [\`aws_cdk.ResourceEnvironment\`](#aws_cdk.ResourceEnvironment)
 
@@ -31675,6 +36435,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.INodegroup.property.stack\\"></a>
 
+\`\`\`python
+stack: Stack
+\`\`\`
+
 - *Type:* [\`aws_cdk.Stack\`](#aws_cdk.Stack)
 
 The stack in which this resource is defined.
@@ -31682,6 +36446,10 @@ The stack in which this resource is defined.
 ---
 
 ##### \`nodegroup_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_eks.INodegroup.property.nodegroup_name\\"></a>
+
+\`\`\`python
+nodegroup_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -32025,11 +36793,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.attrArn\\"></a>
 
+\`\`\`typescript
+public readonly attrArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: TagManager
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.TagManager\`](#@aws-cdk/core.TagManager)
 
@@ -32041,6 +36817,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repositoryCatalogData\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryCatalogData\\"></a>
 
+\`\`\`typescript
+public readonly repositoryCatalogData: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -32051,6 +36831,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryPolicyText\\"></a>
 
+\`\`\`typescript
+public readonly repositoryPolicyText: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -32060,6 +36844,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -32072,6 +36860,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -32140,11 +36932,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.attrRegistryId\\"></a>
 
+\`\`\`typescript
+public readonly attrRegistryId: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.policyText\\"></a>
+
+\`\`\`typescript
+public readonly policyText: any
+\`\`\`
 
 - *Type:* \`any\`
 
@@ -32157,6 +36957,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -32225,11 +37029,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.attrRegistryId\\"></a>
 
+\`\`\`typescript
+public readonly attrRegistryId: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.replicationConfiguration\\"></a>
+
+\`\`\`typescript
+public readonly replicationConfiguration: IResolvable | ReplicationConfigurationProperty
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
 
@@ -32242,6 +37054,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -32310,17 +37126,29 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.attrArn\\"></a>
 
+\`\`\`typescript
+public readonly attrArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`attrRepositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.attrRepositoryUri\\"></a>
 
+\`\`\`typescript
+public readonly attrRepositoryUri: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: TagManager
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.TagManager\`](#@aws-cdk/core.TagManager)
 
@@ -32332,6 +37160,10 @@ tree inspector to collect and process attributes.
 
 ##### \`encryptionConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.encryptionConfiguration\\"></a>
 
+\`\`\`typescript
+public readonly encryptionConfiguration: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -32341,6 +37173,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`imageScanningConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.imageScanningConfiguration\\"></a>
+
+\`\`\`typescript
+public readonly imageScanningConfiguration: any
+\`\`\`
 
 - *Type:* \`any\`
 
@@ -32352,6 +37188,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.repositoryPolicyText\\"></a>
 
+\`\`\`typescript
+public readonly repositoryPolicyText: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -32361,6 +37201,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.imageTagMutability\\"></a>
+
+\`\`\`typescript
+public readonly imageTagMutability: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -32372,6 +37216,10 @@ tree inspector to collect and process attributes.
 
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.lifecyclePolicy\\"></a>
 
+\`\`\`typescript
+public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty\`](#@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty)
 
 \`AWS::ECR::Repository.LifecyclePolicy\`.
@@ -32381,6 +37229,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -32393,6 +37245,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -32566,6 +37422,10 @@ Repository.fromRepositoryName(scope: Construct, id: string, repositoryName: stri
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.property.repositoryArn\\"></a>
 
+\`\`\`typescript
+public readonly repositoryArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The ARN of the repository.
@@ -32573,6 +37433,10 @@ The ARN of the repository.
 ---
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -32788,6 +37652,10 @@ Optional image tag.
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryArn\\"></a>
 
+\`\`\`typescript
+public readonly repositoryArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The ARN of the repository.
@@ -32796,6 +37664,10 @@ The ARN of the repository.
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryName\\"></a>
 
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The name of the repository.
@@ -32803,6 +37675,10 @@ The name of the repository.
 ---
 
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryUri\\"></a>
+
+\`\`\`typescript
+public readonly repositoryUri: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -32831,6 +37707,10 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ##### \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
+\`\`\`typescript
+public readonly repositoryCatalogData: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -32840,6 +37720,10 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -32851,6 +37735,10 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
+\`\`\`typescript
+public readonly repositoryPolicyText: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -32860,6 +37748,10 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: CfnTag[]
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
 
@@ -32885,6 +37777,10 @@ const cfnRegistryPolicyProps: CfnRegistryPolicyProps = { ... }
 
 ##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicyProps.property.policyText\\"></a>
 
+\`\`\`typescript
+public readonly policyText: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::RegistryPolicy.PolicyText\`.
@@ -32908,6 +37804,10 @@ const cfnReplicationConfigurationProps: CfnReplicationConfigurationProps = { ...
 \`\`\`
 
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfigurationProps.property.replicationConfiguration\\"></a>
+
+\`\`\`typescript
+public readonly replicationConfiguration: IResolvable | ReplicationConfigurationProperty
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
 
@@ -32933,6 +37833,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ##### \`encryptionConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.encryptionConfiguration\\"></a>
 
+\`\`\`typescript
+public readonly encryptionConfiguration: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -32942,6 +37846,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 ---
 
 ##### \`imageScanningConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.imageScanningConfiguration\\"></a>
+
+\`\`\`typescript
+public readonly imageScanningConfiguration: any
+\`\`\`
 
 - *Type:* \`any\`
 
@@ -32953,6 +37861,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.imageTagMutability\\"></a>
 
+\`\`\`typescript
+public readonly imageTagMutability: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::ECR::Repository.ImageTagMutability\`.
@@ -32962,6 +37874,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 ---
 
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.lifecyclePolicy\\"></a>
+
+\`\`\`typescript
+public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty\`](#@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty)
 
@@ -32973,6 +37889,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.repositoryName\\"></a>
 
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::ECR::Repository.RepositoryName\`.
@@ -32983,6 +37903,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.repositoryPolicyText\\"></a>
 
+\`\`\`typescript
+public readonly repositoryPolicyText: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -32992,6 +37916,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: CfnTag[]
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
 
@@ -33015,6 +37943,10 @@ const lifecyclePolicyProperty: LifecyclePolicyProperty = { ... }
 
 ##### \`lifecyclePolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.property.lifecyclePolicyText\\"></a>
 
+\`\`\`typescript
+public readonly lifecyclePolicyText: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnRepository.LifecyclePolicyProperty.LifecyclePolicyText\`.
@@ -33024,6 +37956,10 @@ const lifecyclePolicyProperty: LifecyclePolicyProperty = { ... }
 ---
 
 ##### \`registryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.property.registryId\\"></a>
+
+\`\`\`typescript
+public readonly registryId: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -33047,6 +37983,10 @@ const lifecycleRule: LifecycleRule = { ... }
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.description\\"></a>
 
+\`\`\`typescript
+public readonly description: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* No description
 
@@ -33055,6 +37995,10 @@ Describes the purpose of the rule.
 ---
 
 ##### \`maxImageAge\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.maxImageAge\\"></a>
+
+\`\`\`typescript
+public readonly maxImageAge: Duration
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.Duration\`](#@aws-cdk/core.Duration)
 
@@ -33066,6 +38010,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ##### \`maxImageCount\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.maxImageCount\\"></a>
 
+\`\`\`typescript
+public readonly maxImageCount: number
+\`\`\`
+
 - *Type:* \`number\`
 
 The maximum number of images to retain.
@@ -33075,6 +38023,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 ---
 
 ##### \`rulePriority\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.rulePriority\\"></a>
+
+\`\`\`typescript
+public readonly rulePriority: number
+\`\`\`
 
 - *Type:* \`number\`
 - *Default:* Automatically assigned
@@ -33094,6 +38046,10 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ##### \`tagPrefixList\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.tagPrefixList\\"></a>
 
+\`\`\`typescript
+public readonly tagPrefixList: string[]
+\`\`\`
+
 - *Type:* \`string\`[]
 
 Select images that have ALL the given prefixes in their tag.
@@ -33103,6 +38059,10 @@ Only if tagStatus == TagStatus.Tagged
 ---
 
 ##### \`tagStatus\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.tagStatus\\"></a>
+
+\`\`\`typescript
+public readonly tagStatus: TagStatus
+\`\`\`
 
 - *Type:* [\`@aws-cdk/aws-ecr.TagStatus\`](#@aws-cdk/aws-ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -33128,6 +38088,10 @@ const onCloudTrailImagePushedOptions: OnCloudTrailImagePushedOptions = { ... }
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
+\`\`\`typescript
+public readonly description: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* No description
 
@@ -33136,6 +38100,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.eventPattern\\"></a>
+
+\`\`\`typescript
+public readonly eventPattern: EventPattern
+\`\`\`
 
 - *Type:* [\`@aws-cdk/aws-events.EventPattern\`](#@aws-cdk/aws-events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -33152,6 +38120,10 @@ on top of that filtering.
 
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.ruleName\\"></a>
 
+\`\`\`typescript
+public readonly ruleName: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -33161,6 +38133,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
+\`\`\`typescript
+public readonly target: IRuleTarget
+\`\`\`
+
 - *Type:* [\`@aws-cdk/aws-events.IRuleTarget\`](#@aws-cdk/aws-events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -33169,6 +38145,10 @@ The target to register for the event.
 ---
 
 ##### \`imageTag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.imageTag\\"></a>
+
+\`\`\`typescript
+public readonly imageTag: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* Watch changes to all tags
@@ -33191,6 +38171,10 @@ const onImageScanCompletedOptions: OnImageScanCompletedOptions = { ... }
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
+\`\`\`typescript
+public readonly description: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* No description
 
@@ -33199,6 +38183,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.eventPattern\\"></a>
+
+\`\`\`typescript
+public readonly eventPattern: EventPattern
+\`\`\`
 
 - *Type:* [\`@aws-cdk/aws-events.EventPattern\`](#@aws-cdk/aws-events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -33215,6 +38203,10 @@ on top of that filtering.
 
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.ruleName\\"></a>
 
+\`\`\`typescript
+public readonly ruleName: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -33224,6 +38216,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
+\`\`\`typescript
+public readonly target: IRuleTarget
+\`\`\`
+
 - *Type:* [\`@aws-cdk/aws-events.IRuleTarget\`](#@aws-cdk/aws-events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -33232,6 +38228,10 @@ The target to register for the event.
 ---
 
 ##### \`imageTags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.imageTags\\"></a>
+
+\`\`\`typescript
+public readonly imageTags: string[]
+\`\`\`
 
 - *Type:* \`string\`[]
 - *Default:* Watch the changes to the repository with all image tags
@@ -33256,6 +38256,10 @@ const replicationConfigurationProperty: ReplicationConfigurationProperty = { ...
 
 ##### \`rules\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
+\`\`\`typescript
+public readonly rules: IResolvable | IResolvable | ReplicationRuleProperty[]
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty)[]
 
 \`CfnReplicationConfiguration.ReplicationConfigurationProperty.Rules\`.
@@ -33278,6 +38282,10 @@ const replicationDestinationProperty: ReplicationDestinationProperty = { ... }
 
 ##### \`region\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
+\`\`\`typescript
+public readonly region: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnReplicationConfiguration.ReplicationDestinationProperty.Region\`.
@@ -33287,6 +38295,10 @@ const replicationDestinationProperty: ReplicationDestinationProperty = { ... }
 ---
 
 ##### \`registryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registryId\\"></a>
+
+\`\`\`typescript
+public readonly registryId: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -33310,6 +38322,10 @@ const replicationRuleProperty: ReplicationRuleProperty = { ... }
 
 ##### \`destinations\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
+\`\`\`typescript
+public readonly destinations: IResolvable | IResolvable | ReplicationDestinationProperty[]
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)[]
 
 \`CfnReplicationConfiguration.ReplicationRuleProperty.Destinations\`.
@@ -33330,11 +38346,19 @@ const repositoryAttributes: RepositoryAttributes = { ... }
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.property.repositoryArn\\"></a>
 
+\`\`\`typescript
+public readonly repositoryArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -33352,6 +38376,10 @@ const repositoryProps: RepositoryProps = { ... }
 
 ##### \`imageScanOnPush\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.imageScanOnPush\\"></a>
 
+\`\`\`typescript
+public readonly imageScanOnPush: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -33360,6 +38388,10 @@ Enable the scan on push when creating the repository.
 ---
 
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.imageTagMutability\\"></a>
+
+\`\`\`typescript
+public readonly imageTagMutability: TagMutability
+\`\`\`
 
 - *Type:* [\`@aws-cdk/aws-ecr.TagMutability\`](#@aws-cdk/aws-ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -33372,6 +38404,10 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ##### \`lifecycleRegistryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.lifecycleRegistryId\\"></a>
 
+\`\`\`typescript
+public readonly lifecycleRegistryId: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* The default registry is assumed.
 
@@ -33383,6 +38419,10 @@ The AWS account ID associated with the registry that contains the repository.
 
 ##### \`lifecycleRules\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.lifecycleRules\\"></a>
 
+\`\`\`typescript
+public readonly lifecycleRules: LifecycleRule[]
+\`\`\`
+
 - *Type:* [\`@aws-cdk/aws-ecr.LifecycleRule\`](#@aws-cdk/aws-ecr.LifecycleRule)[]
 - *Default:* No life cycle rules
 
@@ -33392,6 +38432,10 @@ Life cycle rules to apply to this registry.
 
 ##### \`removalPolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.removalPolicy\\"></a>
 
+\`\`\`typescript
+public readonly removalPolicy: RemovalPolicy
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.RemovalPolicy\`](#@aws-cdk/core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
 
@@ -33400,6 +38444,10 @@ Determine what happens to the repository when the resource/stack is deleted.
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* Automatically generated name.
@@ -33642,6 +38690,10 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 ##### \`node\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.node\\"></a>
 
+\`\`\`typescript
+public readonly node: ConstructNode
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.ConstructNode\`](#@aws-cdk/core.ConstructNode)
 
 The construct tree node for this construct.
@@ -33649,6 +38701,10 @@ The construct tree node for this construct.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.env\\"></a>
+
+\`\`\`typescript
+public readonly env: ResourceEnvironment
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.ResourceEnvironment\`](#@aws-cdk/core.ResourceEnvironment)
 
@@ -33665,6 +38721,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.stack\\"></a>
 
+\`\`\`typescript
+public readonly stack: Stack
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.Stack\`](#@aws-cdk/core.Stack)
 
 The stack in which this resource is defined.
@@ -33672,6 +38732,10 @@ The stack in which this resource is defined.
 ---
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryArn\\"></a>
+
+\`\`\`typescript
+public readonly repositoryArn: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -33681,6 +38745,10 @@ The ARN of the repository.
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryName\\"></a>
 
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The name of the repository.
@@ -33688,6 +38756,10 @@ The name of the repository.
 ---
 
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryUri\\"></a>
+
+\`\`\`typescript
+public readonly repositoryUri: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -33907,11 +38979,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.attrArn\\"></a>
 
+\`\`\`typescript
+public readonly attrArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: TagManager
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.TagManager\`](#@aws-cdk/core.TagManager)
 
@@ -33923,6 +39003,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repositoryCatalogData\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryCatalogData\\"></a>
 
+\`\`\`typescript
+public readonly repositoryCatalogData: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -33933,6 +39017,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryPolicyText\\"></a>
 
+\`\`\`typescript
+public readonly repositoryPolicyText: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -33942,6 +39030,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -33954,6 +39046,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -34022,11 +39118,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.attrRegistryId\\"></a>
 
+\`\`\`typescript
+public readonly attrRegistryId: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.policyText\\"></a>
+
+\`\`\`typescript
+public readonly policyText: any
+\`\`\`
 
 - *Type:* \`any\`
 
@@ -34039,6 +39143,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -34107,11 +39215,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.attrRegistryId\\"></a>
 
+\`\`\`typescript
+public readonly attrRegistryId: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.replicationConfiguration\\"></a>
+
+\`\`\`typescript
+public readonly replicationConfiguration: IResolvable | ReplicationConfigurationProperty
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
 
@@ -34124,6 +39240,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -34192,17 +39312,29 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.attrArn\\"></a>
 
+\`\`\`typescript
+public readonly attrArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`attrRepositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.attrRepositoryUri\\"></a>
 
+\`\`\`typescript
+public readonly attrRepositoryUri: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: TagManager
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.TagManager\`](#@aws-cdk/core.TagManager)
 
@@ -34214,6 +39346,10 @@ tree inspector to collect and process attributes.
 
 ##### \`encryptionConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.encryptionConfiguration\\"></a>
 
+\`\`\`typescript
+public readonly encryptionConfiguration: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -34223,6 +39359,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`imageScanningConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.imageScanningConfiguration\\"></a>
+
+\`\`\`typescript
+public readonly imageScanningConfiguration: any
+\`\`\`
 
 - *Type:* \`any\`
 
@@ -34234,6 +39374,10 @@ tree inspector to collect and process attributes.
 
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.repositoryPolicyText\\"></a>
 
+\`\`\`typescript
+public readonly repositoryPolicyText: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -34243,6 +39387,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.imageTagMutability\\"></a>
+
+\`\`\`typescript
+public readonly imageTagMutability: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -34254,6 +39402,10 @@ tree inspector to collect and process attributes.
 
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.lifecyclePolicy\\"></a>
 
+\`\`\`typescript
+public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty\`](#@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty)
 
 \`AWS::ECR::Repository.LifecyclePolicy\`.
@@ -34263,6 +39415,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -34275,6 +39431,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -34448,6 +39608,10 @@ Repository.fromRepositoryName(scope: Construct, id: string, repositoryName: stri
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.property.repositoryArn\\"></a>
 
+\`\`\`typescript
+public readonly repositoryArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The ARN of the repository.
@@ -34455,6 +39619,10 @@ The ARN of the repository.
 ---
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -34670,6 +39838,10 @@ Optional image tag.
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryArn\\"></a>
 
+\`\`\`typescript
+public readonly repositoryArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The ARN of the repository.
@@ -34678,6 +39850,10 @@ The ARN of the repository.
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryName\\"></a>
 
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The name of the repository.
@@ -34685,6 +39861,10 @@ The name of the repository.
 ---
 
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryUri\\"></a>
+
+\`\`\`typescript
+public readonly repositoryUri: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -34713,6 +39893,10 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ##### \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
+\`\`\`typescript
+public readonly repositoryCatalogData: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -34722,6 +39906,10 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -34733,6 +39921,10 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
+\`\`\`typescript
+public readonly repositoryPolicyText: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -34742,6 +39934,10 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: CfnTag[]
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
 
@@ -34767,6 +39963,10 @@ const cfnRegistryPolicyProps: CfnRegistryPolicyProps = { ... }
 
 ##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicyProps.property.policyText\\"></a>
 
+\`\`\`typescript
+public readonly policyText: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::RegistryPolicy.PolicyText\`.
@@ -34790,6 +39990,10 @@ const cfnReplicationConfigurationProps: CfnReplicationConfigurationProps = { ...
 \`\`\`
 
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfigurationProps.property.replicationConfiguration\\"></a>
+
+\`\`\`typescript
+public readonly replicationConfiguration: IResolvable | ReplicationConfigurationProperty
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
 
@@ -34815,6 +40019,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ##### \`encryptionConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.encryptionConfiguration\\"></a>
 
+\`\`\`typescript
+public readonly encryptionConfiguration: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::Repository.EncryptionConfiguration\`.
@@ -34824,6 +40032,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 ---
 
 ##### \`imageScanningConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.imageScanningConfiguration\\"></a>
+
+\`\`\`typescript
+public readonly imageScanningConfiguration: any
+\`\`\`
 
 - *Type:* \`any\`
 
@@ -34835,6 +40047,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.imageTagMutability\\"></a>
 
+\`\`\`typescript
+public readonly imageTagMutability: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::ECR::Repository.ImageTagMutability\`.
@@ -34844,6 +40060,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 ---
 
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.lifecyclePolicy\\"></a>
+
+\`\`\`typescript
+public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty\`](#@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty)
 
@@ -34855,6 +40075,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.repositoryName\\"></a>
 
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::ECR::Repository.RepositoryName\`.
@@ -34865,6 +40089,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.repositoryPolicyText\\"></a>
 
+\`\`\`typescript
+public readonly repositoryPolicyText: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::Repository.RepositoryPolicyText\`.
@@ -34874,6 +40102,10 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: CfnTag[]
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
 
@@ -34897,6 +40129,10 @@ const lifecyclePolicyProperty: LifecyclePolicyProperty = { ... }
 
 ##### \`lifecyclePolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.property.lifecyclePolicyText\\"></a>
 
+\`\`\`typescript
+public readonly lifecyclePolicyText: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnRepository.LifecyclePolicyProperty.LifecyclePolicyText\`.
@@ -34906,6 +40142,10 @@ const lifecyclePolicyProperty: LifecyclePolicyProperty = { ... }
 ---
 
 ##### \`registryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.property.registryId\\"></a>
+
+\`\`\`typescript
+public readonly registryId: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -34929,6 +40169,10 @@ const lifecycleRule: LifecycleRule = { ... }
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.description\\"></a>
 
+\`\`\`typescript
+public readonly description: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* No description
 
@@ -34937,6 +40181,10 @@ Describes the purpose of the rule.
 ---
 
 ##### \`maxImageAge\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.maxImageAge\\"></a>
+
+\`\`\`typescript
+public readonly maxImageAge: Duration
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.Duration\`](#@aws-cdk/core.Duration)
 
@@ -34948,6 +40196,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 ##### \`maxImageCount\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.maxImageCount\\"></a>
 
+\`\`\`typescript
+public readonly maxImageCount: number
+\`\`\`
+
 - *Type:* \`number\`
 
 The maximum number of images to retain.
@@ -34957,6 +40209,10 @@ Specify exactly one of maxImageCount and maxImageAge.
 ---
 
 ##### \`rulePriority\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.rulePriority\\"></a>
+
+\`\`\`typescript
+public readonly rulePriority: number
+\`\`\`
 
 - *Type:* \`number\`
 - *Default:* Automatically assigned
@@ -34976,6 +40232,10 @@ automatically assigned to them, higher than any rules that DO have priorities.
 
 ##### \`tagPrefixList\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.tagPrefixList\\"></a>
 
+\`\`\`typescript
+public readonly tagPrefixList: string[]
+\`\`\`
+
 - *Type:* \`string\`[]
 
 Select images that have ALL the given prefixes in their tag.
@@ -34985,6 +40245,10 @@ Only if tagStatus == TagStatus.Tagged
 ---
 
 ##### \`tagStatus\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.tagStatus\\"></a>
+
+\`\`\`typescript
+public readonly tagStatus: TagStatus
+\`\`\`
 
 - *Type:* [\`@aws-cdk/aws-ecr.TagStatus\`](#@aws-cdk/aws-ecr.TagStatus)
 - *Default:* TagStatus.Tagged if tagPrefixList is given, TagStatus.Any otherwise
@@ -35010,6 +40274,10 @@ const onCloudTrailImagePushedOptions: OnCloudTrailImagePushedOptions = { ... }
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
+\`\`\`typescript
+public readonly description: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* No description
 
@@ -35018,6 +40286,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.eventPattern\\"></a>
+
+\`\`\`typescript
+public readonly eventPattern: EventPattern
+\`\`\`
 
 - *Type:* [\`@aws-cdk/aws-events.EventPattern\`](#@aws-cdk/aws-events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -35034,6 +40306,10 @@ on top of that filtering.
 
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.ruleName\\"></a>
 
+\`\`\`typescript
+public readonly ruleName: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -35043,6 +40319,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
+\`\`\`typescript
+public readonly target: IRuleTarget
+\`\`\`
+
 - *Type:* [\`@aws-cdk/aws-events.IRuleTarget\`](#@aws-cdk/aws-events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -35051,6 +40331,10 @@ The target to register for the event.
 ---
 
 ##### \`imageTag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.imageTag\\"></a>
+
+\`\`\`typescript
+public readonly imageTag: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* Watch changes to all tags
@@ -35073,6 +40357,10 @@ const onImageScanCompletedOptions: OnImageScanCompletedOptions = { ... }
 
 ##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
+\`\`\`typescript
+public readonly description: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* No description
 
@@ -35081,6 +40369,10 @@ A description of the rule's purpose.
 ---
 
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.eventPattern\\"></a>
+
+\`\`\`typescript
+public readonly eventPattern: EventPattern
+\`\`\`
 
 - *Type:* [\`@aws-cdk/aws-events.EventPattern\`](#@aws-cdk/aws-events.EventPattern)
 - *Default:* No additional filtering based on an event pattern.
@@ -35097,6 +40389,10 @@ on top of that filtering.
 
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.ruleName\\"></a>
 
+\`\`\`typescript
+public readonly ruleName: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* AWS CloudFormation generates a unique physical ID.
 
@@ -35106,6 +40402,10 @@ A name for the rule.
 
 ##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
+\`\`\`typescript
+public readonly target: IRuleTarget
+\`\`\`
+
 - *Type:* [\`@aws-cdk/aws-events.IRuleTarget\`](#@aws-cdk/aws-events.IRuleTarget)
 - *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
 
@@ -35114,6 +40414,10 @@ The target to register for the event.
 ---
 
 ##### \`imageTags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.imageTags\\"></a>
+
+\`\`\`typescript
+public readonly imageTags: string[]
+\`\`\`
 
 - *Type:* \`string\`[]
 - *Default:* Watch the changes to the repository with all image tags
@@ -35138,6 +40442,10 @@ const replicationConfigurationProperty: ReplicationConfigurationProperty = { ...
 
 ##### \`rules\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
+\`\`\`typescript
+public readonly rules: IResolvable | IResolvable | ReplicationRuleProperty[]
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty)[]
 
 \`CfnReplicationConfiguration.ReplicationConfigurationProperty.Rules\`.
@@ -35160,6 +40468,10 @@ const replicationDestinationProperty: ReplicationDestinationProperty = { ... }
 
 ##### \`region\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
+\`\`\`typescript
+public readonly region: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnReplicationConfiguration.ReplicationDestinationProperty.Region\`.
@@ -35169,6 +40481,10 @@ const replicationDestinationProperty: ReplicationDestinationProperty = { ... }
 ---
 
 ##### \`registryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registryId\\"></a>
+
+\`\`\`typescript
+public readonly registryId: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -35192,6 +40508,10 @@ const replicationRuleProperty: ReplicationRuleProperty = { ... }
 
 ##### \`destinations\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
+\`\`\`typescript
+public readonly destinations: IResolvable | IResolvable | ReplicationDestinationProperty[]
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)[]
 
 \`CfnReplicationConfiguration.ReplicationRuleProperty.Destinations\`.
@@ -35212,11 +40532,19 @@ const repositoryAttributes: RepositoryAttributes = { ... }
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.property.repositoryArn\\"></a>
 
+\`\`\`typescript
+public readonly repositoryArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -35234,6 +40562,10 @@ const repositoryProps: RepositoryProps = { ... }
 
 ##### \`imageScanOnPush\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.imageScanOnPush\\"></a>
 
+\`\`\`typescript
+public readonly imageScanOnPush: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -35242,6 +40574,10 @@ Enable the scan on push when creating the repository.
 ---
 
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.imageTagMutability\\"></a>
+
+\`\`\`typescript
+public readonly imageTagMutability: TagMutability
+\`\`\`
 
 - *Type:* [\`@aws-cdk/aws-ecr.TagMutability\`](#@aws-cdk/aws-ecr.TagMutability)
 - *Default:* TagMutability.MUTABLE
@@ -35254,6 +40590,10 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 
 ##### \`lifecycleRegistryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.lifecycleRegistryId\\"></a>
 
+\`\`\`typescript
+public readonly lifecycleRegistryId: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* The default registry is assumed.
 
@@ -35265,6 +40605,10 @@ The AWS account ID associated with the registry that contains the repository.
 
 ##### \`lifecycleRules\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.lifecycleRules\\"></a>
 
+\`\`\`typescript
+public readonly lifecycleRules: LifecycleRule[]
+\`\`\`
+
 - *Type:* [\`@aws-cdk/aws-ecr.LifecycleRule\`](#@aws-cdk/aws-ecr.LifecycleRule)[]
 - *Default:* No life cycle rules
 
@@ -35274,6 +40618,10 @@ Life cycle rules to apply to this registry.
 
 ##### \`removalPolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.removalPolicy\\"></a>
 
+\`\`\`typescript
+public readonly removalPolicy: RemovalPolicy
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.RemovalPolicy\`](#@aws-cdk/core.RemovalPolicy)
 - *Default:* RemovalPolicy.Retain
 
@@ -35282,6 +40630,10 @@ Determine what happens to the repository when the resource/stack is deleted.
 ---
 
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* Automatically generated name.
@@ -35524,6 +40876,10 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 ##### \`node\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.node\\"></a>
 
+\`\`\`typescript
+public readonly node: ConstructNode
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.ConstructNode\`](#@aws-cdk/core.ConstructNode)
 
 The construct tree node for this construct.
@@ -35531,6 +40887,10 @@ The construct tree node for this construct.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.env\\"></a>
+
+\`\`\`typescript
+public readonly env: ResourceEnvironment
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.ResourceEnvironment\`](#@aws-cdk/core.ResourceEnvironment)
 
@@ -35547,6 +40907,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.stack\\"></a>
 
+\`\`\`typescript
+public readonly stack: Stack
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.Stack\`](#@aws-cdk/core.Stack)
 
 The stack in which this resource is defined.
@@ -35554,6 +40918,10 @@ The stack in which this resource is defined.
 ---
 
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryArn\\"></a>
+
+\`\`\`typescript
+public readonly repositoryArn: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -35563,6 +40931,10 @@ The ARN of the repository.
 
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryName\\"></a>
 
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The name of the repository.
@@ -35570,6 +40942,10 @@ The name of the repository.
 ---
 
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryUri\\"></a>
+
+\`\`\`typescript
+public readonly repositoryUri: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37020,11 +42396,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.attrArn\\"></a>
 
+\`\`\`typescript
+public readonly attrArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.TagManager\`](#aws-cdk-lib.TagManager)
 
@@ -37036,6 +42420,10 @@ tree inspector to collect and process attributes.
 
 ##### \`addonName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.addonName\\"></a>
 
+\`\`\`typescript
+public readonly addonName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Addon.AddonName\`.
@@ -37045,6 +42433,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.clusterName\\"></a>
+
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37056,6 +42448,10 @@ tree inspector to collect and process attributes.
 
 ##### \`addonVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.addonVersion\\"></a>
 
+\`\`\`typescript
+public readonly addonVersion: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Addon.AddonVersion\`.
@@ -37066,6 +42462,10 @@ tree inspector to collect and process attributes.
 
 ##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.resolveConflicts\\"></a>
 
+\`\`\`typescript
+public readonly resolveConflicts: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Addon.ResolveConflicts\`.
@@ -37075,6 +42475,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.serviceAccountRoleArn\\"></a>
+
+\`\`\`typescript
+public readonly serviceAccountRoleArn: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37087,6 +42491,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37155,11 +42563,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrArn\\"></a>
 
+\`\`\`typescript
+public readonly attrArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`attrCertificateAuthorityData\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrCertificateAuthorityData\\"></a>
+
+\`\`\`typescript
+public readonly attrCertificateAuthorityData: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37167,11 +42583,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrClusterSecurityGroupId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrClusterSecurityGroupId\\"></a>
 
+\`\`\`typescript
+public readonly attrClusterSecurityGroupId: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`attrEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrEncryptionConfigKeyArn\\"></a>
+
+\`\`\`typescript
+public readonly attrEncryptionConfigKeyArn: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37179,17 +42603,29 @@ tree inspector to collect and process attributes.
 
 ##### \`attrEndpoint\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrEndpoint\\"></a>
 
+\`\`\`typescript
+public readonly attrEndpoint: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`attrOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrOpenIdConnectIssuerUrl\\"></a>
 
+\`\`\`typescript
+public readonly attrOpenIdConnectIssuerUrl: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.resourcesVpcConfig\\"></a>
+
+\`\`\`typescript
+public readonly resourcesVpcConfig: ResourcesVpcConfigProperty | IResolvable
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -37201,6 +42637,10 @@ tree inspector to collect and process attributes.
 
 ##### \`roleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.roleArn\\"></a>
 
+\`\`\`typescript
+public readonly roleArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Cluster.RoleArn\`.
@@ -37210,6 +42650,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.encryptionConfig\\"></a>
+
+\`\`\`typescript
+public readonly encryptionConfig: IResolvable | EncryptionConfigProperty | IResolvable[]
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
@@ -37221,6 +42665,10 @@ tree inspector to collect and process attributes.
 
 ##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.kubernetesNetworkConfig\\"></a>
 
+\`\`\`typescript
+public readonly kubernetesNetworkConfig: KubernetesNetworkConfigProperty | IResolvable
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
 \`AWS::EKS::Cluster.KubernetesNetworkConfig\`.
@@ -37231,6 +42679,10 @@ tree inspector to collect and process attributes.
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.name\\"></a>
 
+\`\`\`typescript
+public readonly name: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Cluster.Name\`.
@@ -37240,6 +42692,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.version\\"></a>
+
+\`\`\`typescript
+public readonly version: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37252,6 +42708,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37320,11 +42780,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.attrArn\\"></a>
 
+\`\`\`typescript
+public readonly attrArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.TagManager\`](#aws-cdk-lib.TagManager)
 
@@ -37336,6 +42804,10 @@ tree inspector to collect and process attributes.
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.clusterName\\"></a>
 
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::FargateProfile.ClusterName\`.
@@ -37345,6 +42817,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.podExecutionRoleArn\\"></a>
+
+\`\`\`typescript
+public readonly podExecutionRoleArn: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37356,6 +42832,10 @@ tree inspector to collect and process attributes.
 
 ##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.selectors\\"></a>
 
+\`\`\`typescript
+public readonly selectors: IResolvable | SelectorProperty | IResolvable[]
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
 \`AWS::EKS::FargateProfile.Selectors\`.
@@ -37366,6 +42846,10 @@ tree inspector to collect and process attributes.
 
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.fargateProfileName\\"></a>
 
+\`\`\`typescript
+public readonly fargateProfileName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::FargateProfile.FargateProfileName\`.
@@ -37375,6 +42859,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.subnets\\"></a>
+
+\`\`\`typescript
+public readonly subnets: string[]
+\`\`\`
 
 - *Type:* \`string\`[]
 
@@ -37387,6 +42875,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37455,11 +42947,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.attrArn\\"></a>
 
+\`\`\`typescript
+public readonly attrArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`attrClusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.attrClusterName\\"></a>
+
+\`\`\`typescript
+public readonly attrClusterName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37467,11 +42967,19 @@ tree inspector to collect and process attributes.
 
 ##### \`attrNodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.attrNodegroupName\\"></a>
 
+\`\`\`typescript
+public readonly attrNodegroupName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.TagManager\`](#aws-cdk-lib.TagManager)
 
@@ -37483,6 +42991,10 @@ tree inspector to collect and process attributes.
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.clusterName\\"></a>
 
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Nodegroup.ClusterName\`.
@@ -37492,6 +43004,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`labels\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.labels\\"></a>
+
+\`\`\`typescript
+public readonly labels: any
+\`\`\`
 
 - *Type:* \`any\`
 
@@ -37503,6 +43019,10 @@ tree inspector to collect and process attributes.
 
 ##### \`nodeRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.nodeRole\\"></a>
 
+\`\`\`typescript
+public readonly nodeRole: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Nodegroup.NodeRole\`.
@@ -37512,6 +43032,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`subnets\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.subnets\\"></a>
+
+\`\`\`typescript
+public readonly subnets: string[]
+\`\`\`
 
 - *Type:* \`string\`[]
 
@@ -37523,6 +43047,10 @@ tree inspector to collect and process attributes.
 
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.amiType\\"></a>
 
+\`\`\`typescript
+public readonly amiType: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Nodegroup.AmiType\`.
@@ -37532,6 +43060,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.capacityType\\"></a>
+
+\`\`\`typescript
+public readonly capacityType: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37543,6 +43075,10 @@ tree inspector to collect and process attributes.
 
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.diskSize\\"></a>
 
+\`\`\`typescript
+public readonly diskSize: number
+\`\`\`
+
 - *Type:* \`number\`
 
 \`AWS::EKS::Nodegroup.DiskSize\`.
@@ -37552,6 +43088,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.forceUpdateEnabled\\"></a>
+
+\`\`\`typescript
+public readonly forceUpdateEnabled: boolean | IResolvable
+\`\`\`
 
 - *Type:* \`boolean\` | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -37563,6 +43103,10 @@ tree inspector to collect and process attributes.
 
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.instanceTypes\\"></a>
 
+\`\`\`typescript
+public readonly instanceTypes: string[]
+\`\`\`
+
 - *Type:* \`string\`[]
 
 \`AWS::EKS::Nodegroup.InstanceTypes\`.
@@ -37572,6 +43116,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.launchTemplate\\"></a>
+
+\`\`\`typescript
+public readonly launchTemplate: LaunchTemplateSpecificationProperty | IResolvable
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -37583,6 +43131,10 @@ tree inspector to collect and process attributes.
 
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.nodegroupName\\"></a>
 
+\`\`\`typescript
+public readonly nodegroupName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Nodegroup.NodegroupName\`.
@@ -37592,6 +43144,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.releaseVersion\\"></a>
+
+\`\`\`typescript
+public readonly releaseVersion: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37603,6 +43159,10 @@ tree inspector to collect and process attributes.
 
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.remoteAccess\\"></a>
 
+\`\`\`typescript
+public readonly remoteAccess: RemoteAccessProperty | IResolvable
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
 \`AWS::EKS::Nodegroup.RemoteAccess\`.
@@ -37612,6 +43172,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.scalingConfig\\"></a>
+
+\`\`\`typescript
+public readonly scalingConfig: ScalingConfigProperty | IResolvable
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -37623,6 +43187,10 @@ tree inspector to collect and process attributes.
 
 ##### \`taints\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.taints\\"></a>
 
+\`\`\`typescript
+public readonly taints: IResolvable | TaintProperty | IResolvable[]
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
 \`AWS::EKS::Nodegroup.Taints\`.
@@ -37632,6 +43200,10 @@ tree inspector to collect and process attributes.
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.version\\"></a>
+
+\`\`\`typescript
+public readonly version: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37644,6 +43216,10 @@ tree inspector to collect and process attributes.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+\`\`\`typescript
+public readonly CFN_RESOURCE_TYPE_NAME: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37922,6 +43498,10 @@ the cluster properties to use for importing information.
 
 ##### \`adminRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.adminRole\\"></a>
 
+\`\`\`typescript
+public readonly adminRole: Role
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_iam.Role\`](#aws-cdk-lib.aws_iam.Role)
 
 An IAM role with administrative permissions to create or update the cluster.
@@ -37932,6 +43512,10 @@ This role also has \`systems:master\` permissions.
 
 ##### \`awsAuth\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.awsAuth\\"></a>
 
+\`\`\`typescript
+public readonly awsAuth: AwsAuth
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.AwsAuth\`](#aws-cdk-lib.aws_eks.AwsAuth)
 
 Lazily creates the AwsAuth resource, which manages AWS authentication mapping.
@@ -37939,6 +43523,10 @@ Lazily creates the AwsAuth resource, which manages AWS authentication mapping.
 ---
 
 ##### \`clusterArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterArn\\"></a>
+
+\`\`\`typescript
+public readonly clusterArn: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37948,6 +43536,10 @@ The AWS generated ARN for the Cluster resource.
 
 ##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterCertificateAuthorityData\\"></a>
 
+\`\`\`typescript
+public readonly clusterCertificateAuthorityData: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The certificate-authority-data for your cluster.
@@ -37956,6 +43548,10 @@ The certificate-authority-data for your cluster.
 
 ##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterEncryptionConfigKeyArn\\"></a>
 
+\`\`\`typescript
+public readonly clusterEncryptionConfigKeyArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 Amazon Resource Name (ARN) or alias of the customer master key (CMK).
@@ -37963,6 +43559,10 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 ---
 
 ##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterEndpoint\\"></a>
+
+\`\`\`typescript
+public readonly clusterEndpoint: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37974,6 +43574,10 @@ This is the URL inside the kubeconfig file to use with kubectl
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterName\\"></a>
 
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The Name of the created EKS Cluster.
@@ -37981,6 +43585,10 @@ The Name of the created EKS Cluster.
 ---
 
 ##### \`clusterOpenIdConnectIssuer\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterOpenIdConnectIssuer\\"></a>
+
+\`\`\`typescript
+public readonly clusterOpenIdConnectIssuer: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -37994,6 +43602,10 @@ stock \`CfnCluster\`), this is \`undefined\`.
 
 ##### \`clusterOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterOpenIdConnectIssuerUrl\\"></a>
 
+\`\`\`typescript
+public readonly clusterOpenIdConnectIssuerUrl: string
+\`\`\`
+
 - *Type:* \`string\`
 
 If this cluster is kubectl-enabled, returns the OpenID Connect issuer url.
@@ -38006,6 +43618,10 @@ stock \`CfnCluster\`), this is \`undefined\`.
 
 ##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterSecurityGroup\\"></a>
 
+\`\`\`typescript
+public readonly clusterSecurityGroup: ISecurityGroup
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 
 The cluster security group that was created by Amazon EKS for the cluster.
@@ -38013,6 +43629,10 @@ The cluster security group that was created by Amazon EKS for the cluster.
 ---
 
 ##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterSecurityGroupId\\"></a>
+
+\`\`\`typescript
+public readonly clusterSecurityGroupId: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -38022,6 +43642,10 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 
 ##### \`connections\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.connections\\"></a>
 
+\`\`\`typescript
+public readonly connections: Connections
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.Connections\`](#aws-cdk-lib.aws_ec2.Connections)
 
 Manages connection rules (Security Group Rules) for the cluster.
@@ -38029,6 +43653,10 @@ Manages connection rules (Security Group Rules) for the cluster.
 ---
 
 ##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.openIdConnectProvider\\"></a>
+
+\`\`\`typescript
+public readonly openIdConnectProvider: IOpenIdConnectProvider
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IOpenIdConnectProvider\`](#aws-cdk-lib.aws_iam.IOpenIdConnectProvider)
 
@@ -38040,6 +43668,10 @@ A provider will only be defined if this property is accessed (lazy initializatio
 
 ##### \`prune\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.prune\\"></a>
 
+\`\`\`typescript
+public readonly prune: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 
 Determines if Kubernetes resources can be pruned automatically.
@@ -38047,6 +43679,10 @@ Determines if Kubernetes resources can be pruned automatically.
 ---
 
 ##### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.role\\"></a>
+
+\`\`\`typescript
+public readonly role: IRole
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
@@ -38056,6 +43692,10 @@ IAM role assumed by the EKS Control Plane.
 
 ##### \`vpc\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.vpc\\"></a>
 
+\`\`\`typescript
+public readonly vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 
 The VPC in which this Cluster was created.
@@ -38063,6 +43703,10 @@ The VPC in which this Cluster was created.
 ---
 
 ##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.defaultCapacity\\"></a>
+
+\`\`\`typescript
+public readonly defaultCapacity: AutoScalingGroup
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.AutoScalingGroup\`](#aws-cdk-lib.aws_autoscaling.AutoScalingGroup)
 
@@ -38075,6 +43719,10 @@ This will be \`undefined\` if the \`defaultCapacityType\` is not \`EC2\` or
 
 ##### \`defaultNodegroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.defaultNodegroup\\"></a>
 
+\`\`\`typescript
+public readonly defaultNodegroup: Nodegroup
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.Nodegroup\`](#aws-cdk-lib.aws_eks.Nodegroup)
 
 The node group that hosts the default capacity for this cluster.
@@ -38086,6 +43734,10 @@ This will be \`undefined\` if the \`defaultCapacityType\` is \`EC2\` or
 
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlEnvironment\\"></a>
 
+\`\`\`typescript
+public readonly kubectlEnvironment: {[ key: string ]: string}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`string\`}
 
 Custom environment variables when running \`kubectl\` against this cluster.
@@ -38093,6 +43745,10 @@ Custom environment variables when running \`kubectl\` against this cluster.
 ---
 
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlLayer\\"></a>
+
+\`\`\`typescript
+public readonly kubectlLayer: ILayerVersion
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
 
@@ -38105,6 +43761,10 @@ undefined, a SAR app that contains this layer will be used.
 
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlMemory\\"></a>
 
+\`\`\`typescript
+public readonly kubectlMemory: Size
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
 
 The amount of memory allocated to the kubectl provider's lambda function.
@@ -38112,6 +43772,10 @@ The amount of memory allocated to the kubectl provider's lambda function.
 ---
 
 ##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlPrivateSubnets\\"></a>
+
+\`\`\`typescript
+public readonly kubectlPrivateSubnets: ISubnet[]
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISubnet\`](#aws-cdk-lib.aws_ec2.ISubnet)[]
 - *Default:* If not specified, the k8s endpoint is expected to be accessible
@@ -38123,6 +43787,10 @@ Subnets to host the \`kubectl\` compute resources.
 
 ##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlRole\\"></a>
 
+\`\`\`typescript
+public readonly kubectlRole: IRole
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
 An IAM role that can perform kubectl operations against this cluster.
@@ -38132,6 +43800,10 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 ---
 
 ##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlSecurityGroup\\"></a>
+
+\`\`\`typescript
+public readonly kubectlSecurityGroup: ISecurityGroup
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 - *Default:* If not specified, the k8s endpoint is expected to be accessible
@@ -38235,6 +43907,10 @@ new aws_eks.FargateProfile(scope: Construct, id: string, props: FargateProfilePr
 
 ##### \`fargateProfileArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.property.fargateProfileArn\\"></a>
 
+\`\`\`typescript
+public readonly fargateProfileArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The full Amazon Resource Name (ARN) of the Fargate profile.
@@ -38243,6 +43919,10 @@ The full Amazon Resource Name (ARN) of the Fargate profile.
 
 ##### \`fargateProfileName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.property.fargateProfileName\\"></a>
 
+\`\`\`typescript
+public readonly fargateProfileName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The name of the Fargate profile.
@@ -38250,6 +43930,10 @@ The name of the Fargate profile.
 ---
 
 ##### \`podExecutionRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.property.podExecutionRole\\"></a>
+
+\`\`\`typescript
+public readonly podExecutionRole: IRole
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
@@ -38262,6 +43946,10 @@ ECR image repositories.
 ---
 
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: TagManager
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.TagManager\`](#aws-cdk-lib.TagManager)
 
@@ -38308,6 +43996,10 @@ new aws_eks.HelmChart(scope: Construct, id: string, props: HelmChartProps)
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`RESOURCE_TYPE\` <a name=\\"aws-cdk-lib.aws_eks.HelmChart.property.RESOURCE_TYPE\\"></a>
+
+\`\`\`typescript
+public readonly RESOURCE_TYPE: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -38357,6 +44049,10 @@ new aws_eks.KubernetesManifest(scope: Construct, id: string, props: KubernetesMa
 
 ##### \`RESOURCE_TYPE\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifest.property.RESOURCE_TYPE\\"></a>
 
+\`\`\`typescript
+public readonly RESOURCE_TYPE: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The CloudFormation reosurce type.
@@ -38401,6 +44097,10 @@ new aws_eks.KubernetesObjectValue(scope: Construct, id: string, props: Kubernete
 
 ##### \`value\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.property.value\\"></a>
 
+\`\`\`typescript
+public readonly value: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The value as a string token.
@@ -38410,6 +44110,10 @@ The value as a string token.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`RESOURCE_TYPE\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.property.RESOURCE_TYPE\\"></a>
+
+\`\`\`typescript
+public readonly RESOURCE_TYPE: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -38518,6 +44222,10 @@ aws_eks.Nodegroup.fromNodegroupName(scope: Construct, id: string, nodegroupName:
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.property.cluster\\"></a>
 
+\`\`\`typescript
+public readonly cluster: ICluster
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
 the Amazon EKS cluster resource.
@@ -38525,6 +44233,10 @@ the Amazon EKS cluster resource.
 ---
 
 ##### \`nodegroupArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.property.nodegroupArn\\"></a>
+
+\`\`\`typescript
+public readonly nodegroupArn: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -38534,6 +44246,10 @@ ARN of the nodegroup.
 
 ##### \`nodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.property.nodegroupName\\"></a>
 
+\`\`\`typescript
+public readonly nodegroupName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 Nodegroup name.
@@ -38541,6 +44257,10 @@ Nodegroup name.
 ---
 
 ##### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.property.role\\"></a>
+
+\`\`\`typescript
+public readonly role: IRole
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
@@ -38649,6 +44369,10 @@ public addToPrincipalPolicy(statement: PolicyStatement)
 
 ##### \`assumeRoleAction\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.assumeRoleAction\\"></a>
 
+\`\`\`typescript
+public readonly assumeRoleAction: string
+\`\`\`
+
 - *Type:* \`string\`
 
 When this Principal is used in an AssumeRole policy, the action to use.
@@ -38656,6 +44380,10 @@ When this Principal is used in an AssumeRole policy, the action to use.
 ---
 
 ##### \`grantPrincipal\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.grantPrincipal\\"></a>
+
+\`\`\`typescript
+public readonly grantPrincipal: IPrincipal
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IPrincipal\`](#aws-cdk-lib.aws_iam.IPrincipal)
 
@@ -38665,6 +44393,10 @@ The principal to grant permissions to.
 
 ##### \`policyFragment\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.policyFragment\\"></a>
 
+\`\`\`typescript
+public readonly policyFragment: PrincipalPolicyFragment
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_iam.PrincipalPolicyFragment\`](#aws-cdk-lib.aws_iam.PrincipalPolicyFragment)
 
 Return the policy fragment that identifies this principal in a Policy.
@@ -38672,6 +44404,10 @@ Return the policy fragment that identifies this principal in a Policy.
 ---
 
 ##### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.role\\"></a>
+
+\`\`\`typescript
+public readonly role: IRole
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
@@ -38681,6 +44417,10 @@ The role which is linked to the service account.
 
 ##### \`serviceAccountName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.serviceAccountName\\"></a>
 
+\`\`\`typescript
+public readonly serviceAccountName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The name of the service account.
@@ -38688,6 +44428,10 @@ The name of the service account.
 ---
 
 ##### \`serviceAccountNamespace\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.serviceAccountNamespace\\"></a>
+
+\`\`\`typescript
+public readonly serviceAccountNamespace: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -38712,6 +44456,10 @@ const autoScalingGroupCapacityOptions: aws_eks.AutoScalingGroupCapacityOptions =
 
 ##### \`allowAllOutbound\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.allowAllOutbound\\"></a>
 
+\`\`\`typescript
+public readonly allowAllOutbound: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* true
 
@@ -38721,6 +44469,10 @@ Whether the instances can initiate connections to anywhere by default.
 
 ##### \`associatePublicIpAddress\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.associatePublicIpAddress\\"></a>
 
+\`\`\`typescript
+public readonly associatePublicIpAddress: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* Use subnet setting.
 
@@ -38729,6 +44481,10 @@ Whether instances in the Auto Scaling Group should have public IP addresses asso
 ---
 
 ##### \`autoScalingGroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.autoScalingGroupName\\"></a>
+
+\`\`\`typescript
+public readonly autoScalingGroupName: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* Auto generated by CloudFormation
@@ -38740,6 +44496,10 @@ This name must be unique per Region per account.
 ---
 
 ##### \`blockDevices\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.blockDevices\\"></a>
+
+\`\`\`typescript
+public readonly blockDevices: BlockDevice[]
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.BlockDevice\`](#aws-cdk-lib.aws_autoscaling.BlockDevice)[]
 - *Default:* Uses the block device mapping of the AMI
@@ -38757,6 +44517,10 @@ instance store volumes to attach to an instance when it is launched.
 
 ##### \`cooldown\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.cooldown\\"></a>
 
+\`\`\`typescript
+public readonly cooldown: Duration
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
 - *Default:* Duration.minutes(5)
 
@@ -38765,6 +44529,10 @@ Default scaling cooldown for this AutoScalingGroup.
 ---
 
 ##### \`desiredCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.desiredCapacity\\"></a>
+
+\`\`\`typescript
+public readonly desiredCapacity: number
+\`\`\`
 
 - *Type:* \`number\`
 - *Default:* minCapacity, and leave unchanged during deployment
@@ -38780,6 +44548,10 @@ instances to this number. It is recommended to leave this value blank.
 
 ##### \`groupMetrics\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.groupMetrics\\"></a>
 
+\`\`\`typescript
+public readonly groupMetrics: GroupMetrics[]
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.GroupMetrics\`](#aws-cdk-lib.aws_autoscaling.GroupMetrics)[]
 - *Default:* no group metrics will be reported
 
@@ -38792,6 +44564,10 @@ Group metrics are reported in a granularity of 1 minute at no additional charge.
 
 ##### \`healthCheck\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.healthCheck\\"></a>
 
+\`\`\`typescript
+public readonly healthCheck: HealthCheck
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.HealthCheck\`](#aws-cdk-lib.aws_autoscaling.HealthCheck)
 - *Default:* HealthCheck.ec2 with no grace period
 
@@ -38800,6 +44576,10 @@ Configuration for health checks.
 ---
 
 ##### \`ignoreUnmodifiedSizeProperties\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.ignoreUnmodifiedSizeProperties\\"></a>
+
+\`\`\`typescript
+public readonly ignoreUnmodifiedSizeProperties: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -38816,6 +44596,10 @@ on deployment.
 
 ##### \`instanceMonitoring\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.instanceMonitoring\\"></a>
 
+\`\`\`typescript
+public readonly instanceMonitoring: Monitoring
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.Monitoring\`](#aws-cdk-lib.aws_autoscaling.Monitoring)
 - *Default:* Monitoring.DETAILED
 
@@ -38830,6 +44614,10 @@ is charged a fee. When you disable detailed monitoring, CloudWatch generates met
 
 ##### \`keyName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.keyName\\"></a>
 
+\`\`\`typescript
+public readonly keyName: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* No SSH access will be possible.
 
@@ -38839,6 +44627,10 @@ Name of SSH keypair to grant access to instances.
 
 ##### \`maxCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.maxCapacity\\"></a>
 
+\`\`\`typescript
+public readonly maxCapacity: number
+\`\`\`
+
 - *Type:* \`number\`
 - *Default:* desiredCapacity
 
@@ -38847,6 +44639,10 @@ Maximum number of instances in the fleet.
 ---
 
 ##### \`maxInstanceLifetime\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.maxInstanceLifetime\\"></a>
+
+\`\`\`typescript
+public readonly maxInstanceLifetime: Duration
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
 - *Default:* none
@@ -38866,6 +44662,10 @@ leave this property undefined.
 
 ##### \`minCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.minCapacity\\"></a>
 
+\`\`\`typescript
+public readonly minCapacity: number
+\`\`\`
+
 - *Type:* \`number\`
 - *Default:* 1
 
@@ -38874,6 +44674,10 @@ Minimum number of instances in the fleet.
 ---
 
 ##### \`newInstancesProtectedFromScaleIn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.newInstancesProtectedFromScaleIn\\"></a>
+
+\`\`\`typescript
+public readonly newInstancesProtectedFromScaleIn: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -38893,6 +44697,10 @@ an ECS Capacity Provider with managed termination protection.
 
 ##### \`notifications\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.notifications\\"></a>
 
+\`\`\`typescript
+public readonly notifications: NotificationConfiguration[]
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.NotificationConfiguration\`](#aws-cdk-lib.aws_autoscaling.NotificationConfiguration)[]
 - *Default:* No fleet change notifications will be sent.
 
@@ -38903,6 +44711,10 @@ Configure autoscaling group to send notifications about fleet changes to an SNS 
 ---
 
 ##### \`signals\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.signals\\"></a>
+
+\`\`\`typescript
+public readonly signals: Signals
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.Signals\`](#aws-cdk-lib.aws_autoscaling.Signals)
 - *Default:* Do not wait for signals
@@ -38929,6 +44741,10 @@ https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services
 
 ##### \`spotPrice\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.spotPrice\\"></a>
 
+\`\`\`typescript
+public readonly spotPrice: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* none
 
@@ -38940,6 +44756,10 @@ launched when the price you specify exceeds the current Spot market price.
 ---
 
 ##### \`updatePolicy\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.updatePolicy\\"></a>
+
+\`\`\`typescript
+public readonly updatePolicy: UpdatePolicy
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.UpdatePolicy\`](#aws-cdk-lib.aws_autoscaling.UpdatePolicy)
 - *Default:* \`UpdatePolicy.rollingUpdate()\` if using \`init\`, \`UpdatePolicy.none()\` otherwise
@@ -38956,6 +44776,10 @@ is done and only new instances are launched with the new config.
 
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.vpcSubnets\\"></a>
 
+\`\`\`typescript
+public readonly vpcSubnets: SubnetSelection
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
 - *Default:* All Private subnets.
 
@@ -38965,6 +44789,10 @@ Where to place instances within the VPC.
 
 ##### \`instanceType\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.instanceType\\"></a>
 
+\`\`\`typescript
+public readonly instanceType: InstanceType
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.InstanceType\`](#aws-cdk-lib.aws_ec2.InstanceType)
 
 Instance type of the instances to start.
@@ -38972,6 +44800,10 @@ Instance type of the instances to start.
 ---
 
 ##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.bootstrapEnabled\\"></a>
+
+\`\`\`typescript
+public readonly bootstrapEnabled: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -38985,6 +44817,10 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 
 ##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.bootstrapOptions\\"></a>
 
+\`\`\`typescript
+public readonly bootstrapOptions: BootstrapOptions
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.BootstrapOptions\`](#aws-cdk-lib.aws_eks.BootstrapOptions)
 - *Default:* none
 
@@ -38994,6 +44830,10 @@ EKS node bootstrapping options.
 
 ##### \`machineImageType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.machineImageType\\"></a>
 
+\`\`\`typescript
+public readonly machineImageType: MachineImageType
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.MachineImageType\`](#aws-cdk-lib.aws_eks.MachineImageType)
 - *Default:* MachineImageType.AMAZON_LINUX_2
 
@@ -39002,6 +44842,10 @@ Machine image type.
 ---
 
 ##### \`mapRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.mapRole\\"></a>
+
+\`\`\`typescript
+public readonly mapRole: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true if the cluster has kubectl enabled (which is the default).
@@ -39013,6 +44857,10 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 ---
 
 ##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.spotInterruptHandler\\"></a>
+
+\`\`\`typescript
+public readonly spotInterruptHandler: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -39037,6 +44885,10 @@ const autoScalingGroupOptions: aws_eks.AutoScalingGroupOptions = { ... }
 
 ##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.bootstrapEnabled\\"></a>
 
+\`\`\`typescript
+public readonly bootstrapEnabled: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* true
 
@@ -39049,6 +44901,10 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 
 ##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.bootstrapOptions\\"></a>
 
+\`\`\`typescript
+public readonly bootstrapOptions: BootstrapOptions
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.BootstrapOptions\`](#aws-cdk-lib.aws_eks.BootstrapOptions)
 - *Default:* default options
 
@@ -39058,6 +44914,10 @@ Allows options for node bootstrapping through EC2 user data.
 
 ##### \`machineImageType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.machineImageType\\"></a>
 
+\`\`\`typescript
+public readonly machineImageType: MachineImageType
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.MachineImageType\`](#aws-cdk-lib.aws_eks.MachineImageType)
 - *Default:* MachineImageType.AMAZON_LINUX_2
 
@@ -39066,6 +44926,10 @@ Allow options to specify different machine image type.
 ---
 
 ##### \`mapRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.mapRole\\"></a>
+
+\`\`\`typescript
+public readonly mapRole: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true if the cluster has kubectl enabled (which is the default).
@@ -39077,6 +44941,10 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 ---
 
 ##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.spotInterruptHandler\\"></a>
+
+\`\`\`typescript
+public readonly spotInterruptHandler: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -39101,6 +44969,10 @@ const awsAuthMapping: aws_eks.AwsAuthMapping = { ... }
 
 ##### \`groups\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuthMapping.property.groups\\"></a>
 
+\`\`\`typescript
+public readonly groups: string[]
+\`\`\`
+
 - *Type:* \`string\`[]
 
 A list of groups within Kubernetes to which the role is mapped.
@@ -39110,6 +44982,10 @@ A list of groups within Kubernetes to which the role is mapped.
 ---
 
 ##### \`username\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuthMapping.property.username\\"></a>
+
+\`\`\`typescript
+public readonly username: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* By default, the user name is the ARN of the IAM role.
@@ -39131,6 +45007,10 @@ const awsAuthProps: aws_eks.AwsAuthProps = { ... }
 \`\`\`
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuthProps.property.cluster\\"></a>
+
+\`\`\`typescript
+public readonly cluster: Cluster
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.Cluster\`](#aws-cdk-lib.aws_eks.Cluster)
 
@@ -39154,6 +45034,10 @@ const bootstrapOptions: aws_eks.BootstrapOptions = { ... }
 
 ##### \`additionalArgs\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.additionalArgs\\"></a>
 
+\`\`\`typescript
+public readonly additionalArgs: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* none
 
@@ -39165,6 +45049,10 @@ Additional command line arguments to pass to the \`/etc/eks/bootstrap.sh\` comma
 
 ##### \`awsApiRetryAttempts\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.awsApiRetryAttempts\\"></a>
 
+\`\`\`typescript
+public readonly awsApiRetryAttempts: number
+\`\`\`
+
 - *Type:* \`number\`
 - *Default:* 3
 
@@ -39173,6 +45061,10 @@ Number of retry attempts for AWS API call (DescribeCluster).
 ---
 
 ##### \`dnsClusterIp\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.dnsClusterIp\\"></a>
+
+\`\`\`typescript
+public readonly dnsClusterIp: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* 10.100.0.10 or 172.20.0.10 based on the IP
@@ -39184,6 +45076,10 @@ Overrides the IP address to use for DNS queries within the cluster.
 
 ##### \`dockerConfigJson\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.dockerConfigJson\\"></a>
 
+\`\`\`typescript
+public readonly dockerConfigJson: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* none
 
@@ -39193,6 +45089,10 @@ The contents of the \`/etc/docker/daemon.json\` file. Useful if you want a custo
 
 ##### \`enableDockerBridge\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.enableDockerBridge\\"></a>
 
+\`\`\`typescript
+public readonly enableDockerBridge: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -39201,6 +45101,10 @@ Restores the docker default bridge network.
 ---
 
 ##### \`kubeletExtraArgs\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.kubeletExtraArgs\\"></a>
+
+\`\`\`typescript
+public readonly kubeletExtraArgs: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* none
@@ -39212,6 +45116,10 @@ Useful for adding labels or taints.
 ---
 
 ##### \`useMaxPods\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.useMaxPods\\"></a>
+
+\`\`\`typescript
+public readonly useMaxPods: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -39236,6 +45144,10 @@ const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 
 ##### \`addonName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.addonName\\"></a>
 
+\`\`\`typescript
+public readonly addonName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Addon.AddonName\`.
@@ -39245,6 +45157,10 @@ const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 ---
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.clusterName\\"></a>
+
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -39256,6 +45172,10 @@ const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 
 ##### \`addonVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.addonVersion\\"></a>
 
+\`\`\`typescript
+public readonly addonVersion: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Addon.AddonVersion\`.
@@ -39265,6 +45185,10 @@ const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 ---
 
 ##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.resolveConflicts\\"></a>
+
+\`\`\`typescript
+public readonly resolveConflicts: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -39276,6 +45200,10 @@ const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 
 ##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.serviceAccountRoleArn\\"></a>
 
+\`\`\`typescript
+public readonly serviceAccountRoleArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Addon.ServiceAccountRoleArn\`.
@@ -39285,6 +45213,10 @@ const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: CfnTag[]
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.CfnTag\`](#aws-cdk-lib.CfnTag)[]
 
@@ -39310,6 +45242,10 @@ const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 
 ##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.resourcesVpcConfig\\"></a>
 
+\`\`\`typescript
+public readonly resourcesVpcConfig: ResourcesVpcConfigProperty | IResolvable
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
 \`AWS::EKS::Cluster.ResourcesVpcConfig\`.
@@ -39319,6 +45255,10 @@ const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 ---
 
 ##### \`roleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.roleArn\\"></a>
+
+\`\`\`typescript
+public readonly roleArn: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -39330,6 +45270,10 @@ const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 
 ##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.encryptionConfig\\"></a>
 
+\`\`\`typescript
+public readonly encryptionConfig: IResolvable | EncryptionConfigProperty | IResolvable[]
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
 \`AWS::EKS::Cluster.EncryptionConfig\`.
@@ -39339,6 +45283,10 @@ const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 ---
 
 ##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.kubernetesNetworkConfig\\"></a>
+
+\`\`\`typescript
+public readonly kubernetesNetworkConfig: KubernetesNetworkConfigProperty | IResolvable
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -39350,6 +45298,10 @@ const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.name\\"></a>
 
+\`\`\`typescript
+public readonly name: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Cluster.Name\`.
@@ -39359,6 +45311,10 @@ const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.version\\"></a>
+
+\`\`\`typescript
+public readonly version: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -39384,6 +45340,10 @@ const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.clusterName\\"></a>
 
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::FargateProfile.ClusterName\`.
@@ -39393,6 +45353,10 @@ const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 ---
 
 ##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.podExecutionRoleArn\\"></a>
+
+\`\`\`typescript
+public readonly podExecutionRoleArn: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -39404,6 +45368,10 @@ const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 
 ##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.selectors\\"></a>
 
+\`\`\`typescript
+public readonly selectors: IResolvable | SelectorProperty | IResolvable[]
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
 \`AWS::EKS::FargateProfile.Selectors\`.
@@ -39413,6 +45381,10 @@ const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 ---
 
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.fargateProfileName\\"></a>
+
+\`\`\`typescript
+public readonly fargateProfileName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -39424,6 +45396,10 @@ const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.subnets\\"></a>
 
+\`\`\`typescript
+public readonly subnets: string[]
+\`\`\`
+
 - *Type:* \`string\`[]
 
 \`AWS::EKS::FargateProfile.Subnets\`.
@@ -39433,6 +45409,10 @@ const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: CfnTag[]
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.CfnTag\`](#aws-cdk-lib.CfnTag)[]
 
@@ -39458,6 +45438,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.clusterName\\"></a>
 
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Nodegroup.ClusterName\`.
@@ -39467,6 +45451,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 ---
 
 ##### \`nodeRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.nodeRole\\"></a>
+
+\`\`\`typescript
+public readonly nodeRole: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -39478,6 +45466,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ##### \`subnets\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.subnets\\"></a>
 
+\`\`\`typescript
+public readonly subnets: string[]
+\`\`\`
+
 - *Type:* \`string\`[]
 
 \`AWS::EKS::Nodegroup.Subnets\`.
@@ -39487,6 +45479,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 ---
 
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.amiType\\"></a>
+
+\`\`\`typescript
+public readonly amiType: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -39498,6 +45494,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.capacityType\\"></a>
 
+\`\`\`typescript
+public readonly capacityType: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Nodegroup.CapacityType\`.
@@ -39507,6 +45507,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 ---
 
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.diskSize\\"></a>
+
+\`\`\`typescript
+public readonly diskSize: number
+\`\`\`
 
 - *Type:* \`number\`
 
@@ -39518,6 +45522,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.forceUpdateEnabled\\"></a>
 
+\`\`\`typescript
+public readonly forceUpdateEnabled: boolean | IResolvable
+\`\`\`
+
 - *Type:* \`boolean\` | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
 \`AWS::EKS::Nodegroup.ForceUpdateEnabled\`.
@@ -39527,6 +45535,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 ---
 
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.instanceTypes\\"></a>
+
+\`\`\`typescript
+public readonly instanceTypes: string[]
+\`\`\`
 
 - *Type:* \`string\`[]
 
@@ -39538,6 +45550,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.labels\\"></a>
 
+\`\`\`typescript
+public readonly labels: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::EKS::Nodegroup.Labels\`.
@@ -39547,6 +45563,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 ---
 
 ##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.launchTemplate\\"></a>
+
+\`\`\`typescript
+public readonly launchTemplate: LaunchTemplateSpecificationProperty | IResolvable
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -39558,6 +45578,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.nodegroupName\\"></a>
 
+\`\`\`typescript
+public readonly nodegroupName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`AWS::EKS::Nodegroup.NodegroupName\`.
@@ -39567,6 +45591,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 ---
 
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.releaseVersion\\"></a>
+
+\`\`\`typescript
+public readonly releaseVersion: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -39578,6 +45606,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.remoteAccess\\"></a>
 
+\`\`\`typescript
+public readonly remoteAccess: RemoteAccessProperty | IResolvable
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
 \`AWS::EKS::Nodegroup.RemoteAccess\`.
@@ -39587,6 +45619,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 ---
 
 ##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.scalingConfig\\"></a>
+
+\`\`\`typescript
+public readonly scalingConfig: ScalingConfigProperty | IResolvable
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
@@ -39598,6 +45634,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.tags\\"></a>
 
+\`\`\`typescript
+public readonly tags: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::EKS::Nodegroup.Tags\`.
@@ -39608,6 +45648,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 
 ##### \`taints\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.taints\\"></a>
 
+\`\`\`typescript
+public readonly taints: IResolvable | TaintProperty | IResolvable[]
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
 \`AWS::EKS::Nodegroup.Taints\`.
@@ -39617,6 +45661,10 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.version\\"></a>
+
+\`\`\`typescript
+public readonly version: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -39640,6 +45688,10 @@ const clusterAttributes: aws_eks.ClusterAttributes = { ... }
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterName\\"></a>
 
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The physical name of the Cluster.
@@ -39647,6 +45699,10 @@ The physical name of the Cluster.
 ---
 
 ##### \`clusterCertificateAuthorityData\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterCertificateAuthorityData\\"></a>
+
+\`\`\`typescript
+public readonly clusterCertificateAuthorityData: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* if not specified \`cluster.clusterCertificateAuthorityData\` will
@@ -39658,6 +45714,10 @@ The certificate-authority-data for your cluster.
 
 ##### \`clusterEncryptionConfigKeyArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterEncryptionConfigKeyArn\\"></a>
 
+\`\`\`typescript
+public readonly clusterEncryptionConfigKeyArn: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* if not specified \`cluster.clusterEncryptionConfigKeyArn\` will
 throw an error
@@ -39668,6 +45728,10 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ##### \`clusterEndpoint\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterEndpoint\\"></a>
 
+\`\`\`typescript
+public readonly clusterEndpoint: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* if not specified \`cluster.clusterEndpoint\` will throw an error.
 
@@ -39676,6 +45740,10 @@ The API Server endpoint URL.
 ---
 
 ##### \`clusterSecurityGroupId\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterSecurityGroupId\\"></a>
+
+\`\`\`typescript
+public readonly clusterSecurityGroupId: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* if not specified \`cluster.clusterSecurityGroupId\` will throw an
@@ -39687,6 +45755,10 @@ The cluster security group that was created by Amazon EKS for the cluster.
 
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlEnvironment\\"></a>
 
+\`\`\`typescript
+public readonly kubectlEnvironment: {[ key: string ]: string}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* no additional variables
 
@@ -39695,6 +45767,10 @@ Environment variables to use when running \`kubectl\` against this cluster.
 ---
 
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlLayer\\"></a>
+
+\`\`\`typescript
+public readonly kubectlLayer: ILayerVersion
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
 - *Default:* a layer bundled with this module.
@@ -39714,6 +45790,10 @@ The handler expects the layer to include the following executables:
 
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlMemory\\"></a>
 
+\`\`\`typescript
+public readonly kubectlMemory: Size
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
 - *Default:* Size.gibibytes(1)
 
@@ -39722,6 +45802,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`kubectlPrivateSubnetIds\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlPrivateSubnetIds\\"></a>
+
+\`\`\`typescript
+public readonly kubectlPrivateSubnetIds: string[]
+\`\`\`
 
 - *Type:* \`string\`[]
 - *Default:* k8s endpoint is expected to be accessible publicly
@@ -39735,6 +45819,10 @@ endpoint is expected to be accessible publicly.
 
 ##### \`kubectlRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlRoleArn\\"></a>
 
+\`\`\`typescript
+public readonly kubectlRoleArn: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* if not specified, it not be possible to issue \`kubectl\` commands
 against an imported cluster.
@@ -39744,6 +45832,10 @@ An IAM role with cluster administrator and \\"system:masters\\" permissions.
 ---
 
 ##### \`kubectlSecurityGroupId\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlSecurityGroupId\\"></a>
+
+\`\`\`typescript
+public readonly kubectlSecurityGroupId: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* k8s endpoint is expected to be accessible publicly
@@ -39757,6 +45849,10 @@ endpoint is expected to be accessible publicly.
 
 ##### \`openIdConnectProvider\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.openIdConnectProvider\\"></a>
 
+\`\`\`typescript
+public readonly openIdConnectProvider: IOpenIdConnectProvider
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_iam.IOpenIdConnectProvider\`](#aws-cdk-lib.aws_iam.IOpenIdConnectProvider)
 - *Default:* if not specified \`cluster.openIdConnectProvider\` and \`cluster.addServiceAccount\` will throw an error.
 
@@ -39768,6 +45864,10 @@ or create a new provider using \`new eks.OpenIdConnectProvider\`
 ---
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.prune\\"></a>
+
+\`\`\`typescript
+public readonly prune: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -39782,6 +45882,10 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.securityGroupIds\\"></a>
 
+\`\`\`typescript
+public readonly securityGroupIds: string[]
+\`\`\`
+
 - *Type:* \`string\`[]
 - *Default:* if not specified, no additional security groups will be
 considered in \`cluster.connections\`.
@@ -39791,6 +45895,10 @@ Additional security groups associated with this cluster.
 ---
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.vpc\\"></a>
+
+\`\`\`typescript
+public readonly vpc: IVpc
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* if not specified \`cluster.vpc\` will throw an error
@@ -39813,6 +45921,10 @@ const clusterOptions: aws_eks.ClusterOptions = { ... }
 
 ##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.version\\"></a>
 
+\`\`\`typescript
+public readonly version: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
 The Kubernetes version to run in the cluster.
@@ -39820,6 +45932,10 @@ The Kubernetes version to run in the cluster.
 ---
 
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.clusterName\\"></a>
+
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* Automatically generated name
@@ -39830,6 +45946,10 @@ Name for the cluster.
 
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.outputClusterName\\"></a>
 
+\`\`\`typescript
+public readonly outputClusterName: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -39838,6 +45958,10 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ---
 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.outputConfigCommand\\"></a>
+
+\`\`\`typescript
+public readonly outputConfigCommand: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -39851,6 +45975,10 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.role\\"></a>
 
+\`\`\`typescript
+public readonly role: IRole
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* A role is automatically created for you
 
@@ -39859,6 +45987,10 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ---
 
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.securityGroup\\"></a>
+
+\`\`\`typescript
+public readonly securityGroup: ISecurityGroup
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -39869,6 +46001,10 @@ Security Group to use for Control Plane ENIs.
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.vpc\\"></a>
 
+\`\`\`typescript
+public readonly vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
 
@@ -39877,6 +46013,10 @@ The VPC in which to create the Cluster.
 ---
 
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.vpcSubnets\\"></a>
+
+\`\`\`typescript
+public readonly vpcSubnets: SubnetSelection[]
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)[]
 - *Default:* All public and private subnets
@@ -39897,6 +46037,10 @@ vpcSubnets: [
 
 ##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.clusterHandlerEnvironment\\"></a>
 
+\`\`\`typescript
+public readonly clusterHandlerEnvironment: {[ key: string ]: string}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* No environment variables.
 
@@ -39906,6 +46050,10 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.coreDnsComputeType\\"></a>
 
+\`\`\`typescript
+public readonly coreDnsComputeType: CoreDnsComputeType
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.CoreDnsComputeType\`](#aws-cdk-lib.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
 
@@ -39914,6 +46062,10 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ---
 
 ##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.endpointAccess\\"></a>
+
+\`\`\`typescript
+public readonly endpointAccess: EndpointAccess
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -39926,6 +46078,10 @@ Configure access to the Kubernetes API server endpoint..
 
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.kubectlEnvironment\\"></a>
 
+\`\`\`typescript
+public readonly kubectlEnvironment: {[ key: string ]: string}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* No environment variables.
 
@@ -39936,6 +46092,10 @@ Only relevant for kubectl enabled clusters.
 ---
 
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.kubectlLayer\\"></a>
+
+\`\`\`typescript
+public readonly kubectlLayer: ILayerVersion
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -39964,6 +46124,10 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.kubectlMemory\\"></a>
 
+\`\`\`typescript
+public readonly kubectlMemory: Size
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
 - *Default:* Size.gibibytes(1)
 
@@ -39972,6 +46136,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`mastersRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.mastersRole\\"></a>
+
+\`\`\`typescript
+public readonly mastersRole: IRole
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -39985,6 +46153,10 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.outputMastersRoleArn\\"></a>
 
+\`\`\`typescript
+public readonly outputMastersRoleArn: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -39994,6 +46166,10 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.placeClusterHandlerInVpc\\"></a>
 
+\`\`\`typescript
+public readonly placeClusterHandlerInVpc: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -40002,6 +46178,10 @@ If set to true, the cluster handler functions will be placed in the private subn
 ---
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.prune\\"></a>
+
+\`\`\`typescript
+public readonly prune: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -40015,6 +46195,10 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 ---
 
 ##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.secretsEncryptionKey\\"></a>
+
+\`\`\`typescript
+public readonly secretsEncryptionKey: IKey
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_kms.IKey\`](#aws-cdk-lib.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
@@ -40039,6 +46223,10 @@ const clusterProps: aws_eks.ClusterProps = { ... }
 
 ##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.version\\"></a>
 
+\`\`\`typescript
+public readonly version: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
 The Kubernetes version to run in the cluster.
@@ -40046,6 +46234,10 @@ The Kubernetes version to run in the cluster.
 ---
 
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.clusterName\\"></a>
+
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* Automatically generated name
@@ -40056,6 +46248,10 @@ Name for the cluster.
 
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.outputClusterName\\"></a>
 
+\`\`\`typescript
+public readonly outputClusterName: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -40064,6 +46260,10 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ---
 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.outputConfigCommand\\"></a>
+
+\`\`\`typescript
+public readonly outputConfigCommand: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -40077,6 +46277,10 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.role\\"></a>
 
+\`\`\`typescript
+public readonly role: IRole
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* A role is automatically created for you
 
@@ -40085,6 +46289,10 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ---
 
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.securityGroup\\"></a>
+
+\`\`\`typescript
+public readonly securityGroup: ISecurityGroup
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -40095,6 +46303,10 @@ Security Group to use for Control Plane ENIs.
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.vpc\\"></a>
 
+\`\`\`typescript
+public readonly vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
 
@@ -40103,6 +46315,10 @@ The VPC in which to create the Cluster.
 ---
 
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.vpcSubnets\\"></a>
+
+\`\`\`typescript
+public readonly vpcSubnets: SubnetSelection[]
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)[]
 - *Default:* All public and private subnets
@@ -40123,6 +46339,10 @@ vpcSubnets: [
 
 ##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.clusterHandlerEnvironment\\"></a>
 
+\`\`\`typescript
+public readonly clusterHandlerEnvironment: {[ key: string ]: string}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* No environment variables.
 
@@ -40132,6 +46352,10 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.coreDnsComputeType\\"></a>
 
+\`\`\`typescript
+public readonly coreDnsComputeType: CoreDnsComputeType
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.CoreDnsComputeType\`](#aws-cdk-lib.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
 
@@ -40140,6 +46364,10 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ---
 
 ##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.endpointAccess\\"></a>
+
+\`\`\`typescript
+public readonly endpointAccess: EndpointAccess
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -40152,6 +46380,10 @@ Configure access to the Kubernetes API server endpoint..
 
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.kubectlEnvironment\\"></a>
 
+\`\`\`typescript
+public readonly kubectlEnvironment: {[ key: string ]: string}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* No environment variables.
 
@@ -40162,6 +46394,10 @@ Only relevant for kubectl enabled clusters.
 ---
 
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.kubectlLayer\\"></a>
+
+\`\`\`typescript
+public readonly kubectlLayer: ILayerVersion
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -40190,6 +46426,10 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.kubectlMemory\\"></a>
 
+\`\`\`typescript
+public readonly kubectlMemory: Size
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
 - *Default:* Size.gibibytes(1)
 
@@ -40198,6 +46438,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`mastersRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.mastersRole\\"></a>
+
+\`\`\`typescript
+public readonly mastersRole: IRole
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -40211,6 +46455,10 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.outputMastersRoleArn\\"></a>
 
+\`\`\`typescript
+public readonly outputMastersRoleArn: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -40220,6 +46468,10 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.placeClusterHandlerInVpc\\"></a>
 
+\`\`\`typescript
+public readonly placeClusterHandlerInVpc: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -40228,6 +46480,10 @@ If set to true, the cluster handler functions will be placed in the private subn
 ---
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.prune\\"></a>
+
+\`\`\`typescript
+public readonly prune: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -40242,6 +46498,10 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.secretsEncryptionKey\\"></a>
 
+\`\`\`typescript
+public readonly secretsEncryptionKey: IKey
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_kms.IKey\`](#aws-cdk-lib.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
   all etcd volumes used by Amazon EKS are encrypted at the disk-level
@@ -40252,6 +46512,10 @@ KMS secret for envelope encryption for Kubernetes secrets.
 ---
 
 ##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.defaultCapacity\\"></a>
+
+\`\`\`typescript
+public readonly defaultCapacity: number
+\`\`\`
 
 - *Type:* \`number\`
 - *Default:* 2
@@ -40268,6 +46532,10 @@ to \`0\` is you wish to avoid the initial capacity allocation.
 
 ##### \`defaultCapacityInstance\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.defaultCapacityInstance\\"></a>
 
+\`\`\`typescript
+public readonly defaultCapacityInstance: InstanceType
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.InstanceType\`](#aws-cdk-lib.aws_ec2.InstanceType)
 - *Default:* m5.large
 
@@ -40279,6 +46547,10 @@ into account if \`defaultCapacity\` is > 0.
 ---
 
 ##### \`defaultCapacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.defaultCapacityType\\"></a>
+
+\`\`\`typescript
+public readonly defaultCapacityType: DefaultCapacityType
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.DefaultCapacityType\`](#aws-cdk-lib.aws_eks.DefaultCapacityType)
 - *Default:* NODEGROUP
@@ -40301,6 +46573,10 @@ const commonClusterOptions: aws_eks.CommonClusterOptions = { ... }
 
 ##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.version\\"></a>
 
+\`\`\`typescript
+public readonly version: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
 The Kubernetes version to run in the cluster.
@@ -40308,6 +46584,10 @@ The Kubernetes version to run in the cluster.
 ---
 
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.clusterName\\"></a>
+
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* Automatically generated name
@@ -40318,6 +46598,10 @@ Name for the cluster.
 
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.outputClusterName\\"></a>
 
+\`\`\`typescript
+public readonly outputClusterName: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -40326,6 +46610,10 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ---
 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.outputConfigCommand\\"></a>
+
+\`\`\`typescript
+public readonly outputConfigCommand: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -40339,6 +46627,10 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.role\\"></a>
 
+\`\`\`typescript
+public readonly role: IRole
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* A role is automatically created for you
 
@@ -40347,6 +46639,10 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ---
 
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.securityGroup\\"></a>
+
+\`\`\`typescript
+public readonly securityGroup: ISecurityGroup
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -40357,6 +46653,10 @@ Security Group to use for Control Plane ENIs.
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.vpc\\"></a>
 
+\`\`\`typescript
+public readonly vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
 
@@ -40365,6 +46665,10 @@ The VPC in which to create the Cluster.
 ---
 
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.vpcSubnets\\"></a>
+
+\`\`\`typescript
+public readonly vpcSubnets: SubnetSelection[]
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)[]
 - *Default:* All public and private subnets
@@ -40397,6 +46701,10 @@ const eksOptimizedImageProps: aws_eks.EksOptimizedImageProps = { ... }
 
 ##### \`cpuArch\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImageProps.property.cpuArch\\"></a>
 
+\`\`\`typescript
+public readonly cpuArch: CpuArch
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.CpuArch\`](#aws-cdk-lib.aws_eks.CpuArch)
 - *Default:* CpuArch.X86_64
 
@@ -40406,6 +46714,10 @@ What cpu architecture to retrieve the image for (arm64 or x86_64).
 
 ##### \`kubernetesVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImageProps.property.kubernetesVersion\\"></a>
 
+\`\`\`typescript
+public readonly kubernetesVersion: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* The latest version
 
@@ -40414,6 +46726,10 @@ The Kubernetes version to use.
 ---
 
 ##### \`nodeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImageProps.property.nodeType\\"></a>
+
+\`\`\`typescript
+public readonly nodeType: NodeType
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodeType\`](#aws-cdk-lib.aws_eks.NodeType)
 - *Default:* NodeType.STANDARD
@@ -40436,6 +46752,10 @@ const encryptionConfigProperty: aws_eks.CfnCluster.EncryptionConfigProperty = { 
 
 ##### \`provider\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty.property.provider\\"></a>
 
+\`\`\`typescript
+public readonly provider: ProviderProperty | IResolvable
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.ProviderProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.ProviderProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
 
 \`CfnCluster.EncryptionConfigProperty.Provider\`.
@@ -40445,6 +46765,10 @@ const encryptionConfigProperty: aws_eks.CfnCluster.EncryptionConfigProperty = { 
 ---
 
 ##### \`resources\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty.property.resources\\"></a>
+
+\`\`\`typescript
+public readonly resources: string[]
+\`\`\`
 
 - *Type:* \`string\`[]
 
@@ -40468,6 +46792,10 @@ const fargateClusterProps: aws_eks.FargateClusterProps = { ... }
 
 ##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.version\\"></a>
 
+\`\`\`typescript
+public readonly version: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
 The Kubernetes version to run in the cluster.
@@ -40475,6 +46803,10 @@ The Kubernetes version to run in the cluster.
 ---
 
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.clusterName\\"></a>
+
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* Automatically generated name
@@ -40485,6 +46817,10 @@ Name for the cluster.
 
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.outputClusterName\\"></a>
 
+\`\`\`typescript
+public readonly outputClusterName: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -40493,6 +46829,10 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ---
 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.outputConfigCommand\\"></a>
+
+\`\`\`typescript
+public readonly outputConfigCommand: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -40506,6 +46846,10 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 
 ##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.role\\"></a>
 
+\`\`\`typescript
+public readonly role: IRole
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* A role is automatically created for you
 
@@ -40514,6 +46858,10 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ---
 
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.securityGroup\\"></a>
+
+\`\`\`typescript
+public readonly securityGroup: ISecurityGroup
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 - *Default:* A security group is automatically created
@@ -40524,6 +46872,10 @@ Security Group to use for Control Plane ENIs.
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.vpc\\"></a>
 
+\`\`\`typescript
+public readonly vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
 
@@ -40532,6 +46884,10 @@ The VPC in which to create the Cluster.
 ---
 
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.vpcSubnets\\"></a>
+
+\`\`\`typescript
+public readonly vpcSubnets: SubnetSelection[]
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)[]
 - *Default:* All public and private subnets
@@ -40552,6 +46908,10 @@ vpcSubnets: [
 
 ##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.clusterHandlerEnvironment\\"></a>
 
+\`\`\`typescript
+public readonly clusterHandlerEnvironment: {[ key: string ]: string}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* No environment variables.
 
@@ -40561,6 +46921,10 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 
 ##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.coreDnsComputeType\\"></a>
 
+\`\`\`typescript
+public readonly coreDnsComputeType: CoreDnsComputeType
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.CoreDnsComputeType\`](#aws-cdk-lib.aws_eks.CoreDnsComputeType)
 - *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
 
@@ -40569,6 +46933,10 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ---
 
 ##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.endpointAccess\\"></a>
+
+\`\`\`typescript
+public readonly endpointAccess: EndpointAccess
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 - *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
@@ -40581,6 +46949,10 @@ Configure access to the Kubernetes API server endpoint..
 
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.kubectlEnvironment\\"></a>
 
+\`\`\`typescript
+public readonly kubectlEnvironment: {[ key: string ]: string}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* No environment variables.
 
@@ -40591,6 +46963,10 @@ Only relevant for kubectl enabled clusters.
 ---
 
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.kubectlLayer\\"></a>
+
+\`\`\`typescript
+public readonly kubectlLayer: ILayerVersion
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
 - *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
@@ -40619,6 +46995,10 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.kubectlMemory\\"></a>
 
+\`\`\`typescript
+public readonly kubectlMemory: Size
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
 - *Default:* Size.gibibytes(1)
 
@@ -40627,6 +47007,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`mastersRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.mastersRole\\"></a>
+
+\`\`\`typescript
+public readonly mastersRole: IRole
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* a role that assumable by anyone with permissions in the same
@@ -40640,6 +47024,10 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 
 ##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.outputMastersRoleArn\\"></a>
 
+\`\`\`typescript
+public readonly outputMastersRoleArn: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -40649,6 +47037,10 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 
 ##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.placeClusterHandlerInVpc\\"></a>
 
+\`\`\`typescript
+public readonly placeClusterHandlerInVpc: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -40657,6 +47049,10 @@ If set to true, the cluster handler functions will be placed in the private subn
 ---
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.prune\\"></a>
+
+\`\`\`typescript
+public readonly prune: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -40671,6 +47067,10 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 
 ##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.secretsEncryptionKey\\"></a>
 
+\`\`\`typescript
+public readonly secretsEncryptionKey: IKey
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_kms.IKey\`](#aws-cdk-lib.aws_kms.IKey)
 - *Default:* By default, Kubernetes stores all secret object data within etcd and
   all etcd volumes used by Amazon EKS are encrypted at the disk-level
@@ -40681,6 +47081,10 @@ KMS secret for envelope encryption for Kubernetes secrets.
 ---
 
 ##### \`defaultProfile\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.defaultProfile\\"></a>
+
+\`\`\`typescript
+public readonly defaultProfile: FargateProfileOptions
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.FargateProfileOptions\`](#aws-cdk-lib.aws_eks.FargateProfileOptions)
 - *Default:* A profile called \\"default\\" with 'default' and 'kube-system'
@@ -40704,6 +47108,10 @@ const fargateProfileOptions: aws_eks.FargateProfileOptions = { ... }
 
 ##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.selectors\\"></a>
 
+\`\`\`typescript
+public readonly selectors: Selector[]
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.Selector\`](#aws-cdk-lib.aws_eks.Selector)[]
 
 The selectors to match for pods to use this Fargate profile.
@@ -40718,6 +47126,10 @@ At least one selector is required and you may specify up to five selectors.
 
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.fargateProfileName\\"></a>
 
+\`\`\`typescript
+public readonly fargateProfileName: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* generated
 
@@ -40726,6 +47138,10 @@ The name of the Fargate profile.
 ---
 
 ##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.podExecutionRole\\"></a>
+
+\`\`\`typescript
+public readonly podExecutionRole: IRole
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* a role will be automatically created
@@ -40742,6 +47158,10 @@ ECR image repositories.
 
 ##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.subnetSelection\\"></a>
 
+\`\`\`typescript
+public readonly subnetSelection: SubnetSelection
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
 - *Default:* all private subnets of the VPC are selected.
 
@@ -40754,6 +47174,10 @@ on Fargate are not assigned public IP addresses, so only private subnets
 ---
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.vpc\\"></a>
+
+\`\`\`typescript
+public readonly vpc: IVpc
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* all private subnets used by theEKS cluster
@@ -40779,6 +47203,10 @@ const fargateProfileProps: aws_eks.FargateProfileProps = { ... }
 
 ##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.selectors\\"></a>
 
+\`\`\`typescript
+public readonly selectors: Selector[]
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.Selector\`](#aws-cdk-lib.aws_eks.Selector)[]
 
 The selectors to match for pods to use this Fargate profile.
@@ -40793,6 +47221,10 @@ At least one selector is required and you may specify up to five selectors.
 
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.fargateProfileName\\"></a>
 
+\`\`\`typescript
+public readonly fargateProfileName: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* generated
 
@@ -40801,6 +47233,10 @@ The name of the Fargate profile.
 ---
 
 ##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.podExecutionRole\\"></a>
+
+\`\`\`typescript
+public readonly podExecutionRole: IRole
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* a role will be automatically created
@@ -40817,6 +47253,10 @@ ECR image repositories.
 
 ##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.subnetSelection\\"></a>
 
+\`\`\`typescript
+public readonly subnetSelection: SubnetSelection
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
 - *Default:* all private subnets of the VPC are selected.
 
@@ -40830,6 +47270,10 @@ on Fargate are not assigned public IP addresses, so only private subnets
 
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.vpc\\"></a>
 
+\`\`\`typescript
+public readonly vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 - *Default:* all private subnets used by theEKS cluster
 
@@ -40841,6 +47285,10 @@ By default, all private subnets are selected. You can customize this using
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.cluster\\"></a>
+
+\`\`\`typescript
+public readonly cluster: Cluster
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.Cluster\`](#aws-cdk-lib.aws_eks.Cluster)
 
@@ -40864,6 +47312,10 @@ const helmChartOptions: aws_eks.HelmChartOptions = { ... }
 
 ##### \`chart\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.chart\\"></a>
 
+\`\`\`typescript
+public readonly chart: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The name of the chart.
@@ -40871,6 +47323,10 @@ The name of the chart.
 ---
 
 ##### \`createNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.createNamespace\\"></a>
+
+\`\`\`typescript
+public readonly createNamespace: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -40881,6 +47337,10 @@ create namespace if not exist.
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.namespace\\"></a>
 
+\`\`\`typescript
+public readonly namespace: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* default
 
@@ -40890,6 +47350,10 @@ The Kubernetes namespace scope of the requests.
 
 ##### \`release\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.release\\"></a>
 
+\`\`\`typescript
+public readonly release: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
 
@@ -40898,6 +47362,10 @@ The name of the release.
 ---
 
 ##### \`repository\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.repository\\"></a>
+
+\`\`\`typescript
+public readonly repository: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -40910,6 +47378,10 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.timeout\\"></a>
 
+\`\`\`typescript
+public readonly timeout: Duration
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
 - *Default:* Duration.minutes(5)
 
@@ -40921,6 +47393,10 @@ Maximum 15 minutes.
 
 ##### \`values\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.values\\"></a>
 
+\`\`\`typescript
+public readonly values: {[ key: string ]: any}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`any\`}
 - *Default:* No values are provided to the chart.
 
@@ -40930,6 +47406,10 @@ The values to be used by the chart.
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.version\\"></a>
 
+\`\`\`typescript
+public readonly version: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* If this is not specified, the latest version is installed
 
@@ -40938,6 +47418,10 @@ The chart version to install.
 ---
 
 ##### \`wait\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.wait\\"></a>
+
+\`\`\`typescript
+public readonly wait: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* Helm will not wait before marking release as successful
@@ -40960,6 +47444,10 @@ const helmChartProps: aws_eks.HelmChartProps = { ... }
 
 ##### \`chart\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.chart\\"></a>
 
+\`\`\`typescript
+public readonly chart: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The name of the chart.
@@ -40967,6 +47455,10 @@ The name of the chart.
 ---
 
 ##### \`createNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.createNamespace\\"></a>
+
+\`\`\`typescript
+public readonly createNamespace: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -40977,6 +47469,10 @@ create namespace if not exist.
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.namespace\\"></a>
 
+\`\`\`typescript
+public readonly namespace: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* default
 
@@ -40986,6 +47482,10 @@ The Kubernetes namespace scope of the requests.
 
 ##### \`release\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.release\\"></a>
 
+\`\`\`typescript
+public readonly release: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
 
@@ -40994,6 +47494,10 @@ The name of the release.
 ---
 
 ##### \`repository\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.repository\\"></a>
+
+\`\`\`typescript
+public readonly repository: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
@@ -41006,6 +47510,10 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.timeout\\"></a>
 
+\`\`\`typescript
+public readonly timeout: Duration
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
 - *Default:* Duration.minutes(5)
 
@@ -41017,6 +47525,10 @@ Maximum 15 minutes.
 
 ##### \`values\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.values\\"></a>
 
+\`\`\`typescript
+public readonly values: {[ key: string ]: any}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`any\`}
 - *Default:* No values are provided to the chart.
 
@@ -41025,6 +47537,10 @@ The values to be used by the chart.
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.version\\"></a>
+
+\`\`\`typescript
+public readonly version: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* If this is not specified, the latest version is installed
@@ -41035,6 +47551,10 @@ The chart version to install.
 
 ##### \`wait\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.wait\\"></a>
 
+\`\`\`typescript
+public readonly wait: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* Helm will not wait before marking release as successful
 
@@ -41043,6 +47563,10 @@ Whether or not Helm should wait until all Pods, PVCs, Services, and minimum numb
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.cluster\\"></a>
+
+\`\`\`typescript
+public readonly cluster: ICluster
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
@@ -41065,6 +47589,10 @@ const kubernetesManifestOptions: aws_eks.KubernetesManifestOptions = { ... }
 \`\`\`
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestOptions.property.prune\\"></a>
+
+\`\`\`typescript
+public readonly prune: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* based on the prune option of the cluster, which is \`true\` unless
@@ -41092,6 +47620,10 @@ empty.
 
 ##### \`skipValidation\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestOptions.property.skipValidation\\"></a>
 
+\`\`\`typescript
+public readonly skipValidation: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -41112,6 +47644,10 @@ const kubernetesManifestProps: aws_eks.KubernetesManifestProps = { ... }
 \`\`\`
 
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.prune\\"></a>
+
+\`\`\`typescript
+public readonly prune: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* based on the prune option of the cluster, which is \`true\` unless
@@ -41139,6 +47675,10 @@ empty.
 
 ##### \`skipValidation\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.skipValidation\\"></a>
 
+\`\`\`typescript
+public readonly skipValidation: boolean
+\`\`\`
+
 - *Type:* \`boolean\`
 - *Default:* false
 
@@ -41147,6 +47687,10 @@ A flag to signify if the manifest validation should be skipped.
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.cluster\\"></a>
+
+\`\`\`typescript
+public readonly cluster: ICluster
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
@@ -41157,6 +47701,10 @@ The EKS cluster to apply this manifest to.
 ---
 
 ##### \`manifest\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.manifest\\"></a>
+
+\`\`\`typescript
+public readonly manifest: {[ key: string ]: any}[]
+\`\`\`
 
 - *Type:* {[ key: string ]: \`any\`}[]
 
@@ -41171,6 +47719,10 @@ deleted, the resources in the manifest will be deleted through \`kubectl delete\
 ---
 
 ##### \`overwrite\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.overwrite\\"></a>
+
+\`\`\`typescript
+public readonly overwrite: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* false
@@ -41197,6 +47749,10 @@ const kubernetesNetworkConfigProperty: aws_eks.CfnCluster.KubernetesNetworkConfi
 
 ##### \`serviceIpv4Cidr\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty.property.serviceIpv4Cidr\\"></a>
 
+\`\`\`typescript
+public readonly serviceIpv4Cidr: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnCluster.KubernetesNetworkConfigProperty.ServiceIpv4Cidr\`.
@@ -41219,6 +47775,10 @@ const kubernetesObjectValueProps: aws_eks.KubernetesObjectValueProps = { ... }
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.cluster\\"></a>
 
+\`\`\`typescript
+public readonly cluster: ICluster
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
 The EKS cluster to fetch attributes from.
@@ -41228,6 +47788,10 @@ The EKS cluster to fetch attributes from.
 ---
 
 ##### \`jsonPath\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.jsonPath\\"></a>
+
+\`\`\`typescript
+public readonly jsonPath: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -41239,6 +47803,10 @@ JSONPath to the specific value.
 
 ##### \`objectName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.objectName\\"></a>
 
+\`\`\`typescript
+public readonly objectName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The name of the object to query.
@@ -41246,6 +47814,10 @@ The name of the object to query.
 ---
 
 ##### \`objectType\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.objectType\\"></a>
+
+\`\`\`typescript
+public readonly objectType: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -41257,6 +47829,10 @@ The object type to query.
 
 ##### \`objectNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.objectNamespace\\"></a>
 
+\`\`\`typescript
+public readonly objectNamespace: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* 'default'
 
@@ -41265,6 +47841,10 @@ The namespace the object belongs to.
 ---
 
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.timeout\\"></a>
+
+\`\`\`typescript
+public readonly timeout: Duration
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
 - *Default:* Duration.minutes(5)
@@ -41287,6 +47867,10 @@ const kubernetesPatchProps: aws_eks.KubernetesPatchProps = { ... }
 
 ##### \`applyPatch\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.applyPatch\\"></a>
 
+\`\`\`typescript
+public readonly applyPatch: {[ key: string ]: any}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`any\`}
 
 The JSON object to pass to \`kubectl patch\` when the resource is created/updated.
@@ -41294,6 +47878,10 @@ The JSON object to pass to \`kubectl patch\` when the resource is created/update
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.cluster\\"></a>
+
+\`\`\`typescript
+public readonly cluster: ICluster
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
@@ -41305,6 +47893,10 @@ The cluster to apply the patch to.
 
 ##### \`resourceName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.resourceName\\"></a>
 
+\`\`\`typescript
+public readonly resourceName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The full name of the resource to patch (e.g. \`deployment/coredns\`).
@@ -41313,6 +47905,10 @@ The full name of the resource to patch (e.g. \`deployment/coredns\`).
 
 ##### \`restorePatch\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.restorePatch\\"></a>
 
+\`\`\`typescript
+public readonly restorePatch: {[ key: string ]: any}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`any\`}
 
 The JSON object to pass to \`kubectl patch\` when the resource is removed.
@@ -41320,6 +47916,10 @@ The JSON object to pass to \`kubectl patch\` when the resource is removed.
 ---
 
 ##### \`patchType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.patchType\\"></a>
+
+\`\`\`typescript
+public readonly patchType: PatchType
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.PatchType\`](#aws-cdk-lib.aws_eks.PatchType)
 - *Default:* PatchType.STRATEGIC
@@ -41331,6 +47931,10 @@ The default type used by \`kubectl patch\` is \\"strategic\\".
 ---
 
 ##### \`resourceNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.resourceNamespace\\"></a>
+
+\`\`\`typescript
+public readonly resourceNamespace: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* \\"default\\"
@@ -41353,6 +47957,10 @@ const labelProperty: aws_eks.CfnFargateProfile.LabelProperty = { ... }
 
 ##### \`key\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty.property.key\\"></a>
 
+\`\`\`typescript
+public readonly key: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnFargateProfile.LabelProperty.Key\`.
@@ -41362,6 +47970,10 @@ const labelProperty: aws_eks.CfnFargateProfile.LabelProperty = { ... }
 ---
 
 ##### \`value\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty.property.value\\"></a>
+
+\`\`\`typescript
+public readonly value: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -41385,6 +47997,10 @@ const launchTemplateSpec: aws_eks.LaunchTemplateSpec = { ... }
 
 ##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.LaunchTemplateSpec.property.id\\"></a>
 
+\`\`\`typescript
+public readonly id: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The Launch template ID.
@@ -41392,6 +48008,10 @@ The Launch template ID.
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.LaunchTemplateSpec.property.version\\"></a>
+
+\`\`\`typescript
+public readonly version: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* the default version of the launch template
@@ -41414,6 +48034,10 @@ const launchTemplateSpecificationProperty: aws_eks.CfnNodegroup.LaunchTemplateSp
 
 ##### \`id\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.id\\"></a>
 
+\`\`\`typescript
+public readonly id: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnNodegroup.LaunchTemplateSpecificationProperty.Id\`.
@@ -41424,6 +48048,10 @@ const launchTemplateSpecificationProperty: aws_eks.CfnNodegroup.LaunchTemplateSp
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.name\\"></a>
 
+\`\`\`typescript
+public readonly name: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnNodegroup.LaunchTemplateSpecificationProperty.Name\`.
@@ -41433,6 +48061,10 @@ const launchTemplateSpecificationProperty: aws_eks.CfnNodegroup.LaunchTemplateSp
 ---
 
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.version\\"></a>
+
+\`\`\`typescript
+public readonly version: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -41456,6 +48088,10 @@ const nodegroupOptions: aws_eks.NodegroupOptions = { ... }
 
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.amiType\\"></a>
 
+\`\`\`typescript
+public readonly amiType: NodegroupAmiType
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupAmiType\`](#aws-cdk-lib.aws_eks.NodegroupAmiType)
 - *Default:* auto-determined from the instanceTypes property.
 
@@ -41465,6 +48101,10 @@ The AMI type for your node group.
 
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.capacityType\\"></a>
 
+\`\`\`typescript
+public readonly capacityType: CapacityType
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.CapacityType\`](#aws-cdk-lib.aws_eks.CapacityType)
 - *Default:* ON_DEMAND
 
@@ -41473,6 +48113,10 @@ The capacity type of the nodegroup.
 ---
 
 ##### \`desiredSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.desiredSize\\"></a>
+
+\`\`\`typescript
+public readonly desiredSize: number
+\`\`\`
 
 - *Type:* \`number\`
 - *Default:* 2
@@ -41486,6 +48130,10 @@ the nodewgroup will initially create \`minSize\` instances.
 
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.diskSize\\"></a>
 
+\`\`\`typescript
+public readonly diskSize: number
+\`\`\`
+
 - *Type:* \`number\`
 - *Default:* 20
 
@@ -41494,6 +48142,10 @@ The root device disk size (in GiB) for your node group instances.
 ---
 
 ##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.forceUpdate\\"></a>
+
+\`\`\`typescript
+public readonly forceUpdate: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -41508,6 +48160,10 @@ running on the node.
 
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.instanceTypes\\"></a>
 
+\`\`\`typescript
+public readonly instanceTypes: InstanceType[]
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.InstanceType\`](#aws-cdk-lib.aws_ec2.InstanceType)[]
 - *Default:* t3.medium will be used according to the cloudformation document.
 
@@ -41519,6 +48175,10 @@ The instance types to use for your node group.
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.labels\\"></a>
 
+\`\`\`typescript
+public readonly labels: {[ key: string ]: string}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* None
 
@@ -41527,6 +48187,10 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 ---
 
 ##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.launchTemplateSpec\\"></a>
+
+\`\`\`typescript
+public readonly launchTemplateSpec: LaunchTemplateSpec
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.LaunchTemplateSpec\`](#aws-cdk-lib.aws_eks.LaunchTemplateSpec)
 - *Default:* no launch template
@@ -41539,6 +48203,10 @@ Launch template specification used for the nodegroup.
 
 ##### \`maxSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.maxSize\\"></a>
 
+\`\`\`typescript
+public readonly maxSize: number
+\`\`\`
+
 - *Type:* \`number\`
 - *Default:* desiredSize
 
@@ -41549,6 +48217,10 @@ Managed node groups can support up to 100 nodes by default.
 ---
 
 ##### \`minSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.minSize\\"></a>
+
+\`\`\`typescript
+public readonly minSize: number
+\`\`\`
 
 - *Type:* \`number\`
 - *Default:* 1
@@ -41561,6 +48233,10 @@ This number must be greater than zero.
 
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.nodegroupName\\"></a>
 
+\`\`\`typescript
+public readonly nodegroupName: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* resource ID
 
@@ -41569,6 +48245,10 @@ Name of the Nodegroup.
 ---
 
 ##### \`nodeRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.nodeRole\\"></a>
+
+\`\`\`typescript
+public readonly nodeRole: IRole
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* None. Auto-generated if not specified.
@@ -41584,6 +48264,10 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.releaseVersion\\"></a>
 
+\`\`\`typescript
+public readonly releaseVersion: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
 
@@ -41592,6 +48276,10 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 ---
 
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.remoteAccess\\"></a>
+
+\`\`\`typescript
+public readonly remoteAccess: NodegroupRemoteAccess
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupRemoteAccess\`](#aws-cdk-lib.aws_eks.NodegroupRemoteAccess)
 - *Default:* disabled
@@ -41606,6 +48294,10 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.subnets\\"></a>
 
+\`\`\`typescript
+public readonly subnets: SubnetSelection
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
 - *Default:* private subnets
 
@@ -41619,6 +48311,10 @@ the name of your cluster.
 ---
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: {[ key: string ]: string}
+\`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* None
@@ -41645,6 +48341,10 @@ const nodegroupProps: aws_eks.NodegroupProps = { ... }
 
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.amiType\\"></a>
 
+\`\`\`typescript
+public readonly amiType: NodegroupAmiType
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupAmiType\`](#aws-cdk-lib.aws_eks.NodegroupAmiType)
 - *Default:* auto-determined from the instanceTypes property.
 
@@ -41654,6 +48354,10 @@ The AMI type for your node group.
 
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.capacityType\\"></a>
 
+\`\`\`typescript
+public readonly capacityType: CapacityType
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.CapacityType\`](#aws-cdk-lib.aws_eks.CapacityType)
 - *Default:* ON_DEMAND
 
@@ -41662,6 +48366,10 @@ The capacity type of the nodegroup.
 ---
 
 ##### \`desiredSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.desiredSize\\"></a>
+
+\`\`\`typescript
+public readonly desiredSize: number
+\`\`\`
 
 - *Type:* \`number\`
 - *Default:* 2
@@ -41675,6 +48383,10 @@ the nodewgroup will initially create \`minSize\` instances.
 
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.diskSize\\"></a>
 
+\`\`\`typescript
+public readonly diskSize: number
+\`\`\`
+
 - *Type:* \`number\`
 - *Default:* 20
 
@@ -41683,6 +48395,10 @@ The root device disk size (in GiB) for your node group instances.
 ---
 
 ##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.forceUpdate\\"></a>
+
+\`\`\`typescript
+public readonly forceUpdate: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 - *Default:* true
@@ -41697,6 +48413,10 @@ running on the node.
 
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.instanceTypes\\"></a>
 
+\`\`\`typescript
+public readonly instanceTypes: InstanceType[]
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.InstanceType\`](#aws-cdk-lib.aws_ec2.InstanceType)[]
 - *Default:* t3.medium will be used according to the cloudformation document.
 
@@ -41708,6 +48428,10 @@ The instance types to use for your node group.
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.labels\\"></a>
 
+\`\`\`typescript
+public readonly labels: {[ key: string ]: string}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* None
 
@@ -41716,6 +48440,10 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 ---
 
 ##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.launchTemplateSpec\\"></a>
+
+\`\`\`typescript
+public readonly launchTemplateSpec: LaunchTemplateSpec
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.LaunchTemplateSpec\`](#aws-cdk-lib.aws_eks.LaunchTemplateSpec)
 - *Default:* no launch template
@@ -41728,6 +48456,10 @@ Launch template specification used for the nodegroup.
 
 ##### \`maxSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.maxSize\\"></a>
 
+\`\`\`typescript
+public readonly maxSize: number
+\`\`\`
+
 - *Type:* \`number\`
 - *Default:* desiredSize
 
@@ -41738,6 +48470,10 @@ Managed node groups can support up to 100 nodes by default.
 ---
 
 ##### \`minSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.minSize\\"></a>
+
+\`\`\`typescript
+public readonly minSize: number
+\`\`\`
 
 - *Type:* \`number\`
 - *Default:* 1
@@ -41750,6 +48486,10 @@ This number must be greater than zero.
 
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.nodegroupName\\"></a>
 
+\`\`\`typescript
+public readonly nodegroupName: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* resource ID
 
@@ -41758,6 +48498,10 @@ Name of the Nodegroup.
 ---
 
 ##### \`nodeRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.nodeRole\\"></a>
+
+\`\`\`typescript
+public readonly nodeRole: IRole
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 - *Default:* None. Auto-generated if not specified.
@@ -41773,6 +48517,10 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.releaseVersion\\"></a>
 
+\`\`\`typescript
+public readonly releaseVersion: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
 
@@ -41781,6 +48529,10 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 ---
 
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.remoteAccess\\"></a>
+
+\`\`\`typescript
+public readonly remoteAccess: NodegroupRemoteAccess
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupRemoteAccess\`](#aws-cdk-lib.aws_eks.NodegroupRemoteAccess)
 - *Default:* disabled
@@ -41794,6 +48546,10 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 ---
 
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.subnets\\"></a>
+
+\`\`\`typescript
+public readonly subnets: SubnetSelection
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
 - *Default:* private subnets
@@ -41809,6 +48565,10 @@ the name of your cluster.
 
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.tags\\"></a>
 
+\`\`\`typescript
+public readonly tags: {[ key: string ]: string}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* None
 
@@ -41821,6 +48581,10 @@ associated with the node group, such as the Amazon EC2 instances or subnets.
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.cluster\\"></a>
+
+\`\`\`typescript
+public readonly cluster: ICluster
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
@@ -41844,6 +48608,10 @@ const nodegroupRemoteAccess: aws_eks.NodegroupRemoteAccess = { ... }
 
 ##### \`sshKeyName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupRemoteAccess.property.sshKeyName\\"></a>
 
+\`\`\`typescript
+public readonly sshKeyName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The Amazon EC2 SSH key that provides access for SSH communication with the worker nodes in the managed node group.
@@ -41851,6 +48619,10 @@ The Amazon EC2 SSH key that provides access for SSH communication with the worke
 ---
 
 ##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupRemoteAccess.property.sourceSecurityGroups\\"></a>
+
+\`\`\`typescript
+public readonly sourceSecurityGroups: ISecurityGroup[]
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)[]
 - *Default:* port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
@@ -41876,6 +48648,10 @@ const openIdConnectProviderProps: aws_eks.OpenIdConnectProviderProps = { ... }
 \`\`\`
 
 ##### \`url\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.OpenIdConnectProviderProps.property.url\\"></a>
+
+\`\`\`typescript
+public readonly url: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -41906,6 +48682,10 @@ const providerProperty: aws_eks.CfnCluster.ProviderProperty = { ... }
 
 ##### \`keyArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.ProviderProperty.property.keyArn\\"></a>
 
+\`\`\`typescript
+public readonly keyArn: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnCluster.ProviderProperty.KeyArn\`.
@@ -41928,6 +48708,10 @@ const remoteAccessProperty: aws_eks.CfnNodegroup.RemoteAccessProperty = { ... }
 
 ##### \`ec2SshKey\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty.property.ec2SshKey\\"></a>
 
+\`\`\`typescript
+public readonly ec2SshKey: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnNodegroup.RemoteAccessProperty.Ec2SshKey\`.
@@ -41937,6 +48721,10 @@ const remoteAccessProperty: aws_eks.CfnNodegroup.RemoteAccessProperty = { ... }
 ---
 
 ##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty.property.sourceSecurityGroups\\"></a>
+
+\`\`\`typescript
+public readonly sourceSecurityGroups: string[]
+\`\`\`
 
 - *Type:* \`string\`[]
 
@@ -41960,6 +48748,10 @@ const resourcesVpcConfigProperty: aws_eks.CfnCluster.ResourcesVpcConfigProperty 
 
 ##### \`subnetIds\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty.property.subnetIds\\"></a>
 
+\`\`\`typescript
+public readonly subnetIds: string[]
+\`\`\`
+
 - *Type:* \`string\`[]
 
 \`CfnCluster.ResourcesVpcConfigProperty.SubnetIds\`.
@@ -41969,6 +48761,10 @@ const resourcesVpcConfigProperty: aws_eks.CfnCluster.ResourcesVpcConfigProperty 
 ---
 
 ##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty.property.securityGroupIds\\"></a>
+
+\`\`\`typescript
+public readonly securityGroupIds: string[]
+\`\`\`
 
 - *Type:* \`string\`[]
 
@@ -41992,6 +48788,10 @@ const scalingConfigProperty: aws_eks.CfnNodegroup.ScalingConfigProperty = { ... 
 
 ##### \`desiredSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty.property.desiredSize\\"></a>
 
+\`\`\`typescript
+public readonly desiredSize: number
+\`\`\`
+
 - *Type:* \`number\`
 
 \`CfnNodegroup.ScalingConfigProperty.DesiredSize\`.
@@ -42002,6 +48802,10 @@ const scalingConfigProperty: aws_eks.CfnNodegroup.ScalingConfigProperty = { ... 
 
 ##### \`maxSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty.property.maxSize\\"></a>
 
+\`\`\`typescript
+public readonly maxSize: number
+\`\`\`
+
 - *Type:* \`number\`
 
 \`CfnNodegroup.ScalingConfigProperty.MaxSize\`.
@@ -42011,6 +48815,10 @@ const scalingConfigProperty: aws_eks.CfnNodegroup.ScalingConfigProperty = { ... 
 ---
 
 ##### \`minSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty.property.minSize\\"></a>
+
+\`\`\`typescript
+public readonly minSize: number
+\`\`\`
 
 - *Type:* \`number\`
 
@@ -42034,6 +48842,10 @@ const selector: aws_eks.Selector = { ... }
 
 ##### \`namespace\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Selector.property.namespace\\"></a>
 
+\`\`\`typescript
+public readonly namespace: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The Kubernetes namespace that the selector should match.
@@ -42045,6 +48857,10 @@ to target multiple namespaces.
 ---
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Selector.property.labels\\"></a>
+
+\`\`\`typescript
+public readonly labels: {[ key: string ]: string}
+\`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
 - *Default:* all pods within the namespace will be selected.
@@ -42071,6 +48887,10 @@ const selectorProperty: aws_eks.CfnFargateProfile.SelectorProperty = { ... }
 
 ##### \`namespace\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty.property.namespace\\"></a>
 
+\`\`\`typescript
+public readonly namespace: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnFargateProfile.SelectorProperty.Namespace\`.
@@ -42080,6 +48900,10 @@ const selectorProperty: aws_eks.CfnFargateProfile.SelectorProperty = { ... }
 ---
 
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty.property.labels\\"></a>
+
+\`\`\`typescript
+public readonly labels: IResolvable | LabelProperty | IResolvable[]
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty\`](#aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
 
@@ -42103,6 +48927,10 @@ const serviceAccountOptions: aws_eks.ServiceAccountOptions = { ... }
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountOptions.property.name\\"></a>
 
+\`\`\`typescript
+public readonly name: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* If no name is given, it will use the id of the resource.
 
@@ -42111,6 +48939,10 @@ The name of the service account.
 ---
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountOptions.property.namespace\\"></a>
+
+\`\`\`typescript
+public readonly namespace: string
+\`\`\`
 
 - *Type:* \`string\`
 - *Default:* \\"default\\"
@@ -42133,6 +48965,10 @@ const serviceAccountProps: aws_eks.ServiceAccountProps = { ... }
 
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountProps.property.name\\"></a>
 
+\`\`\`typescript
+public readonly name: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* If no name is given, it will use the id of the resource.
 
@@ -42142,6 +48978,10 @@ The name of the service account.
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountProps.property.namespace\\"></a>
 
+\`\`\`typescript
+public readonly namespace: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* \\"default\\"
 
@@ -42150,6 +48990,10 @@ The namespace of the service account.
 ---
 
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountProps.property.cluster\\"></a>
+
+\`\`\`typescript
+public readonly cluster: ICluster
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
 
@@ -42171,6 +49015,10 @@ const serviceLoadBalancerAddressOptions: aws_eks.ServiceLoadBalancerAddressOptio
 
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceLoadBalancerAddressOptions.property.namespace\\"></a>
 
+\`\`\`typescript
+public readonly namespace: string
+\`\`\`
+
 - *Type:* \`string\`
 - *Default:* 'default'
 
@@ -42179,6 +49027,10 @@ The namespace the service belongs to.
 ---
 
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceLoadBalancerAddressOptions.property.timeout\\"></a>
+
+\`\`\`typescript
+public readonly timeout: Duration
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
 - *Default:* Duration.minutes(5)
@@ -42201,6 +49053,10 @@ const taintProperty: aws_eks.CfnNodegroup.TaintProperty = { ... }
 
 ##### \`effect\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty.property.effect\\"></a>
 
+\`\`\`typescript
+public readonly effect: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnNodegroup.TaintProperty.Effect\`.
@@ -42211,6 +49067,10 @@ const taintProperty: aws_eks.CfnNodegroup.TaintProperty = { ... }
 
 ##### \`key\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty.property.key\\"></a>
 
+\`\`\`typescript
+public readonly key: string
+\`\`\`
+
 - *Type:* \`string\`
 
 \`CfnNodegroup.TaintProperty.Key\`.
@@ -42220,6 +49080,10 @@ const taintProperty: aws_eks.CfnNodegroup.TaintProperty = { ... }
 ---
 
 ##### \`value\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty.property.value\\"></a>
+
+\`\`\`typescript
+public readonly value: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -42294,6 +49158,10 @@ CIDR blocks.
 
 ##### \`PRIVATE\` <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.property.PRIVATE\\"></a>
 
+\`\`\`typescript
+public readonly PRIVATE: EndpointAccess
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 
 The cluster endpoint is only accessible through your VPC.
@@ -42303,6 +49171,10 @@ Worker node traffic to the endpoint will stay within your VPC.
 ---
 
 ##### \`PUBLIC\` <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.property.PUBLIC\\"></a>
+
+\`\`\`typescript
+public readonly PUBLIC: EndpointAccess
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 
@@ -42318,6 +49190,10 @@ access the public endpoint from.
 ---
 
 ##### \`PUBLIC_AND_PRIVATE\` <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.property.PUBLIC_AND_PRIVATE\\"></a>
+
+\`\`\`typescript
+public readonly PUBLIC_AND_PRIVATE: EndpointAccess
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 
@@ -42359,6 +49235,10 @@ custom version number.
 
 ##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.version\\"></a>
 
+\`\`\`typescript
+public readonly version: string
+\`\`\`
+
 - *Type:* \`string\`
 
 cluster version number.
@@ -42369,6 +49249,10 @@ cluster version number.
 
 ##### \`V1_14\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_14\\"></a>
 
+\`\`\`typescript
+public readonly V1_14: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
 Kubernetes version 1.14.
@@ -42376,6 +49260,10 @@ Kubernetes version 1.14.
 ---
 
 ##### \`V1_15\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_15\\"></a>
+
+\`\`\`typescript
+public readonly V1_15: KubernetesVersion
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -42385,6 +49273,10 @@ Kubernetes version 1.15.
 
 ##### \`V1_16\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_16\\"></a>
 
+\`\`\`typescript
+public readonly V1_16: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
 Kubernetes version 1.16.
@@ -42392,6 +49284,10 @@ Kubernetes version 1.16.
 ---
 
 ##### \`V1_17\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_17\\"></a>
+
+\`\`\`typescript
+public readonly V1_17: KubernetesVersion
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -42401,6 +49297,10 @@ Kubernetes version 1.17.
 
 ##### \`V1_18\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_18\\"></a>
 
+\`\`\`typescript
+public readonly V1_18: KubernetesVersion
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
 Kubernetes version 1.18.
@@ -42408,6 +49308,10 @@ Kubernetes version 1.18.
 ---
 
 ##### \`V1_19\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_19\\"></a>
+
+\`\`\`typescript
+public readonly V1_19: KubernetesVersion
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -42519,6 +49423,10 @@ service account options.
 
 ##### \`node\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.node\\"></a>
 
+\`\`\`typescript
+public readonly node: Node
+\`\`\`
+
 - *Type:* [\`constructs.Node\`](#constructs.Node)
 
 The tree node.
@@ -42526,6 +49434,10 @@ The tree node.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.env\\"></a>
+
+\`\`\`typescript
+public readonly env: ResourceEnvironment
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.ResourceEnvironment\`](#aws-cdk-lib.ResourceEnvironment)
 
@@ -42542,6 +49454,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.stack\\"></a>
 
+\`\`\`typescript
+public readonly stack: Stack
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.Stack\`](#aws-cdk-lib.Stack)
 
 The stack in which this resource is defined.
@@ -42550,11 +49466,19 @@ The stack in which this resource is defined.
 
 ##### \`connections\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.connections\\"></a>
 
+\`\`\`typescript
+public readonly connections: Connections
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.Connections\`](#aws-cdk-lib.aws_ec2.Connections)
 
 ---
 
 ##### \`clusterArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterArn\\"></a>
+
+\`\`\`typescript
+public readonly clusterArn: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -42564,6 +49488,10 @@ The unique ARN assigned to the service by AWS in the form of arn:aws:eks:.
 
 ##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterCertificateAuthorityData\\"></a>
 
+\`\`\`typescript
+public readonly clusterCertificateAuthorityData: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The certificate-authority-data for your cluster.
@@ -42571,6 +49499,10 @@ The certificate-authority-data for your cluster.
 ---
 
 ##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterEncryptionConfigKeyArn\\"></a>
+
+\`\`\`typescript
+public readonly clusterEncryptionConfigKeyArn: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -42580,6 +49512,10 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 
 ##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterEndpoint\\"></a>
 
+\`\`\`typescript
+public readonly clusterEndpoint: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The API Server endpoint URL.
@@ -42587,6 +49523,10 @@ The API Server endpoint URL.
 ---
 
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterName\\"></a>
+
+\`\`\`typescript
+public readonly clusterName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -42596,6 +49536,10 @@ The physical name of the Cluster.
 
 ##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterSecurityGroup\\"></a>
 
+\`\`\`typescript
+public readonly clusterSecurityGroup: ISecurityGroup
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 
 The cluster security group that was created by Amazon EKS for the cluster.
@@ -42603,6 +49547,10 @@ The cluster security group that was created by Amazon EKS for the cluster.
 ---
 
 ##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterSecurityGroupId\\"></a>
+
+\`\`\`typescript
+public readonly clusterSecurityGroupId: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -42612,6 +49560,10 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 
 ##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.openIdConnectProvider\\"></a>
 
+\`\`\`typescript
+public readonly openIdConnectProvider: IOpenIdConnectProvider
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_iam.IOpenIdConnectProvider\`](#aws-cdk-lib.aws_iam.IOpenIdConnectProvider)
 
 The Open ID Connect Provider of the cluster used to configure Service Accounts.
@@ -42619,6 +49571,10 @@ The Open ID Connect Provider of the cluster used to configure Service Accounts.
 ---
 
 ##### \`prune\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.prune\\"></a>
+
+\`\`\`typescript
+public readonly prune: boolean
+\`\`\`
 
 - *Type:* \`boolean\`
 
@@ -42633,6 +49589,10 @@ apply\` operation with the \`--prune\` switch.
 
 ##### \`vpc\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.vpc\\"></a>
 
+\`\`\`typescript
+public readonly vpc: IVpc
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
 
 The VPC in which this Cluster was created.
@@ -42641,6 +49601,10 @@ The VPC in which this Cluster was created.
 
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlEnvironment\\"></a>
 
+\`\`\`typescript
+public readonly kubectlEnvironment: {[ key: string ]: string}
+\`\`\`
+
 - *Type:* {[ key: string ]: \`string\`}
 
 Custom environment variables when running \`kubectl\` against this cluster.
@@ -42648,6 +49612,10 @@ Custom environment variables when running \`kubectl\` against this cluster.
 ---
 
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlLayer\\"></a>
+
+\`\`\`typescript
+public readonly kubectlLayer: ILayerVersion
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
 
@@ -42659,6 +49627,10 @@ If not defined, a default layer will be used.
 
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlMemory\\"></a>
 
+\`\`\`typescript
+public readonly kubectlMemory: Size
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
 
 Amount of memory to allocate to the provider's lambda function.
@@ -42666,6 +49638,10 @@ Amount of memory to allocate to the provider's lambda function.
 ---
 
 ##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlPrivateSubnets\\"></a>
+
+\`\`\`typescript
+public readonly kubectlPrivateSubnets: ISubnet[]
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISubnet\`](#aws-cdk-lib.aws_ec2.ISubnet)[]
 
@@ -42678,6 +49654,10 @@ publicly.
 
 ##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlRole\\"></a>
 
+\`\`\`typescript
+public readonly kubectlRole: IRole
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
 
 An IAM role that can perform kubectl operations against this cluster.
@@ -42687,6 +49667,10 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 ---
 
 ##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlSecurityGroup\\"></a>
+
+\`\`\`typescript
+public readonly kubectlSecurityGroup: ISecurityGroup
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
 
@@ -42710,6 +49694,10 @@ NodeGroup interface.
 
 ##### \`node\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.property.node\\"></a>
 
+\`\`\`typescript
+public readonly node: Node
+\`\`\`
+
 - *Type:* [\`constructs.Node\`](#constructs.Node)
 
 The tree node.
@@ -42717,6 +49705,10 @@ The tree node.
 ---
 
 ##### \`env\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.property.env\\"></a>
+
+\`\`\`typescript
+public readonly env: ResourceEnvironment
+\`\`\`
 
 - *Type:* [\`aws-cdk-lib.ResourceEnvironment\`](#aws-cdk-lib.ResourceEnvironment)
 
@@ -42733,6 +49725,10 @@ that might be different than the stack they were imported into.
 
 ##### \`stack\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.property.stack\\"></a>
 
+\`\`\`typescript
+public readonly stack: Stack
+\`\`\`
+
 - *Type:* [\`aws-cdk-lib.Stack\`](#aws-cdk-lib.Stack)
 
 The stack in which this resource is defined.
@@ -42740,6 +49736,10 @@ The stack in which this resource is defined.
 ---
 
 ##### \`nodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.property.nodegroupName\\"></a>
+
+\`\`\`typescript
+public readonly nodegroupName: string
+\`\`\`
 
 - *Type:* \`string\`
 

--- a/test/docgen/view/__snapshots__/documentation.test.ts.snap
+++ b/test/docgen/view/__snapshots__/documentation.test.ts.snap
@@ -290,10 +290,6 @@ repository_name: str
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
-
 - *Type:* \`str\`
 
 The CloudFormation resource type name for this resource class.
@@ -395,10 +391,6 @@ policy_text: typing.Any
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
-
 - *Type:* \`str\`
 
 The CloudFormation resource type name for this resource class.
@@ -499,10 +491,6 @@ replication_configuration: typing.Union[IResolvable, ReplicationConfigurationPro
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
 
 - *Type:* \`str\`
 
@@ -764,10 +752,6 @@ repository_name: str
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
 
 - *Type:* \`str\`
 
@@ -3212,7 +3196,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.attrArn\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrArn()
+public java.lang.String getAttrArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -3222,7 +3206,7 @@ public java.lang.String getAttrArn()
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.tags\\"></a>
 
 \`\`\`java
-public TagManager getTags()
+public TagManager getTags();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.TagManager\`](#software.amazon.awscdk.core.TagManager)
@@ -3236,7 +3220,7 @@ public TagManager getTags()
 ##### \`repositoryCatalogData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.repositoryCatalogData\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryCatalogData()
+public java.lang.Object getRepositoryCatalogData();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -3250,7 +3234,7 @@ public java.lang.Object getRepositoryCatalogData()
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.repositoryPolicyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryPolicyText()
+public java.lang.Object getRepositoryPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -3264,7 +3248,7 @@ public java.lang.Object getRepositoryPolicyText()
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -3278,10 +3262,6 @@ public java.lang.String getRepositoryName()
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`java
-public java.lang.String getCfnResourceTypeName()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3355,7 +3335,7 @@ tree inspector to collect and process attributes.
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicy.property.attrRegistryId\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrRegistryId()
+public java.lang.String getAttrRegistryId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -3365,7 +3345,7 @@ public java.lang.String getAttrRegistryId()
 ##### \`policyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicy.property.policyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getPolicyText()
+public java.lang.Object getPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -3379,10 +3359,6 @@ public java.lang.Object getPolicyText()
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`java
-public java.lang.String getCfnResourceTypeName()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3457,7 +3433,7 @@ tree inspector to collect and process attributes.
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.property.attrRegistryId\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrRegistryId()
+public java.lang.String getAttrRegistryId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -3467,7 +3443,7 @@ public java.lang.String getAttrRegistryId()
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.property.replicationConfiguration\\"></a>
 
 \`\`\`java
-public java.lang.Object getReplicationConfiguration()
+public java.lang.Object getReplicationConfiguration();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
@@ -3481,10 +3457,6 @@ public java.lang.Object getReplicationConfiguration()
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`java
-public java.lang.String getCfnResourceTypeName()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3625,7 +3597,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.attrArn\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrArn()
+public java.lang.String getAttrArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -3635,7 +3607,7 @@ public java.lang.String getAttrArn()
 ##### \`attrRepositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.attrRepositoryUri\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrRepositoryUri()
+public java.lang.String getAttrRepositoryUri();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -3645,7 +3617,7 @@ public java.lang.String getAttrRepositoryUri()
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.tags\\"></a>
 
 \`\`\`java
-public TagManager getTags()
+public TagManager getTags();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.TagManager\`](#software.amazon.awscdk.core.TagManager)
@@ -3659,7 +3631,7 @@ public TagManager getTags()
 ##### \`encryptionConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.encryptionConfiguration\\"></a>
 
 \`\`\`java
-public java.lang.Object getEncryptionConfiguration()
+public java.lang.Object getEncryptionConfiguration();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -3673,7 +3645,7 @@ public java.lang.Object getEncryptionConfiguration()
 ##### \`imageScanningConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.imageScanningConfiguration\\"></a>
 
 \`\`\`java
-public java.lang.Object getImageScanningConfiguration()
+public java.lang.Object getImageScanningConfiguration();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -3687,7 +3659,7 @@ public java.lang.Object getImageScanningConfiguration()
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.repositoryPolicyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryPolicyText()
+public java.lang.Object getRepositoryPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -3701,7 +3673,7 @@ public java.lang.Object getRepositoryPolicyText()
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.imageTagMutability\\"></a>
 
 \`\`\`java
-public java.lang.String getImageTagMutability()
+public java.lang.String getImageTagMutability();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -3715,7 +3687,7 @@ public java.lang.String getImageTagMutability()
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.lifecyclePolicy\\"></a>
 
 \`\`\`java
-public java.lang.Object getLifecyclePolicy()
+public java.lang.Object getLifecyclePolicy();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty\`](#software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty)
@@ -3729,7 +3701,7 @@ public java.lang.Object getLifecyclePolicy()
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -3743,10 +3715,6 @@ public java.lang.String getRepositoryName()
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`java
-public java.lang.String getCfnResourceTypeName()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -3981,7 +3949,7 @@ Repository.fromRepositoryName(Construct scope, java.lang.String id, java.lang.St
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.Repository.property.repositoryArn\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryArn()
+public java.lang.String getRepositoryArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -3993,7 +3961,7 @@ The ARN of the repository.
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.Repository.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4263,7 +4231,7 @@ Optional image tag.
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryBase.property.repositoryArn\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryArn()
+public java.lang.String getRepositoryArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4275,7 +4243,7 @@ The ARN of the repository.
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryBase.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4287,7 +4255,7 @@ The name of the repository.
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryBase.property.repositoryUri\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryUri()
+public java.lang.String getRepositoryUri();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4323,7 +4291,7 @@ CfnPublicRepositoryProps.builder()
 ##### \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryCatalogData()
+public java.lang.Object getRepositoryCatalogData();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -4337,7 +4305,7 @@ public java.lang.Object getRepositoryCatalogData()
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4351,7 +4319,7 @@ public java.lang.String getRepositoryName()
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryPolicyText()
+public java.lang.Object getRepositoryPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -4365,7 +4333,7 @@ public java.lang.Object getRepositoryPolicyText()
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 \`\`\`java
-public java.util.List<CfnTag> getTags()
+public java.util.List<CfnTag> getTags();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
@@ -4395,7 +4363,7 @@ CfnRegistryPolicyProps.builder()
 ##### \`policyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicyProps.property.policyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getPolicyText()
+public java.lang.Object getPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -4426,7 +4394,7 @@ CfnReplicationConfigurationProps.builder()
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfigurationProps.property.replicationConfiguration\\"></a>
 
 \`\`\`java
-public java.lang.Object getReplicationConfiguration()
+public java.lang.Object getReplicationConfiguration();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
@@ -4463,7 +4431,7 @@ CfnRepositoryProps.builder()
 ##### \`encryptionConfiguration\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.encryptionConfiguration\\"></a>
 
 \`\`\`java
-public java.lang.Object getEncryptionConfiguration()
+public java.lang.Object getEncryptionConfiguration();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -4477,7 +4445,7 @@ public java.lang.Object getEncryptionConfiguration()
 ##### \`imageScanningConfiguration\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.imageScanningConfiguration\\"></a>
 
 \`\`\`java
-public java.lang.Object getImageScanningConfiguration()
+public java.lang.Object getImageScanningConfiguration();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -4491,7 +4459,7 @@ public java.lang.Object getImageScanningConfiguration()
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.imageTagMutability\\"></a>
 
 \`\`\`java
-public java.lang.String getImageTagMutability()
+public java.lang.String getImageTagMutability();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4505,7 +4473,7 @@ public java.lang.String getImageTagMutability()
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.lifecyclePolicy\\"></a>
 
 \`\`\`java
-public java.lang.Object getLifecyclePolicy()
+public java.lang.Object getLifecyclePolicy();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty\`](#software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty)
@@ -4519,7 +4487,7 @@ public java.lang.Object getLifecyclePolicy()
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4533,7 +4501,7 @@ public java.lang.String getRepositoryName()
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.repositoryPolicyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryPolicyText()
+public java.lang.Object getRepositoryPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -4547,7 +4515,7 @@ public java.lang.Object getRepositoryPolicyText()
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.tags\\"></a>
 
 \`\`\`java
-public java.util.List<CfnTag> getTags()
+public java.util.List<CfnTag> getTags();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
@@ -4576,7 +4544,7 @@ LifecyclePolicyProperty.builder()
 ##### \`lifecyclePolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty.property.lifecyclePolicyText\\"></a>
 
 \`\`\`java
-public java.lang.String getLifecyclePolicyText()
+public java.lang.String getLifecyclePolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4590,7 +4558,7 @@ public java.lang.String getLifecyclePolicyText()
 ##### \`registryId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty.property.registryId\\"></a>
 
 \`\`\`java
-public java.lang.String getRegistryId()
+public java.lang.String getRegistryId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4623,7 +4591,7 @@ LifecycleRule.builder()
 ##### \`description\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.description\\"></a>
 
 \`\`\`java
-public java.lang.String getDescription()
+public java.lang.String getDescription();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4636,7 +4604,7 @@ Describes the purpose of the rule.
 ##### \`maxImageAge\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.maxImageAge\\"></a>
 
 \`\`\`java
-public Duration getMaxImageAge()
+public Duration getMaxImageAge();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
@@ -4650,7 +4618,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 ##### \`maxImageCount\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.maxImageCount\\"></a>
 
 \`\`\`java
-public java.lang.Number getMaxImageCount()
+public java.lang.Number getMaxImageCount();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -4664,7 +4632,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 ##### \`rulePriority\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.rulePriority\\"></a>
 
 \`\`\`java
-public java.lang.Number getRulePriority()
+public java.lang.Number getRulePriority();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -4686,7 +4654,7 @@ automatically assigned to them, higher than any rules that DO have priorities.
 ##### \`tagPrefixList\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.tagPrefixList\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getTagPrefixList()
+public java.util.List<java.lang.String> getTagPrefixList();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -4700,7 +4668,7 @@ Only if tagStatus == TagStatus.Tagged
 ##### \`tagStatus\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.tagStatus\\"></a>
 
 \`\`\`java
-public TagStatus getTagStatus()
+public TagStatus getTagStatus();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ecr.TagStatus\`](#software.amazon.awscdk.services.ecr.TagStatus)
@@ -4734,7 +4702,7 @@ OnCloudTrailImagePushedOptions.builder()
 ##### \`description\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
 \`\`\`java
-public java.lang.String getDescription()
+public java.lang.String getDescription();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4747,7 +4715,7 @@ A description of the rule's purpose.
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.eventPattern\\"></a>
 
 \`\`\`java
-public EventPattern getEventPattern()
+public EventPattern getEventPattern();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.events.EventPattern\`](#software.amazon.awscdk.services.events.EventPattern)
@@ -4766,7 +4734,7 @@ on top of that filtering.
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.ruleName\\"></a>
 
 \`\`\`java
-public java.lang.String getRuleName()
+public java.lang.String getRuleName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4779,7 +4747,7 @@ A name for the rule.
 ##### \`target\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
 \`\`\`java
-public IRuleTarget getTarget()
+public IRuleTarget getTarget();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.events.IRuleTarget\`](#software.amazon.awscdk.services.events.IRuleTarget)
@@ -4792,7 +4760,7 @@ The target to register for the event.
 ##### \`imageTag\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.imageTag\\"></a>
 
 \`\`\`java
-public java.lang.String getImageTag()
+public java.lang.String getImageTag();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4823,7 +4791,7 @@ OnImageScanCompletedOptions.builder()
 ##### \`description\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
 \`\`\`java
-public java.lang.String getDescription()
+public java.lang.String getDescription();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4836,7 +4804,7 @@ A description of the rule's purpose.
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.eventPattern\\"></a>
 
 \`\`\`java
-public EventPattern getEventPattern()
+public EventPattern getEventPattern();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.events.EventPattern\`](#software.amazon.awscdk.services.events.EventPattern)
@@ -4855,7 +4823,7 @@ on top of that filtering.
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.ruleName\\"></a>
 
 \`\`\`java
-public java.lang.String getRuleName()
+public java.lang.String getRuleName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4868,7 +4836,7 @@ A name for the rule.
 ##### \`target\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
 \`\`\`java
-public IRuleTarget getTarget()
+public IRuleTarget getTarget();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.events.IRuleTarget\`](#software.amazon.awscdk.services.events.IRuleTarget)
@@ -4881,7 +4849,7 @@ The target to register for the event.
 ##### \`imageTags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.imageTags\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getImageTags()
+public java.util.List<java.lang.String> getImageTags();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -4912,7 +4880,7 @@ ReplicationConfigurationProperty.builder()
 ##### \`rules\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
 \`\`\`java
-public java.lang.Object getRules()
+public java.lang.Object getRules();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationRuleProperty)>
@@ -4941,7 +4909,7 @@ ReplicationDestinationProperty.builder()
 ##### \`region\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
 \`\`\`java
-public java.lang.String getRegion()
+public java.lang.String getRegion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4955,7 +4923,7 @@ public java.lang.String getRegion()
 ##### \`registryId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registryId\\"></a>
 
 \`\`\`java
-public java.lang.String getRegistryId()
+public java.lang.String getRegistryId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -4985,7 +4953,7 @@ ReplicationRuleProperty.builder()
 ##### \`destinations\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
 \`\`\`java
-public java.lang.Object getDestinations()
+public java.lang.Object getDestinations();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)>
@@ -5012,7 +4980,7 @@ RepositoryAttributes.builder()
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryAttributes.property.repositoryArn\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryArn()
+public java.lang.String getRepositoryArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -5022,7 +4990,7 @@ public java.lang.String getRepositoryArn()
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryAttributes.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -5049,7 +5017,7 @@ RepositoryProps.builder()
 ##### \`imageScanOnPush\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.imageScanOnPush\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getImageScanOnPush()
+public java.lang.Boolean getImageScanOnPush();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -5062,7 +5030,7 @@ Enable the scan on push when creating the repository.
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.imageTagMutability\\"></a>
 
 \`\`\`java
-public TagMutability getImageTagMutability()
+public TagMutability getImageTagMutability();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ecr.TagMutability\`](#software.amazon.awscdk.services.ecr.TagMutability)
@@ -5077,7 +5045,7 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 ##### \`lifecycleRegistryId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.lifecycleRegistryId\\"></a>
 
 \`\`\`java
-public java.lang.String getLifecycleRegistryId()
+public java.lang.String getLifecycleRegistryId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -5092,7 +5060,7 @@ The AWS account ID associated with the registry that contains the repository.
 ##### \`lifecycleRules\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.lifecycleRules\\"></a>
 
 \`\`\`java
-public java.util.List<LifecycleRule> getLifecycleRules()
+public java.util.List<LifecycleRule> getLifecycleRules();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ecr.LifecycleRule\`](#software.amazon.awscdk.services.ecr.LifecycleRule)>
@@ -5105,7 +5073,7 @@ Life cycle rules to apply to this registry.
 ##### \`removalPolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.removalPolicy\\"></a>
 
 \`\`\`java
-public RemovalPolicy getRemovalPolicy()
+public RemovalPolicy getRemovalPolicy();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.RemovalPolicy\`](#software.amazon.awscdk.core.RemovalPolicy)
@@ -5118,7 +5086,7 @@ Determine what happens to the repository when the resource/stack is deleted.
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -5369,7 +5337,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 ##### \`node\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.node\\"></a>
 
 \`\`\`java
-public ConstructNode getNode()
+public ConstructNode getNode();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.ConstructNode\`](#software.amazon.awscdk.core.ConstructNode)
@@ -5381,7 +5349,7 @@ The construct tree node for this construct.
 ##### \`env\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.env\\"></a>
 
 \`\`\`java
-public ResourceEnvironment getEnv()
+public ResourceEnvironment getEnv();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.ResourceEnvironment\`](#software.amazon.awscdk.core.ResourceEnvironment)
@@ -5400,7 +5368,7 @@ that might be different than the stack they were imported into.
 ##### \`stack\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.stack\\"></a>
 
 \`\`\`java
-public Stack getStack()
+public Stack getStack();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.Stack\`](#software.amazon.awscdk.core.Stack)
@@ -5412,7 +5380,7 @@ The stack in which this resource is defined.
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryArn\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryArn()
+public java.lang.String getRepositoryArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -5424,7 +5392,7 @@ The ARN of the repository.
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -5436,7 +5404,7 @@ The name of the repository.
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryUri\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryUri()
+public java.lang.String getRepositoryUri();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -5713,7 +5681,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.attrArn\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrArn()
+public java.lang.String getAttrArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -5723,7 +5691,7 @@ public java.lang.String getAttrArn()
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.tags\\"></a>
 
 \`\`\`java
-public TagManager getTags()
+public TagManager getTags();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.TagManager\`](#software.amazon.awscdk.core.TagManager)
@@ -5737,7 +5705,7 @@ public TagManager getTags()
 ##### \`repositoryCatalogData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.repositoryCatalogData\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryCatalogData()
+public java.lang.Object getRepositoryCatalogData();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -5751,7 +5719,7 @@ public java.lang.Object getRepositoryCatalogData()
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.repositoryPolicyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryPolicyText()
+public java.lang.Object getRepositoryPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -5765,7 +5733,7 @@ public java.lang.Object getRepositoryPolicyText()
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -5779,10 +5747,6 @@ public java.lang.String getRepositoryName()
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`java
-public java.lang.String getCfnResourceTypeName()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -5856,7 +5820,7 @@ tree inspector to collect and process attributes.
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicy.property.attrRegistryId\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrRegistryId()
+public java.lang.String getAttrRegistryId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -5866,7 +5830,7 @@ public java.lang.String getAttrRegistryId()
 ##### \`policyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicy.property.policyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getPolicyText()
+public java.lang.Object getPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -5880,10 +5844,6 @@ public java.lang.Object getPolicyText()
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`java
-public java.lang.String getCfnResourceTypeName()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -5958,7 +5918,7 @@ tree inspector to collect and process attributes.
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.property.attrRegistryId\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrRegistryId()
+public java.lang.String getAttrRegistryId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -5968,7 +5928,7 @@ public java.lang.String getAttrRegistryId()
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.property.replicationConfiguration\\"></a>
 
 \`\`\`java
-public java.lang.Object getReplicationConfiguration()
+public java.lang.Object getReplicationConfiguration();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
@@ -5982,10 +5942,6 @@ public java.lang.Object getReplicationConfiguration()
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`java
-public java.lang.String getCfnResourceTypeName()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -6126,7 +6082,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.attrArn\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrArn()
+public java.lang.String getAttrArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -6136,7 +6092,7 @@ public java.lang.String getAttrArn()
 ##### \`attrRepositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.attrRepositoryUri\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrRepositoryUri()
+public java.lang.String getAttrRepositoryUri();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -6146,7 +6102,7 @@ public java.lang.String getAttrRepositoryUri()
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.tags\\"></a>
 
 \`\`\`java
-public TagManager getTags()
+public TagManager getTags();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.TagManager\`](#software.amazon.awscdk.core.TagManager)
@@ -6160,7 +6116,7 @@ public TagManager getTags()
 ##### \`encryptionConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.encryptionConfiguration\\"></a>
 
 \`\`\`java
-public java.lang.Object getEncryptionConfiguration()
+public java.lang.Object getEncryptionConfiguration();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -6174,7 +6130,7 @@ public java.lang.Object getEncryptionConfiguration()
 ##### \`imageScanningConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.imageScanningConfiguration\\"></a>
 
 \`\`\`java
-public java.lang.Object getImageScanningConfiguration()
+public java.lang.Object getImageScanningConfiguration();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -6188,7 +6144,7 @@ public java.lang.Object getImageScanningConfiguration()
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.repositoryPolicyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryPolicyText()
+public java.lang.Object getRepositoryPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -6202,7 +6158,7 @@ public java.lang.Object getRepositoryPolicyText()
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.imageTagMutability\\"></a>
 
 \`\`\`java
-public java.lang.String getImageTagMutability()
+public java.lang.String getImageTagMutability();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -6216,7 +6172,7 @@ public java.lang.String getImageTagMutability()
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.lifecyclePolicy\\"></a>
 
 \`\`\`java
-public java.lang.Object getLifecyclePolicy()
+public java.lang.Object getLifecyclePolicy();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty\`](#software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty)
@@ -6230,7 +6186,7 @@ public java.lang.Object getLifecyclePolicy()
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -6244,10 +6200,6 @@ public java.lang.String getRepositoryName()
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`java
-public java.lang.String getCfnResourceTypeName()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -6482,7 +6434,7 @@ Repository.fromRepositoryName(Construct scope, java.lang.String id, java.lang.St
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.Repository.property.repositoryArn\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryArn()
+public java.lang.String getRepositoryArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -6494,7 +6446,7 @@ The ARN of the repository.
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.Repository.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -6764,7 +6716,7 @@ Optional image tag.
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryBase.property.repositoryArn\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryArn()
+public java.lang.String getRepositoryArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -6776,7 +6728,7 @@ The ARN of the repository.
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryBase.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -6788,7 +6740,7 @@ The name of the repository.
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryBase.property.repositoryUri\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryUri()
+public java.lang.String getRepositoryUri();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -6824,7 +6776,7 @@ CfnPublicRepositoryProps.builder()
 ##### \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryCatalogData()
+public java.lang.Object getRepositoryCatalogData();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -6838,7 +6790,7 @@ public java.lang.Object getRepositoryCatalogData()
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -6852,7 +6804,7 @@ public java.lang.String getRepositoryName()
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryPolicyText()
+public java.lang.Object getRepositoryPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -6866,7 +6818,7 @@ public java.lang.Object getRepositoryPolicyText()
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 \`\`\`java
-public java.util.List<CfnTag> getTags()
+public java.util.List<CfnTag> getTags();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
@@ -6896,7 +6848,7 @@ CfnRegistryPolicyProps.builder()
 ##### \`policyText\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRegistryPolicyProps.property.policyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getPolicyText()
+public java.lang.Object getPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -6927,7 +6879,7 @@ CfnReplicationConfigurationProps.builder()
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfigurationProps.property.replicationConfiguration\\"></a>
 
 \`\`\`java
-public java.lang.Object getReplicationConfiguration()
+public java.lang.Object getReplicationConfiguration();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
@@ -6964,7 +6916,7 @@ CfnRepositoryProps.builder()
 ##### \`encryptionConfiguration\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.encryptionConfiguration\\"></a>
 
 \`\`\`java
-public java.lang.Object getEncryptionConfiguration()
+public java.lang.Object getEncryptionConfiguration();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -6978,7 +6930,7 @@ public java.lang.Object getEncryptionConfiguration()
 ##### \`imageScanningConfiguration\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.imageScanningConfiguration\\"></a>
 
 \`\`\`java
-public java.lang.Object getImageScanningConfiguration()
+public java.lang.Object getImageScanningConfiguration();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -6992,7 +6944,7 @@ public java.lang.Object getImageScanningConfiguration()
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.imageTagMutability\\"></a>
 
 \`\`\`java
-public java.lang.String getImageTagMutability()
+public java.lang.String getImageTagMutability();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7006,7 +6958,7 @@ public java.lang.String getImageTagMutability()
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.lifecyclePolicy\\"></a>
 
 \`\`\`java
-public java.lang.Object getLifecyclePolicy()
+public java.lang.Object getLifecyclePolicy();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty\`](#software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty)
@@ -7020,7 +6972,7 @@ public java.lang.Object getLifecyclePolicy()
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7034,7 +6986,7 @@ public java.lang.String getRepositoryName()
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.repositoryPolicyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryPolicyText()
+public java.lang.Object getRepositoryPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -7048,7 +7000,7 @@ public java.lang.Object getRepositoryPolicyText()
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepositoryProps.property.tags\\"></a>
 
 \`\`\`java
-public java.util.List<CfnTag> getTags()
+public java.util.List<CfnTag> getTags();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
@@ -7077,7 +7029,7 @@ LifecyclePolicyProperty.builder()
 ##### \`lifecyclePolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty.property.lifecyclePolicyText\\"></a>
 
 \`\`\`java
-public java.lang.String getLifecyclePolicyText()
+public java.lang.String getLifecyclePolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7091,7 +7043,7 @@ public java.lang.String getLifecyclePolicyText()
 ##### \`registryId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnRepository.LifecyclePolicyProperty.property.registryId\\"></a>
 
 \`\`\`java
-public java.lang.String getRegistryId()
+public java.lang.String getRegistryId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7124,7 +7076,7 @@ LifecycleRule.builder()
 ##### \`description\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.description\\"></a>
 
 \`\`\`java
-public java.lang.String getDescription()
+public java.lang.String getDescription();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7137,7 +7089,7 @@ Describes the purpose of the rule.
 ##### \`maxImageAge\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.maxImageAge\\"></a>
 
 \`\`\`java
-public Duration getMaxImageAge()
+public Duration getMaxImageAge();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
@@ -7151,7 +7103,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 ##### \`maxImageCount\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.maxImageCount\\"></a>
 
 \`\`\`java
-public java.lang.Number getMaxImageCount()
+public java.lang.Number getMaxImageCount();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -7165,7 +7117,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 ##### \`rulePriority\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.rulePriority\\"></a>
 
 \`\`\`java
-public java.lang.Number getRulePriority()
+public java.lang.Number getRulePriority();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -7187,7 +7139,7 @@ automatically assigned to them, higher than any rules that DO have priorities.
 ##### \`tagPrefixList\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.tagPrefixList\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getTagPrefixList()
+public java.util.List<java.lang.String> getTagPrefixList();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -7201,7 +7153,7 @@ Only if tagStatus == TagStatus.Tagged
 ##### \`tagStatus\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.LifecycleRule.property.tagStatus\\"></a>
 
 \`\`\`java
-public TagStatus getTagStatus()
+public TagStatus getTagStatus();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ecr.TagStatus\`](#software.amazon.awscdk.services.ecr.TagStatus)
@@ -7235,7 +7187,7 @@ OnCloudTrailImagePushedOptions.builder()
 ##### \`description\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
 \`\`\`java
-public java.lang.String getDescription()
+public java.lang.String getDescription();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7248,7 +7200,7 @@ A description of the rule's purpose.
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.eventPattern\\"></a>
 
 \`\`\`java
-public EventPattern getEventPattern()
+public EventPattern getEventPattern();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.events.EventPattern\`](#software.amazon.awscdk.services.events.EventPattern)
@@ -7267,7 +7219,7 @@ on top of that filtering.
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.ruleName\\"></a>
 
 \`\`\`java
-public java.lang.String getRuleName()
+public java.lang.String getRuleName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7280,7 +7232,7 @@ A name for the rule.
 ##### \`target\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
 \`\`\`java
-public IRuleTarget getTarget()
+public IRuleTarget getTarget();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.events.IRuleTarget\`](#software.amazon.awscdk.services.events.IRuleTarget)
@@ -7293,7 +7245,7 @@ The target to register for the event.
 ##### \`imageTag\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions.property.imageTag\\"></a>
 
 \`\`\`java
-public java.lang.String getImageTag()
+public java.lang.String getImageTag();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7324,7 +7276,7 @@ OnImageScanCompletedOptions.builder()
 ##### \`description\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
 \`\`\`java
-public java.lang.String getDescription()
+public java.lang.String getDescription();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7337,7 +7289,7 @@ A description of the rule's purpose.
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.eventPattern\\"></a>
 
 \`\`\`java
-public EventPattern getEventPattern()
+public EventPattern getEventPattern();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.events.EventPattern\`](#software.amazon.awscdk.services.events.EventPattern)
@@ -7356,7 +7308,7 @@ on top of that filtering.
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.ruleName\\"></a>
 
 \`\`\`java
-public java.lang.String getRuleName()
+public java.lang.String getRuleName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7369,7 +7321,7 @@ A name for the rule.
 ##### \`target\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
 \`\`\`java
-public IRuleTarget getTarget()
+public IRuleTarget getTarget();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.events.IRuleTarget\`](#software.amazon.awscdk.services.events.IRuleTarget)
@@ -7382,7 +7334,7 @@ The target to register for the event.
 ##### \`imageTags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions.property.imageTags\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getImageTags()
+public java.util.List<java.lang.String> getImageTags();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -7413,7 +7365,7 @@ ReplicationConfigurationProperty.builder()
 ##### \`rules\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
 \`\`\`java
-public java.lang.Object getRules()
+public java.lang.Object getRules();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationRuleProperty)>
@@ -7442,7 +7394,7 @@ ReplicationDestinationProperty.builder()
 ##### \`region\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
 \`\`\`java
-public java.lang.String getRegion()
+public java.lang.String getRegion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7456,7 +7408,7 @@ public java.lang.String getRegion()
 ##### \`registryId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registryId\\"></a>
 
 \`\`\`java
-public java.lang.String getRegistryId()
+public java.lang.String getRegistryId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7486,7 +7438,7 @@ ReplicationRuleProperty.builder()
 ##### \`destinations\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
 \`\`\`java
-public java.lang.Object getDestinations()
+public java.lang.Object getDestinations();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR [\`software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#software.amazon.awscdk.services.ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)>
@@ -7513,7 +7465,7 @@ RepositoryAttributes.builder()
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryAttributes.property.repositoryArn\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryArn()
+public java.lang.String getRepositoryArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7523,7 +7475,7 @@ public java.lang.String getRepositoryArn()
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryAttributes.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7550,7 +7502,7 @@ RepositoryProps.builder()
 ##### \`imageScanOnPush\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.imageScanOnPush\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getImageScanOnPush()
+public java.lang.Boolean getImageScanOnPush();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -7563,7 +7515,7 @@ Enable the scan on push when creating the repository.
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.imageTagMutability\\"></a>
 
 \`\`\`java
-public TagMutability getImageTagMutability()
+public TagMutability getImageTagMutability();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ecr.TagMutability\`](#software.amazon.awscdk.services.ecr.TagMutability)
@@ -7578,7 +7530,7 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 ##### \`lifecycleRegistryId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.lifecycleRegistryId\\"></a>
 
 \`\`\`java
-public java.lang.String getLifecycleRegistryId()
+public java.lang.String getLifecycleRegistryId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7593,7 +7545,7 @@ The AWS account ID associated with the registry that contains the repository.
 ##### \`lifecycleRules\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.lifecycleRules\\"></a>
 
 \`\`\`java
-public java.util.List<LifecycleRule> getLifecycleRules()
+public java.util.List<LifecycleRule> getLifecycleRules();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ecr.LifecycleRule\`](#software.amazon.awscdk.services.ecr.LifecycleRule)>
@@ -7606,7 +7558,7 @@ Life cycle rules to apply to this registry.
 ##### \`removalPolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.removalPolicy\\"></a>
 
 \`\`\`java
-public RemovalPolicy getRemovalPolicy()
+public RemovalPolicy getRemovalPolicy();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.RemovalPolicy\`](#software.amazon.awscdk.core.RemovalPolicy)
@@ -7619,7 +7571,7 @@ Determine what happens to the repository when the resource/stack is deleted.
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.RepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7870,7 +7822,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 ##### \`node\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.node\\"></a>
 
 \`\`\`java
-public ConstructNode getNode()
+public ConstructNode getNode();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.ConstructNode\`](#software.amazon.awscdk.core.ConstructNode)
@@ -7882,7 +7834,7 @@ The construct tree node for this construct.
 ##### \`env\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.env\\"></a>
 
 \`\`\`java
-public ResourceEnvironment getEnv()
+public ResourceEnvironment getEnv();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.ResourceEnvironment\`](#software.amazon.awscdk.core.ResourceEnvironment)
@@ -7901,7 +7853,7 @@ that might be different than the stack they were imported into.
 ##### \`stack\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.stack\\"></a>
 
 \`\`\`java
-public Stack getStack()
+public Stack getStack();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.Stack\`](#software.amazon.awscdk.core.Stack)
@@ -7913,7 +7865,7 @@ The stack in which this resource is defined.
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryArn\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryArn()
+public java.lang.String getRepositoryArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7925,7 +7877,7 @@ The ARN of the repository.
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -7937,7 +7889,7 @@ The name of the repository.
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryUri\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryUri()
+public java.lang.String getRepositoryUri();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9456,7 +9408,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.attrArn\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrArn()
+public java.lang.String getAttrArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9466,7 +9418,7 @@ public java.lang.String getAttrArn()
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.tags\\"></a>
 
 \`\`\`java
-public TagManager getTags()
+public TagManager getTags();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.TagManager\`](#software.amazon.awscdk.TagManager)
@@ -9480,7 +9432,7 @@ public TagManager getTags()
 ##### \`addonName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.addonName\\"></a>
 
 \`\`\`java
-public java.lang.String getAddonName()
+public java.lang.String getAddonName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9494,7 +9446,7 @@ public java.lang.String getAddonName()
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9508,7 +9460,7 @@ public java.lang.String getClusterName()
 ##### \`addonVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.addonVersion\\"></a>
 
 \`\`\`java
-public java.lang.String getAddonVersion()
+public java.lang.String getAddonVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9522,7 +9474,7 @@ public java.lang.String getAddonVersion()
 ##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.resolveConflicts\\"></a>
 
 \`\`\`java
-public java.lang.String getResolveConflicts()
+public java.lang.String getResolveConflicts();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9536,7 +9488,7 @@ public java.lang.String getResolveConflicts()
 ##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.serviceAccountRoleArn\\"></a>
 
 \`\`\`java
-public java.lang.String getServiceAccountRoleArn()
+public java.lang.String getServiceAccountRoleArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9550,10 +9502,6 @@ public java.lang.String getServiceAccountRoleArn()
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`java
-public java.lang.String getCfnResourceTypeName()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -9686,7 +9634,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrArn\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrArn()
+public java.lang.String getAttrArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9696,7 +9644,7 @@ public java.lang.String getAttrArn()
 ##### \`attrCertificateAuthorityData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrCertificateAuthorityData\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrCertificateAuthorityData()
+public java.lang.String getAttrCertificateAuthorityData();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9706,7 +9654,7 @@ public java.lang.String getAttrCertificateAuthorityData()
 ##### \`attrClusterSecurityGroupId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrClusterSecurityGroupId\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrClusterSecurityGroupId()
+public java.lang.String getAttrClusterSecurityGroupId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9716,7 +9664,7 @@ public java.lang.String getAttrClusterSecurityGroupId()
 ##### \`attrEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrEncryptionConfigKeyArn\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrEncryptionConfigKeyArn()
+public java.lang.String getAttrEncryptionConfigKeyArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9726,7 +9674,7 @@ public java.lang.String getAttrEncryptionConfigKeyArn()
 ##### \`attrEndpoint\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrEndpoint\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrEndpoint()
+public java.lang.String getAttrEndpoint();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9736,7 +9684,7 @@ public java.lang.String getAttrEndpoint()
 ##### \`attrOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrOpenIdConnectIssuerUrl\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrOpenIdConnectIssuerUrl()
+public java.lang.String getAttrOpenIdConnectIssuerUrl();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9746,7 +9694,7 @@ public java.lang.String getAttrOpenIdConnectIssuerUrl()
 ##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.resourcesVpcConfig\\"></a>
 
 \`\`\`java
-public java.lang.Object getResourcesVpcConfig()
+public java.lang.Object getResourcesVpcConfig();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -9760,7 +9708,7 @@ public java.lang.Object getResourcesVpcConfig()
 ##### \`roleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.roleArn\\"></a>
 
 \`\`\`java
-public java.lang.String getRoleArn()
+public java.lang.String getRoleArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9774,7 +9722,7 @@ public java.lang.String getRoleArn()
 ##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.encryptionConfig\\"></a>
 
 \`\`\`java
-public java.lang.Object getEncryptionConfig()
+public java.lang.Object getEncryptionConfig();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
@@ -9788,7 +9736,7 @@ public java.lang.Object getEncryptionConfig()
 ##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.kubernetesNetworkConfig\\"></a>
 
 \`\`\`java
-public java.lang.Object getKubernetesNetworkConfig()
+public java.lang.Object getKubernetesNetworkConfig();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -9802,7 +9750,7 @@ public java.lang.Object getKubernetesNetworkConfig()
 ##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.name\\"></a>
 
 \`\`\`java
-public java.lang.String getName()
+public java.lang.String getName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9816,7 +9764,7 @@ public java.lang.String getName()
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.version\\"></a>
 
 \`\`\`java
-public java.lang.String getVersion()
+public java.lang.String getVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9830,10 +9778,6 @@ public java.lang.String getVersion()
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`java
-public java.lang.String getCfnResourceTypeName()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -9964,7 +9908,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.attrArn\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrArn()
+public java.lang.String getAttrArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -9974,7 +9918,7 @@ public java.lang.String getAttrArn()
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.tags\\"></a>
 
 \`\`\`java
-public TagManager getTags()
+public TagManager getTags();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.TagManager\`](#software.amazon.awscdk.TagManager)
@@ -9988,7 +9932,7 @@ public TagManager getTags()
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10002,7 +9946,7 @@ public java.lang.String getClusterName()
 ##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.podExecutionRoleArn\\"></a>
 
 \`\`\`java
-public java.lang.String getPodExecutionRoleArn()
+public java.lang.String getPodExecutionRoleArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10016,7 +9960,7 @@ public java.lang.String getPodExecutionRoleArn()
 ##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.selectors\\"></a>
 
 \`\`\`java
-public java.lang.Object getSelectors()
+public java.lang.Object getSelectors();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty\`](#software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
@@ -10030,7 +9974,7 @@ public java.lang.Object getSelectors()
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.fargateProfileName\\"></a>
 
 \`\`\`java
-public java.lang.String getFargateProfileName()
+public java.lang.String getFargateProfileName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10044,7 +9988,7 @@ public java.lang.String getFargateProfileName()
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.subnets\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getSubnets()
+public java.util.List<java.lang.String> getSubnets();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -10058,10 +10002,6 @@ public java.util.List<java.lang.String> getSubnets()
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`java
-public java.lang.String getCfnResourceTypeName()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -10317,7 +10257,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.attrArn\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrArn()
+public java.lang.String getAttrArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10327,7 +10267,7 @@ public java.lang.String getAttrArn()
 ##### \`attrClusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.attrClusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrClusterName()
+public java.lang.String getAttrClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10337,7 +10277,7 @@ public java.lang.String getAttrClusterName()
 ##### \`attrNodegroupName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.attrNodegroupName\\"></a>
 
 \`\`\`java
-public java.lang.String getAttrNodegroupName()
+public java.lang.String getAttrNodegroupName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10347,7 +10287,7 @@ public java.lang.String getAttrNodegroupName()
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.tags\\"></a>
 
 \`\`\`java
-public TagManager getTags()
+public TagManager getTags();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.TagManager\`](#software.amazon.awscdk.TagManager)
@@ -10361,7 +10301,7 @@ public TagManager getTags()
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10375,7 +10315,7 @@ public java.lang.String getClusterName()
 ##### \`labels\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.labels\\"></a>
 
 \`\`\`java
-public java.lang.Object getLabels()
+public java.lang.Object getLabels();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -10389,7 +10329,7 @@ public java.lang.Object getLabels()
 ##### \`nodeRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.nodeRole\\"></a>
 
 \`\`\`java
-public java.lang.String getNodeRole()
+public java.lang.String getNodeRole();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10403,7 +10343,7 @@ public java.lang.String getNodeRole()
 ##### \`subnets\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.subnets\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getSubnets()
+public java.util.List<java.lang.String> getSubnets();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -10417,7 +10357,7 @@ public java.util.List<java.lang.String> getSubnets()
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.amiType\\"></a>
 
 \`\`\`java
-public java.lang.String getAmiType()
+public java.lang.String getAmiType();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10431,7 +10371,7 @@ public java.lang.String getAmiType()
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.capacityType\\"></a>
 
 \`\`\`java
-public java.lang.String getCapacityType()
+public java.lang.String getCapacityType();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10445,7 +10385,7 @@ public java.lang.String getCapacityType()
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.diskSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getDiskSize()
+public java.lang.Number getDiskSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -10459,7 +10399,7 @@ public java.lang.Number getDiskSize()
 ##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.forceUpdateEnabled\\"></a>
 
 \`\`\`java
-public java.lang.Object getForceUpdateEnabled()
+public java.lang.Object getForceUpdateEnabled();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\` OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -10473,7 +10413,7 @@ public java.lang.Object getForceUpdateEnabled()
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.instanceTypes\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getInstanceTypes()
+public java.util.List<java.lang.String> getInstanceTypes();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -10487,7 +10427,7 @@ public java.util.List<java.lang.String> getInstanceTypes()
 ##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.launchTemplate\\"></a>
 
 \`\`\`java
-public java.lang.Object getLaunchTemplate()
+public java.lang.Object getLaunchTemplate();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -10501,7 +10441,7 @@ public java.lang.Object getLaunchTemplate()
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.nodegroupName\\"></a>
 
 \`\`\`java
-public java.lang.String getNodegroupName()
+public java.lang.String getNodegroupName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10515,7 +10455,7 @@ public java.lang.String getNodegroupName()
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.releaseVersion\\"></a>
 
 \`\`\`java
-public java.lang.String getReleaseVersion()
+public java.lang.String getReleaseVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10529,7 +10469,7 @@ public java.lang.String getReleaseVersion()
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.remoteAccess\\"></a>
 
 \`\`\`java
-public java.lang.Object getRemoteAccess()
+public java.lang.Object getRemoteAccess();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -10543,7 +10483,7 @@ public java.lang.Object getRemoteAccess()
 ##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.scalingConfig\\"></a>
 
 \`\`\`java
-public java.lang.Object getScalingConfig()
+public java.lang.Object getScalingConfig();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -10557,7 +10497,7 @@ public java.lang.Object getScalingConfig()
 ##### \`taints\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.taints\\"></a>
 
 \`\`\`java
-public java.lang.Object getTaints()
+public java.lang.Object getTaints();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
@@ -10571,7 +10511,7 @@ public java.lang.Object getTaints()
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.version\\"></a>
 
 \`\`\`java
-public java.lang.String getVersion()
+public java.lang.String getVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -10585,10 +10525,6 @@ public java.lang.String getVersion()
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`java
-public java.lang.String getCfnResourceTypeName()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -11136,7 +11072,7 @@ the cluster properties to use for importing information.
 ##### \`adminRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.adminRole\\"></a>
 
 \`\`\`java
-public Role getAdminRole()
+public Role getAdminRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.Role\`](#software.amazon.awscdk.services.iam.Role)
@@ -11150,7 +11086,7 @@ This role also has \`systems:master\` permissions.
 ##### \`awsAuth\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.awsAuth\\"></a>
 
 \`\`\`java
-public AwsAuth getAwsAuth()
+public AwsAuth getAwsAuth();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.AwsAuth\`](#software.amazon.awscdk.services.eks.AwsAuth)
@@ -11162,7 +11098,7 @@ Lazily creates the AwsAuth resource, which manages AWS authentication mapping.
 ##### \`clusterArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterArn\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterArn()
+public java.lang.String getClusterArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -11174,7 +11110,7 @@ The AWS generated ARN for the Cluster resource.
 ##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterCertificateAuthorityData\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterCertificateAuthorityData()
+public java.lang.String getClusterCertificateAuthorityData();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -11186,7 +11122,7 @@ The certificate-authority-data for your cluster.
 ##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterEncryptionConfigKeyArn\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterEncryptionConfigKeyArn()
+public java.lang.String getClusterEncryptionConfigKeyArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -11198,7 +11134,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 ##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterEndpoint\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterEndpoint()
+public java.lang.String getClusterEndpoint();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -11212,7 +11148,7 @@ This is the URL inside the kubeconfig file to use with kubectl
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -11224,7 +11160,7 @@ The Name of the created EKS Cluster.
 ##### \`clusterOpenIdConnectIssuer\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterOpenIdConnectIssuer\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterOpenIdConnectIssuer()
+public java.lang.String getClusterOpenIdConnectIssuer();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -11240,7 +11176,7 @@ stock \`CfnCluster\`), this is \`undefined\`.
 ##### \`clusterOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterOpenIdConnectIssuerUrl\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterOpenIdConnectIssuerUrl()
+public java.lang.String getClusterOpenIdConnectIssuerUrl();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -11256,7 +11192,7 @@ stock \`CfnCluster\`), this is \`undefined\`.
 ##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterSecurityGroup\\"></a>
 
 \`\`\`java
-public ISecurityGroup getClusterSecurityGroup()
+public ISecurityGroup getClusterSecurityGroup();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
@@ -11268,7 +11204,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 ##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterSecurityGroupId\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterSecurityGroupId()
+public java.lang.String getClusterSecurityGroupId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -11280,7 +11216,7 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 ##### \`connections\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.connections\\"></a>
 
 \`\`\`java
-public Connections getConnections()
+public Connections getConnections();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.Connections\`](#software.amazon.awscdk.services.ec2.Connections)
@@ -11292,7 +11228,7 @@ Manages connection rules (Security Group Rules) for the cluster.
 ##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.openIdConnectProvider\\"></a>
 
 \`\`\`java
-public IOpenIdConnectProvider getOpenIdConnectProvider()
+public IOpenIdConnectProvider getOpenIdConnectProvider();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IOpenIdConnectProvider\`](#software.amazon.awscdk.services.iam.IOpenIdConnectProvider)
@@ -11306,7 +11242,7 @@ A provider will only be defined if this property is accessed (lazy initializatio
 ##### \`prune\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.prune\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getPrune()
+public java.lang.Boolean getPrune();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -11318,7 +11254,7 @@ Determines if Kubernetes resources can be pruned automatically.
 ##### \`role\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.role\\"></a>
 
 \`\`\`java
-public IRole getRole()
+public IRole getRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -11330,7 +11266,7 @@ IAM role assumed by the EKS Control Plane.
 ##### \`vpc\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.vpc\\"></a>
 
 \`\`\`java
-public IVpc getVpc()
+public IVpc getVpc();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
@@ -11342,7 +11278,7 @@ The VPC in which this Cluster was created.
 ##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.defaultCapacity\\"></a>
 
 \`\`\`java
-public AutoScalingGroup getDefaultCapacity()
+public AutoScalingGroup getDefaultCapacity();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.autoscaling.AutoScalingGroup\`](#software.amazon.awscdk.services.autoscaling.AutoScalingGroup)
@@ -11357,7 +11293,7 @@ This will be \`undefined\` if the \`defaultCapacityType\` is not \`EC2\` or
 ##### \`defaultNodegroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.defaultNodegroup\\"></a>
 
 \`\`\`java
-public Nodegroup getDefaultNodegroup()
+public Nodegroup getDefaultNodegroup();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.Nodegroup\`](#software.amazon.awscdk.services.eks.Nodegroup)
@@ -11372,7 +11308,7 @@ This will be \`undefined\` if the \`defaultCapacityType\` is \`EC2\` or
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlEnvironment\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment()
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -11384,7 +11320,7 @@ Custom environment variables when running \`kubectl\` against this cluster.
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlLayer\\"></a>
 
 \`\`\`java
-public ILayerVersion getKubectlLayer()
+public ILayerVersion getKubectlLayer();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
@@ -11399,7 +11335,7 @@ undefined, a SAR app that contains this layer will be used.
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlMemory\\"></a>
 
 \`\`\`java
-public Size getKubectlMemory()
+public Size getKubectlMemory();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Size\`](#software.amazon.awscdk.Size)
@@ -11411,7 +11347,7 @@ The amount of memory allocated to the kubectl provider's lambda function.
 ##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlPrivateSubnets\\"></a>
 
 \`\`\`java
-public java.util.List<ISubnet> getKubectlPrivateSubnets()
+public java.util.List<ISubnet> getKubectlPrivateSubnets();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.ISubnet\`](#software.amazon.awscdk.services.ec2.ISubnet)>
@@ -11425,7 +11361,7 @@ Subnets to host the \`kubectl\` compute resources.
 ##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlRole\\"></a>
 
 \`\`\`java
-public IRole getKubectlRole()
+public IRole getKubectlRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -11439,7 +11375,7 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 ##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlSecurityGroup\\"></a>
 
 \`\`\`java
-public ISecurityGroup getKubectlSecurityGroup()
+public ISecurityGroup getKubectlSecurityGroup();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
@@ -11858,7 +11794,7 @@ The EKS cluster to apply the Fargate profile to.
 ##### \`fargateProfileArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.property.fargateProfileArn\\"></a>
 
 \`\`\`java
-public java.lang.String getFargateProfileArn()
+public java.lang.String getFargateProfileArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -11870,7 +11806,7 @@ The full Amazon Resource Name (ARN) of the Fargate profile.
 ##### \`fargateProfileName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.property.fargateProfileName\\"></a>
 
 \`\`\`java
-public java.lang.String getFargateProfileName()
+public java.lang.String getFargateProfileName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -11882,7 +11818,7 @@ The name of the Fargate profile.
 ##### \`podExecutionRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.property.podExecutionRole\\"></a>
 
 \`\`\`java
-public IRole getPodExecutionRole()
+public IRole getPodExecutionRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -11898,7 +11834,7 @@ ECR image repositories.
 ##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.property.tags\\"></a>
 
 \`\`\`java
-public TagManager getTags()
+public TagManager getTags();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.TagManager\`](#software.amazon.awscdk.TagManager)
@@ -12046,10 +11982,6 @@ The EKS cluster to apply this configuration to.
 
 ##### \`RESOURCE_TYPE\` <a name=\\"software.amazon.awscdk.services.eks.HelmChart.property.RESOURCE_TYPE\\"></a>
 
-\`\`\`java
-public java.lang.String getResourceType()
-\`\`\`
-
 - *Type:* \`java.lang.String\`
 
 The CloudFormation resource type.
@@ -12170,10 +12102,6 @@ in the cluster with the same name, the operation will fail.
 
 ##### \`RESOURCE_TYPE\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifest.property.RESOURCE_TYPE\\"></a>
 
-\`\`\`java
-public java.lang.String getResourceType()
-\`\`\`
-
 - *Type:* \`java.lang.String\`
 
 The CloudFormation reosurce type.
@@ -12276,7 +12204,7 @@ Timeout for waiting on a value.
 ##### \`value\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValue.property.value\\"></a>
 
 \`\`\`java
-public java.lang.String getValue()
+public java.lang.String getValue();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -12288,10 +12216,6 @@ The value as a string token.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`RESOURCE_TYPE\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValue.property.RESOURCE_TYPE\\"></a>
-
-\`\`\`java
-public java.lang.String getResourceType()
-\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -12653,7 +12577,7 @@ services.eks.Nodegroup.fromNodegroupName(Construct scope, java.lang.String id, j
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.property.cluster\\"></a>
 
 \`\`\`java
-public ICluster getCluster()
+public ICluster getCluster();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
@@ -12665,7 +12589,7 @@ the Amazon EKS cluster resource.
 ##### \`nodegroupArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.property.nodegroupArn\\"></a>
 
 \`\`\`java
-public java.lang.String getNodegroupArn()
+public java.lang.String getNodegroupArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -12677,7 +12601,7 @@ ARN of the nodegroup.
 ##### \`nodegroupName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.property.nodegroupName\\"></a>
 
 \`\`\`java
-public java.lang.String getNodegroupName()
+public java.lang.String getNodegroupName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -12689,7 +12613,7 @@ Nodegroup name.
 ##### \`role\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.property.role\\"></a>
 
 \`\`\`java
-public IRole getRole()
+public IRole getRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -12835,7 +12759,7 @@ public addToPrincipalPolicy(PolicyStatement statement)
 ##### \`assumeRoleAction\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.assumeRoleAction\\"></a>
 
 \`\`\`java
-public java.lang.String getAssumeRoleAction()
+public java.lang.String getAssumeRoleAction();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -12847,7 +12771,7 @@ When this Principal is used in an AssumeRole policy, the action to use.
 ##### \`grantPrincipal\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.grantPrincipal\\"></a>
 
 \`\`\`java
-public IPrincipal getGrantPrincipal()
+public IPrincipal getGrantPrincipal();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IPrincipal\`](#software.amazon.awscdk.services.iam.IPrincipal)
@@ -12859,7 +12783,7 @@ The principal to grant permissions to.
 ##### \`policyFragment\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.policyFragment\\"></a>
 
 \`\`\`java
-public PrincipalPolicyFragment getPolicyFragment()
+public PrincipalPolicyFragment getPolicyFragment();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.PrincipalPolicyFragment\`](#software.amazon.awscdk.services.iam.PrincipalPolicyFragment)
@@ -12871,7 +12795,7 @@ Return the policy fragment that identifies this principal in a Policy.
 ##### \`role\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.role\\"></a>
 
 \`\`\`java
-public IRole getRole()
+public IRole getRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -12883,7 +12807,7 @@ The role which is linked to the service account.
 ##### \`serviceAccountName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.serviceAccountName\\"></a>
 
 \`\`\`java
-public java.lang.String getServiceAccountName()
+public java.lang.String getServiceAccountName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -12895,7 +12819,7 @@ The name of the service account.
 ##### \`serviceAccountNamespace\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.serviceAccountNamespace\\"></a>
 
 \`\`\`java
-public java.lang.String getServiceAccountNamespace()
+public java.lang.String getServiceAccountNamespace();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -12949,7 +12873,7 @@ AutoScalingGroupCapacityOptions.builder()
 ##### \`allowAllOutbound\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.allowAllOutbound\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getAllowAllOutbound()
+public java.lang.Boolean getAllowAllOutbound();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -12962,7 +12886,7 @@ Whether the instances can initiate connections to anywhere by default.
 ##### \`associatePublicIpAddress\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.associatePublicIpAddress\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getAssociatePublicIpAddress()
+public java.lang.Boolean getAssociatePublicIpAddress();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -12975,7 +12899,7 @@ Whether instances in the Auto Scaling Group should have public IP addresses asso
 ##### \`autoScalingGroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.autoScalingGroupName\\"></a>
 
 \`\`\`java
-public java.lang.String getAutoScalingGroupName()
+public java.lang.String getAutoScalingGroupName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -12990,7 +12914,7 @@ This name must be unique per Region per account.
 ##### \`blockDevices\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.blockDevices\\"></a>
 
 \`\`\`java
-public java.util.List<BlockDevice> getBlockDevices()
+public java.util.List<BlockDevice> getBlockDevices();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.autoscaling.BlockDevice\`](#software.amazon.awscdk.services.autoscaling.BlockDevice)>
@@ -13010,7 +12934,7 @@ instance store volumes to attach to an instance when it is launched.
 ##### \`cooldown\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.cooldown\\"></a>
 
 \`\`\`java
-public Duration getCooldown()
+public Duration getCooldown();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Duration\`](#software.amazon.awscdk.Duration)
@@ -13023,7 +12947,7 @@ Default scaling cooldown for this AutoScalingGroup.
 ##### \`desiredCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.desiredCapacity\\"></a>
 
 \`\`\`java
-public java.lang.Number getDesiredCapacity()
+public java.lang.Number getDesiredCapacity();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -13041,7 +12965,7 @@ instances to this number. It is recommended to leave this value blank.
 ##### \`groupMetrics\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.groupMetrics\\"></a>
 
 \`\`\`java
-public java.util.List<GroupMetrics> getGroupMetrics()
+public java.util.List<GroupMetrics> getGroupMetrics();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.autoscaling.GroupMetrics\`](#software.amazon.awscdk.services.autoscaling.GroupMetrics)>
@@ -13057,7 +12981,7 @@ Group metrics are reported in a granularity of 1 minute at no additional charge.
 ##### \`healthCheck\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.healthCheck\\"></a>
 
 \`\`\`java
-public HealthCheck getHealthCheck()
+public HealthCheck getHealthCheck();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.autoscaling.HealthCheck\`](#software.amazon.awscdk.services.autoscaling.HealthCheck)
@@ -13070,7 +12994,7 @@ Configuration for health checks.
 ##### \`ignoreUnmodifiedSizeProperties\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.ignoreUnmodifiedSizeProperties\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getIgnoreUnmodifiedSizeProperties()
+public java.lang.Boolean getIgnoreUnmodifiedSizeProperties();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -13089,7 +13013,7 @@ on deployment.
 ##### \`instanceMonitoring\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.instanceMonitoring\\"></a>
 
 \`\`\`java
-public Monitoring getInstanceMonitoring()
+public Monitoring getInstanceMonitoring();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.autoscaling.Monitoring\`](#software.amazon.awscdk.services.autoscaling.Monitoring)
@@ -13107,7 +13031,7 @@ is charged a fee. When you disable detailed monitoring, CloudWatch generates met
 ##### \`keyName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.keyName\\"></a>
 
 \`\`\`java
-public java.lang.String getKeyName()
+public java.lang.String getKeyName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13120,7 +13044,7 @@ Name of SSH keypair to grant access to instances.
 ##### \`maxCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.maxCapacity\\"></a>
 
 \`\`\`java
-public java.lang.Number getMaxCapacity()
+public java.lang.Number getMaxCapacity();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -13133,7 +13057,7 @@ Maximum number of instances in the fleet.
 ##### \`maxInstanceLifetime\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.maxInstanceLifetime\\"></a>
 
 \`\`\`java
-public Duration getMaxInstanceLifetime()
+public Duration getMaxInstanceLifetime();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Duration\`](#software.amazon.awscdk.Duration)
@@ -13155,7 +13079,7 @@ leave this property undefined.
 ##### \`minCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.minCapacity\\"></a>
 
 \`\`\`java
-public java.lang.Number getMinCapacity()
+public java.lang.Number getMinCapacity();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -13168,7 +13092,7 @@ Minimum number of instances in the fleet.
 ##### \`newInstancesProtectedFromScaleIn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.newInstancesProtectedFromScaleIn\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getNewInstancesProtectedFromScaleIn()
+public java.lang.Boolean getNewInstancesProtectedFromScaleIn();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -13190,7 +13114,7 @@ an ECS Capacity Provider with managed termination protection.
 ##### \`notifications\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.notifications\\"></a>
 
 \`\`\`java
-public java.util.List<NotificationConfiguration> getNotifications()
+public java.util.List<NotificationConfiguration> getNotifications();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.autoscaling.NotificationConfiguration\`](#software.amazon.awscdk.services.autoscaling.NotificationConfiguration)>
@@ -13205,7 +13129,7 @@ Configure autoscaling group to send notifications about fleet changes to an SNS 
 ##### \`signals\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.signals\\"></a>
 
 \`\`\`java
-public Signals getSignals()
+public Signals getSignals();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.autoscaling.Signals\`](#software.amazon.awscdk.services.autoscaling.Signals)
@@ -13234,7 +13158,7 @@ https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services
 ##### \`spotPrice\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.spotPrice\\"></a>
 
 \`\`\`java
-public java.lang.String getSpotPrice()
+public java.lang.String getSpotPrice();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13250,7 +13174,7 @@ launched when the price you specify exceeds the current Spot market price.
 ##### \`updatePolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.updatePolicy\\"></a>
 
 \`\`\`java
-public UpdatePolicy getUpdatePolicy()
+public UpdatePolicy getUpdatePolicy();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.autoscaling.UpdatePolicy\`](#software.amazon.awscdk.services.autoscaling.UpdatePolicy)
@@ -13269,7 +13193,7 @@ is done and only new instances are launched with the new config.
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.vpcSubnets\\"></a>
 
 \`\`\`java
-public SubnetSelection getVpcSubnets()
+public SubnetSelection getVpcSubnets();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
@@ -13282,7 +13206,7 @@ Where to place instances within the VPC.
 ##### \`instanceType\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.instanceType\\"></a>
 
 \`\`\`java
-public InstanceType getInstanceType()
+public InstanceType getInstanceType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)
@@ -13294,7 +13218,7 @@ Instance type of the instances to start.
 ##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.bootstrapEnabled\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getBootstrapEnabled()
+public java.lang.Boolean getBootstrapEnabled();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -13310,7 +13234,7 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 ##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.bootstrapOptions\\"></a>
 
 \`\`\`java
-public BootstrapOptions getBootstrapOptions()
+public BootstrapOptions getBootstrapOptions();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.BootstrapOptions\`](#software.amazon.awscdk.services.eks.BootstrapOptions)
@@ -13323,7 +13247,7 @@ EKS node bootstrapping options.
 ##### \`machineImageType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.machineImageType\\"></a>
 
 \`\`\`java
-public MachineImageType getMachineImageType()
+public MachineImageType getMachineImageType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.MachineImageType\`](#software.amazon.awscdk.services.eks.MachineImageType)
@@ -13336,7 +13260,7 @@ Machine image type.
 ##### \`mapRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.mapRole\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getMapRole()
+public java.lang.Boolean getMapRole();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -13351,7 +13275,7 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 ##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.spotInterruptHandler\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getSpotInterruptHandler()
+public java.lang.Boolean getSpotInterruptHandler();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -13384,7 +13308,7 @@ AutoScalingGroupOptions.builder()
 ##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.bootstrapEnabled\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getBootstrapEnabled()
+public java.lang.Boolean getBootstrapEnabled();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -13400,7 +13324,7 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 ##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.bootstrapOptions\\"></a>
 
 \`\`\`java
-public BootstrapOptions getBootstrapOptions()
+public BootstrapOptions getBootstrapOptions();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.BootstrapOptions\`](#software.amazon.awscdk.services.eks.BootstrapOptions)
@@ -13413,7 +13337,7 @@ Allows options for node bootstrapping through EC2 user data.
 ##### \`machineImageType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.machineImageType\\"></a>
 
 \`\`\`java
-public MachineImageType getMachineImageType()
+public MachineImageType getMachineImageType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.MachineImageType\`](#software.amazon.awscdk.services.eks.MachineImageType)
@@ -13426,7 +13350,7 @@ Allow options to specify different machine image type.
 ##### \`mapRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.mapRole\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getMapRole()
+public java.lang.Boolean getMapRole();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -13441,7 +13365,7 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 ##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.spotInterruptHandler\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getSpotInterruptHandler()
+public java.lang.Boolean getSpotInterruptHandler();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -13471,7 +13395,7 @@ AwsAuthMapping.builder()
 ##### \`groups\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuthMapping.property.groups\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getGroups()
+public java.util.List<java.lang.String> getGroups();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -13485,7 +13409,7 @@ A list of groups within Kubernetes to which the role is mapped.
 ##### \`username\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuthMapping.property.username\\"></a>
 
 \`\`\`java
-public java.lang.String getUsername()
+public java.lang.String getUsername();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13512,7 +13436,7 @@ AwsAuthProps.builder()
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuthProps.property.cluster\\"></a>
 
 \`\`\`java
-public Cluster getCluster()
+public Cluster getCluster();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.Cluster\`](#software.amazon.awscdk.services.eks.Cluster)
@@ -13546,7 +13470,7 @@ BootstrapOptions.builder()
 ##### \`additionalArgs\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.additionalArgs\\"></a>
 
 \`\`\`java
-public java.lang.String getAdditionalArgs()
+public java.lang.String getAdditionalArgs();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13561,7 +13485,7 @@ Additional command line arguments to pass to the \`/etc/eks/bootstrap.sh\` comma
 ##### \`awsApiRetryAttempts\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.awsApiRetryAttempts\\"></a>
 
 \`\`\`java
-public java.lang.Number getAwsApiRetryAttempts()
+public java.lang.Number getAwsApiRetryAttempts();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -13574,7 +13498,7 @@ Number of retry attempts for AWS API call (DescribeCluster).
 ##### \`dnsClusterIp\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.dnsClusterIp\\"></a>
 
 \`\`\`java
-public java.lang.String getDnsClusterIp()
+public java.lang.String getDnsClusterIp();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13588,7 +13512,7 @@ Overrides the IP address to use for DNS queries within the cluster.
 ##### \`dockerConfigJson\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.dockerConfigJson\\"></a>
 
 \`\`\`java
-public java.lang.String getDockerConfigJson()
+public java.lang.String getDockerConfigJson();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13601,7 +13525,7 @@ The contents of the \`/etc/docker/daemon.json\` file. Useful if you want a custo
 ##### \`enableDockerBridge\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.enableDockerBridge\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getEnableDockerBridge()
+public java.lang.Boolean getEnableDockerBridge();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -13614,7 +13538,7 @@ Restores the docker default bridge network.
 ##### \`kubeletExtraArgs\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.kubeletExtraArgs\\"></a>
 
 \`\`\`java
-public java.lang.String getKubeletExtraArgs()
+public java.lang.String getKubeletExtraArgs();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13629,7 +13553,7 @@ Useful for adding labels or taints.
 ##### \`useMaxPods\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.useMaxPods\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getUseMaxPods()
+public java.lang.Boolean getUseMaxPods();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -13663,7 +13587,7 @@ CfnAddonProps.builder()
 ##### \`addonName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.addonName\\"></a>
 
 \`\`\`java
-public java.lang.String getAddonName()
+public java.lang.String getAddonName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13677,7 +13601,7 @@ public java.lang.String getAddonName()
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13691,7 +13615,7 @@ public java.lang.String getClusterName()
 ##### \`addonVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.addonVersion\\"></a>
 
 \`\`\`java
-public java.lang.String getAddonVersion()
+public java.lang.String getAddonVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13705,7 +13629,7 @@ public java.lang.String getAddonVersion()
 ##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.resolveConflicts\\"></a>
 
 \`\`\`java
-public java.lang.String getResolveConflicts()
+public java.lang.String getResolveConflicts();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13719,7 +13643,7 @@ public java.lang.String getResolveConflicts()
 ##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.serviceAccountRoleArn\\"></a>
 
 \`\`\`java
-public java.lang.String getServiceAccountRoleArn()
+public java.lang.String getServiceAccountRoleArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13733,7 +13657,7 @@ public java.lang.String getServiceAccountRoleArn()
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.tags\\"></a>
 
 \`\`\`java
-public java.util.List<CfnTag> getTags()
+public java.util.List<CfnTag> getTags();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.CfnTag\`](#software.amazon.awscdk.CfnTag)>
@@ -13772,7 +13696,7 @@ CfnClusterProps.builder()
 ##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.resourcesVpcConfig\\"></a>
 
 \`\`\`java
-public java.lang.Object getResourcesVpcConfig()
+public java.lang.Object getResourcesVpcConfig();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -13786,7 +13710,7 @@ public java.lang.Object getResourcesVpcConfig()
 ##### \`roleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.roleArn\\"></a>
 
 \`\`\`java
-public java.lang.String getRoleArn()
+public java.lang.String getRoleArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13800,7 +13724,7 @@ public java.lang.String getRoleArn()
 ##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.encryptionConfig\\"></a>
 
 \`\`\`java
-public java.lang.Object getEncryptionConfig()
+public java.lang.Object getEncryptionConfig();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
@@ -13814,7 +13738,7 @@ public java.lang.Object getEncryptionConfig()
 ##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.kubernetesNetworkConfig\\"></a>
 
 \`\`\`java
-public java.lang.Object getKubernetesNetworkConfig()
+public java.lang.Object getKubernetesNetworkConfig();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -13828,7 +13752,7 @@ public java.lang.Object getKubernetesNetworkConfig()
 ##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.name\\"></a>
 
 \`\`\`java
-public java.lang.String getName()
+public java.lang.String getName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13842,7 +13766,7 @@ public java.lang.String getName()
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.version\\"></a>
 
 \`\`\`java
-public java.lang.String getVersion()
+public java.lang.String getVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13879,7 +13803,7 @@ CfnFargateProfileProps.builder()
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13893,7 +13817,7 @@ public java.lang.String getClusterName()
 ##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.podExecutionRoleArn\\"></a>
 
 \`\`\`java
-public java.lang.String getPodExecutionRoleArn()
+public java.lang.String getPodExecutionRoleArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13907,7 +13831,7 @@ public java.lang.String getPodExecutionRoleArn()
 ##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.selectors\\"></a>
 
 \`\`\`java
-public java.lang.Object getSelectors()
+public java.lang.Object getSelectors();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty\`](#software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
@@ -13921,7 +13845,7 @@ public java.lang.Object getSelectors()
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.fargateProfileName\\"></a>
 
 \`\`\`java
-public java.lang.String getFargateProfileName()
+public java.lang.String getFargateProfileName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -13935,7 +13859,7 @@ public java.lang.String getFargateProfileName()
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.subnets\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getSubnets()
+public java.util.List<java.lang.String> getSubnets();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -13949,7 +13873,7 @@ public java.util.List<java.lang.String> getSubnets()
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.tags\\"></a>
 
 \`\`\`java
-public java.util.List<CfnTag> getTags()
+public java.util.List<CfnTag> getTags();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.CfnTag\`](#software.amazon.awscdk.CfnTag)>
@@ -14001,7 +13925,7 @@ CfnNodegroupProps.builder()
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14015,7 +13939,7 @@ public java.lang.String getClusterName()
 ##### \`nodeRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.nodeRole\\"></a>
 
 \`\`\`java
-public java.lang.String getNodeRole()
+public java.lang.String getNodeRole();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14029,7 +13953,7 @@ public java.lang.String getNodeRole()
 ##### \`subnets\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.subnets\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getSubnets()
+public java.util.List<java.lang.String> getSubnets();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -14043,7 +13967,7 @@ public java.util.List<java.lang.String> getSubnets()
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.amiType\\"></a>
 
 \`\`\`java
-public java.lang.String getAmiType()
+public java.lang.String getAmiType();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14057,7 +13981,7 @@ public java.lang.String getAmiType()
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.capacityType\\"></a>
 
 \`\`\`java
-public java.lang.String getCapacityType()
+public java.lang.String getCapacityType();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14071,7 +13995,7 @@ public java.lang.String getCapacityType()
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.diskSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getDiskSize()
+public java.lang.Number getDiskSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -14085,7 +14009,7 @@ public java.lang.Number getDiskSize()
 ##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.forceUpdateEnabled\\"></a>
 
 \`\`\`java
-public java.lang.Object getForceUpdateEnabled()
+public java.lang.Object getForceUpdateEnabled();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\` OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -14099,7 +14023,7 @@ public java.lang.Object getForceUpdateEnabled()
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.instanceTypes\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getInstanceTypes()
+public java.util.List<java.lang.String> getInstanceTypes();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -14113,7 +14037,7 @@ public java.util.List<java.lang.String> getInstanceTypes()
 ##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.labels\\"></a>
 
 \`\`\`java
-public java.lang.Object getLabels()
+public java.lang.Object getLabels();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -14127,7 +14051,7 @@ public java.lang.Object getLabels()
 ##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.launchTemplate\\"></a>
 
 \`\`\`java
-public java.lang.Object getLaunchTemplate()
+public java.lang.Object getLaunchTemplate();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -14141,7 +14065,7 @@ public java.lang.Object getLaunchTemplate()
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.nodegroupName\\"></a>
 
 \`\`\`java
-public java.lang.String getNodegroupName()
+public java.lang.String getNodegroupName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14155,7 +14079,7 @@ public java.lang.String getNodegroupName()
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.releaseVersion\\"></a>
 
 \`\`\`java
-public java.lang.String getReleaseVersion()
+public java.lang.String getReleaseVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14169,7 +14093,7 @@ public java.lang.String getReleaseVersion()
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.remoteAccess\\"></a>
 
 \`\`\`java
-public java.lang.Object getRemoteAccess()
+public java.lang.Object getRemoteAccess();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -14183,7 +14107,7 @@ public java.lang.Object getRemoteAccess()
 ##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.scalingConfig\\"></a>
 
 \`\`\`java
-public java.lang.Object getScalingConfig()
+public java.lang.Object getScalingConfig();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -14197,7 +14121,7 @@ public java.lang.Object getScalingConfig()
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.tags\\"></a>
 
 \`\`\`java
-public java.lang.Object getTags()
+public java.lang.Object getTags();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -14211,7 +14135,7 @@ public java.lang.Object getTags()
 ##### \`taints\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.taints\\"></a>
 
 \`\`\`java
-public java.lang.Object getTaints()
+public java.lang.Object getTaints();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
@@ -14225,7 +14149,7 @@ public java.lang.Object getTaints()
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.version\\"></a>
 
 \`\`\`java
-public java.lang.String getVersion()
+public java.lang.String getVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14267,7 +14191,7 @@ ClusterAttributes.builder()
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14279,7 +14203,7 @@ The physical name of the Cluster.
 ##### \`clusterCertificateAuthorityData\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterCertificateAuthorityData\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterCertificateAuthorityData()
+public java.lang.String getClusterCertificateAuthorityData();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14293,7 +14217,7 @@ The certificate-authority-data for your cluster.
 ##### \`clusterEncryptionConfigKeyArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterEncryptionConfigKeyArn\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterEncryptionConfigKeyArn()
+public java.lang.String getClusterEncryptionConfigKeyArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14307,7 +14231,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 ##### \`clusterEndpoint\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterEndpoint\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterEndpoint()
+public java.lang.String getClusterEndpoint();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14320,7 +14244,7 @@ The API Server endpoint URL.
 ##### \`clusterSecurityGroupId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterSecurityGroupId\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterSecurityGroupId()
+public java.lang.String getClusterSecurityGroupId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14334,7 +14258,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlEnvironment\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment()
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -14347,7 +14271,7 @@ Environment variables to use when running \`kubectl\` against this cluster.
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlLayer\\"></a>
 
 \`\`\`java
-public ILayerVersion getKubectlLayer()
+public ILayerVersion getKubectlLayer();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
@@ -14369,7 +14293,7 @@ The handler expects the layer to include the following executables:
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlMemory\\"></a>
 
 \`\`\`java
-public Size getKubectlMemory()
+public Size getKubectlMemory();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Size\`](#software.amazon.awscdk.Size)
@@ -14382,7 +14306,7 @@ Amount of memory to allocate to the provider's lambda function.
 ##### \`kubectlPrivateSubnetIds\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlPrivateSubnetIds\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getKubectlPrivateSubnetIds()
+public java.util.List<java.lang.String> getKubectlPrivateSubnetIds();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -14398,7 +14322,7 @@ endpoint is expected to be accessible publicly.
 ##### \`kubectlRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlRoleArn\\"></a>
 
 \`\`\`java
-public java.lang.String getKubectlRoleArn()
+public java.lang.String getKubectlRoleArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14412,7 +14336,7 @@ An IAM role with cluster administrator and \\"system:masters\\" permissions.
 ##### \`kubectlSecurityGroupId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlSecurityGroupId\\"></a>
 
 \`\`\`java
-public java.lang.String getKubectlSecurityGroupId()
+public java.lang.String getKubectlSecurityGroupId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14428,7 +14352,7 @@ endpoint is expected to be accessible publicly.
 ##### \`openIdConnectProvider\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.openIdConnectProvider\\"></a>
 
 \`\`\`java
-public IOpenIdConnectProvider getOpenIdConnectProvider()
+public IOpenIdConnectProvider getOpenIdConnectProvider();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IOpenIdConnectProvider\`](#software.amazon.awscdk.services.iam.IOpenIdConnectProvider)
@@ -14444,7 +14368,7 @@ or create a new provider using \`new eks.OpenIdConnectProvider\`
 ##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.prune\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getPrune()
+public java.lang.Boolean getPrune();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -14461,7 +14385,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 ##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.securityGroupIds\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getSecurityGroupIds()
+public java.util.List<java.lang.String> getSecurityGroupIds();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -14475,7 +14399,7 @@ Additional security groups associated with this cluster.
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.vpc\\"></a>
 
 \`\`\`java
-public IVpc getVpc()
+public IVpc getVpc();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
@@ -14520,7 +14444,7 @@ ClusterOptions.builder()
 ##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.version\\"></a>
 
 \`\`\`java
-public KubernetesVersion getVersion()
+public KubernetesVersion getVersion();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
@@ -14532,7 +14456,7 @@ The Kubernetes version to run in the cluster.
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14545,7 +14469,7 @@ Name for the cluster.
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.outputClusterName\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getOutputClusterName()
+public java.lang.Boolean getOutputClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -14558,7 +14482,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.outputConfigCommand\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getOutputConfigCommand()
+public java.lang.Boolean getOutputConfigCommand();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -14574,7 +14498,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 ##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.role\\"></a>
 
 \`\`\`java
-public IRole getRole()
+public IRole getRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -14587,7 +14511,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.securityGroup\\"></a>
 
 \`\`\`java
-public ISecurityGroup getSecurityGroup()
+public ISecurityGroup getSecurityGroup();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
@@ -14600,7 +14524,7 @@ Security Group to use for Control Plane ENIs.
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.vpc\\"></a>
 
 \`\`\`java
-public IVpc getVpc()
+public IVpc getVpc();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
@@ -14613,7 +14537,7 @@ The VPC in which to create the Cluster.
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.vpcSubnets\\"></a>
 
 \`\`\`java
-public java.util.List<SubnetSelection> getVpcSubnets()
+public java.util.List<SubnetSelection> getVpcSubnets();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
@@ -14636,7 +14560,7 @@ vpcSubnets: [
 ##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.clusterHandlerEnvironment\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getClusterHandlerEnvironment()
+public java.util.Map<java.lang.String, java.lang.String> getClusterHandlerEnvironment();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -14649,7 +14573,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 ##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.coreDnsComputeType\\"></a>
 
 \`\`\`java
-public CoreDnsComputeType getCoreDnsComputeType()
+public CoreDnsComputeType getCoreDnsComputeType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CoreDnsComputeType\`](#software.amazon.awscdk.services.eks.CoreDnsComputeType)
@@ -14662,7 +14586,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.endpointAccess\\"></a>
 
 \`\`\`java
-public EndpointAccess getEndpointAccess()
+public EndpointAccess getEndpointAccess();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
@@ -14677,7 +14601,7 @@ Configure access to the Kubernetes API server endpoint..
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.kubectlEnvironment\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment()
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -14692,7 +14616,7 @@ Only relevant for kubectl enabled clusters.
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.kubectlLayer\\"></a>
 
 \`\`\`java
-public ILayerVersion getKubectlLayer()
+public ILayerVersion getKubectlLayer();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
@@ -14723,7 +14647,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.kubectlMemory\\"></a>
 
 \`\`\`java
-public Size getKubectlMemory()
+public Size getKubectlMemory();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Size\`](#software.amazon.awscdk.Size)
@@ -14736,7 +14660,7 @@ Amount of memory to allocate to the provider's lambda function.
 ##### \`mastersRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.mastersRole\\"></a>
 
 \`\`\`java
-public IRole getMastersRole()
+public IRole getMastersRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -14752,7 +14676,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 ##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.outputMastersRoleArn\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getOutputMastersRoleArn()
+public java.lang.Boolean getOutputMastersRoleArn();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -14765,7 +14689,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 ##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.placeClusterHandlerInVpc\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getPlaceClusterHandlerInVpc()
+public java.lang.Boolean getPlaceClusterHandlerInVpc();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -14778,7 +14702,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 ##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.prune\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getPrune()
+public java.lang.Boolean getPrune();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -14795,7 +14719,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 ##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.secretsEncryptionKey\\"></a>
 
 \`\`\`java
-public IKey getSecretsEncryptionKey()
+public IKey getSecretsEncryptionKey();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.kms.IKey\`](#software.amazon.awscdk.services.kms.IKey)
@@ -14845,7 +14769,7 @@ ClusterProps.builder()
 ##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.version\\"></a>
 
 \`\`\`java
-public KubernetesVersion getVersion()
+public KubernetesVersion getVersion();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
@@ -14857,7 +14781,7 @@ The Kubernetes version to run in the cluster.
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -14870,7 +14794,7 @@ Name for the cluster.
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.outputClusterName\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getOutputClusterName()
+public java.lang.Boolean getOutputClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -14883,7 +14807,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.outputConfigCommand\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getOutputConfigCommand()
+public java.lang.Boolean getOutputConfigCommand();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -14899,7 +14823,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 ##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.role\\"></a>
 
 \`\`\`java
-public IRole getRole()
+public IRole getRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -14912,7 +14836,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.securityGroup\\"></a>
 
 \`\`\`java
-public ISecurityGroup getSecurityGroup()
+public ISecurityGroup getSecurityGroup();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
@@ -14925,7 +14849,7 @@ Security Group to use for Control Plane ENIs.
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.vpc\\"></a>
 
 \`\`\`java
-public IVpc getVpc()
+public IVpc getVpc();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
@@ -14938,7 +14862,7 @@ The VPC in which to create the Cluster.
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.vpcSubnets\\"></a>
 
 \`\`\`java
-public java.util.List<SubnetSelection> getVpcSubnets()
+public java.util.List<SubnetSelection> getVpcSubnets();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
@@ -14961,7 +14885,7 @@ vpcSubnets: [
 ##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.clusterHandlerEnvironment\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getClusterHandlerEnvironment()
+public java.util.Map<java.lang.String, java.lang.String> getClusterHandlerEnvironment();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -14974,7 +14898,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 ##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.coreDnsComputeType\\"></a>
 
 \`\`\`java
-public CoreDnsComputeType getCoreDnsComputeType()
+public CoreDnsComputeType getCoreDnsComputeType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CoreDnsComputeType\`](#software.amazon.awscdk.services.eks.CoreDnsComputeType)
@@ -14987,7 +14911,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.endpointAccess\\"></a>
 
 \`\`\`java
-public EndpointAccess getEndpointAccess()
+public EndpointAccess getEndpointAccess();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
@@ -15002,7 +14926,7 @@ Configure access to the Kubernetes API server endpoint..
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.kubectlEnvironment\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment()
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -15017,7 +14941,7 @@ Only relevant for kubectl enabled clusters.
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.kubectlLayer\\"></a>
 
 \`\`\`java
-public ILayerVersion getKubectlLayer()
+public ILayerVersion getKubectlLayer();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
@@ -15048,7 +14972,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.kubectlMemory\\"></a>
 
 \`\`\`java
-public Size getKubectlMemory()
+public Size getKubectlMemory();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Size\`](#software.amazon.awscdk.Size)
@@ -15061,7 +14985,7 @@ Amount of memory to allocate to the provider's lambda function.
 ##### \`mastersRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.mastersRole\\"></a>
 
 \`\`\`java
-public IRole getMastersRole()
+public IRole getMastersRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -15077,7 +15001,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 ##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.outputMastersRoleArn\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getOutputMastersRoleArn()
+public java.lang.Boolean getOutputMastersRoleArn();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -15090,7 +15014,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 ##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.placeClusterHandlerInVpc\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getPlaceClusterHandlerInVpc()
+public java.lang.Boolean getPlaceClusterHandlerInVpc();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -15103,7 +15027,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 ##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.prune\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getPrune()
+public java.lang.Boolean getPrune();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -15120,7 +15044,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 ##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.secretsEncryptionKey\\"></a>
 
 \`\`\`java
-public IKey getSecretsEncryptionKey()
+public IKey getSecretsEncryptionKey();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.kms.IKey\`](#software.amazon.awscdk.services.kms.IKey)
@@ -15135,7 +15059,7 @@ KMS secret for envelope encryption for Kubernetes secrets.
 ##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.defaultCapacity\\"></a>
 
 \`\`\`java
-public java.lang.Number getDefaultCapacity()
+public java.lang.Number getDefaultCapacity();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -15154,7 +15078,7 @@ to \`0\` is you wish to avoid the initial capacity allocation.
 ##### \`defaultCapacityInstance\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.defaultCapacityInstance\\"></a>
 
 \`\`\`java
-public InstanceType getDefaultCapacityInstance()
+public InstanceType getDefaultCapacityInstance();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)
@@ -15170,7 +15094,7 @@ into account if \`defaultCapacity\` is > 0.
 ##### \`defaultCapacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.defaultCapacityType\\"></a>
 
 \`\`\`java
-public DefaultCapacityType getDefaultCapacityType()
+public DefaultCapacityType getDefaultCapacityType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.DefaultCapacityType\`](#software.amazon.awscdk.services.eks.DefaultCapacityType)
@@ -15204,7 +15128,7 @@ CommonClusterOptions.builder()
 ##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.version\\"></a>
 
 \`\`\`java
-public KubernetesVersion getVersion()
+public KubernetesVersion getVersion();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
@@ -15216,7 +15140,7 @@ The Kubernetes version to run in the cluster.
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -15229,7 +15153,7 @@ Name for the cluster.
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.outputClusterName\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getOutputClusterName()
+public java.lang.Boolean getOutputClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -15242,7 +15166,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.outputConfigCommand\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getOutputConfigCommand()
+public java.lang.Boolean getOutputConfigCommand();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -15258,7 +15182,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 ##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.role\\"></a>
 
 \`\`\`java
-public IRole getRole()
+public IRole getRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -15271,7 +15195,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.securityGroup\\"></a>
 
 \`\`\`java
-public ISecurityGroup getSecurityGroup()
+public ISecurityGroup getSecurityGroup();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
@@ -15284,7 +15208,7 @@ Security Group to use for Control Plane ENIs.
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.vpc\\"></a>
 
 \`\`\`java
-public IVpc getVpc()
+public IVpc getVpc();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
@@ -15297,7 +15221,7 @@ The VPC in which to create the Cluster.
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.vpcSubnets\\"></a>
 
 \`\`\`java
-public java.util.List<SubnetSelection> getVpcSubnets()
+public java.util.List<SubnetSelection> getVpcSubnets();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
@@ -15336,7 +15260,7 @@ EksOptimizedImageProps.builder()
 ##### \`cpuArch\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps.property.cpuArch\\"></a>
 
 \`\`\`java
-public CpuArch getCpuArch()
+public CpuArch getCpuArch();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CpuArch\`](#software.amazon.awscdk.services.eks.CpuArch)
@@ -15349,7 +15273,7 @@ What cpu architecture to retrieve the image for (arm64 or x86_64).
 ##### \`kubernetesVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps.property.kubernetesVersion\\"></a>
 
 \`\`\`java
-public java.lang.String getKubernetesVersion()
+public java.lang.String getKubernetesVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -15362,7 +15286,7 @@ The Kubernetes version to use.
 ##### \`nodeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps.property.nodeType\\"></a>
 
 \`\`\`java
-public NodeType getNodeType()
+public NodeType getNodeType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.NodeType\`](#software.amazon.awscdk.services.eks.NodeType)
@@ -15391,7 +15315,7 @@ EncryptionConfigProperty.builder()
 ##### \`provider\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty.property.provider\\"></a>
 
 \`\`\`java
-public java.lang.Object getProvider()
+public java.lang.Object getProvider();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.ProviderProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.ProviderProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)
@@ -15405,7 +15329,7 @@ public java.lang.Object getProvider()
 ##### \`resources\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty.property.resources\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getResources()
+public java.util.List<java.lang.String> getResources();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -15452,7 +15376,7 @@ FargateClusterProps.builder()
 ##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.version\\"></a>
 
 \`\`\`java
-public KubernetesVersion getVersion()
+public KubernetesVersion getVersion();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
@@ -15464,7 +15388,7 @@ The Kubernetes version to run in the cluster.
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -15477,7 +15401,7 @@ Name for the cluster.
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.outputClusterName\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getOutputClusterName()
+public java.lang.Boolean getOutputClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -15490,7 +15414,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.outputConfigCommand\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getOutputConfigCommand()
+public java.lang.Boolean getOutputConfigCommand();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -15506,7 +15430,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 ##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.role\\"></a>
 
 \`\`\`java
-public IRole getRole()
+public IRole getRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -15519,7 +15443,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.securityGroup\\"></a>
 
 \`\`\`java
-public ISecurityGroup getSecurityGroup()
+public ISecurityGroup getSecurityGroup();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
@@ -15532,7 +15456,7 @@ Security Group to use for Control Plane ENIs.
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.vpc\\"></a>
 
 \`\`\`java
-public IVpc getVpc()
+public IVpc getVpc();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
@@ -15545,7 +15469,7 @@ The VPC in which to create the Cluster.
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.vpcSubnets\\"></a>
 
 \`\`\`java
-public java.util.List<SubnetSelection> getVpcSubnets()
+public java.util.List<SubnetSelection> getVpcSubnets();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
@@ -15568,7 +15492,7 @@ vpcSubnets: [
 ##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.clusterHandlerEnvironment\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getClusterHandlerEnvironment()
+public java.util.Map<java.lang.String, java.lang.String> getClusterHandlerEnvironment();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -15581,7 +15505,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 ##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.coreDnsComputeType\\"></a>
 
 \`\`\`java
-public CoreDnsComputeType getCoreDnsComputeType()
+public CoreDnsComputeType getCoreDnsComputeType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CoreDnsComputeType\`](#software.amazon.awscdk.services.eks.CoreDnsComputeType)
@@ -15594,7 +15518,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.endpointAccess\\"></a>
 
 \`\`\`java
-public EndpointAccess getEndpointAccess()
+public EndpointAccess getEndpointAccess();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
@@ -15609,7 +15533,7 @@ Configure access to the Kubernetes API server endpoint..
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.kubectlEnvironment\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment()
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -15624,7 +15548,7 @@ Only relevant for kubectl enabled clusters.
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.kubectlLayer\\"></a>
 
 \`\`\`java
-public ILayerVersion getKubectlLayer()
+public ILayerVersion getKubectlLayer();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
@@ -15655,7 +15579,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.kubectlMemory\\"></a>
 
 \`\`\`java
-public Size getKubectlMemory()
+public Size getKubectlMemory();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Size\`](#software.amazon.awscdk.Size)
@@ -15668,7 +15592,7 @@ Amount of memory to allocate to the provider's lambda function.
 ##### \`mastersRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.mastersRole\\"></a>
 
 \`\`\`java
-public IRole getMastersRole()
+public IRole getMastersRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -15684,7 +15608,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 ##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.outputMastersRoleArn\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getOutputMastersRoleArn()
+public java.lang.Boolean getOutputMastersRoleArn();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -15697,7 +15621,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 ##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.placeClusterHandlerInVpc\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getPlaceClusterHandlerInVpc()
+public java.lang.Boolean getPlaceClusterHandlerInVpc();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -15710,7 +15634,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 ##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.prune\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getPrune()
+public java.lang.Boolean getPrune();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -15727,7 +15651,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 ##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.secretsEncryptionKey\\"></a>
 
 \`\`\`java
-public IKey getSecretsEncryptionKey()
+public IKey getSecretsEncryptionKey();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.kms.IKey\`](#software.amazon.awscdk.services.kms.IKey)
@@ -15742,7 +15666,7 @@ KMS secret for envelope encryption for Kubernetes secrets.
 ##### \`defaultProfile\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.defaultProfile\\"></a>
 
 \`\`\`java
-public FargateProfileOptions getDefaultProfile()
+public FargateProfileOptions getDefaultProfile();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.FargateProfileOptions\`](#software.amazon.awscdk.services.eks.FargateProfileOptions)
@@ -15774,7 +15698,7 @@ FargateProfileOptions.builder()
 ##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.selectors\\"></a>
 
 \`\`\`java
-public java.util.List<Selector> getSelectors()
+public java.util.List<Selector> getSelectors();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.eks.Selector\`](#software.amazon.awscdk.services.eks.Selector)>
@@ -15792,7 +15716,7 @@ At least one selector is required and you may specify up to five selectors.
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.fargateProfileName\\"></a>
 
 \`\`\`java
-public java.lang.String getFargateProfileName()
+public java.lang.String getFargateProfileName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -15805,7 +15729,7 @@ The name of the Fargate profile.
 ##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.podExecutionRole\\"></a>
 
 \`\`\`java
-public IRole getPodExecutionRole()
+public IRole getPodExecutionRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -15824,7 +15748,7 @@ ECR image repositories.
 ##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.subnetSelection\\"></a>
 
 \`\`\`java
-public SubnetSelection getSubnetSelection()
+public SubnetSelection getSubnetSelection();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
@@ -15841,7 +15765,7 @@ on Fargate are not assigned public IP addresses, so only private subnets
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.vpc\\"></a>
 
 \`\`\`java
-public IVpc getVpc()
+public IVpc getVpc();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
@@ -15876,7 +15800,7 @@ FargateProfileProps.builder()
 ##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.selectors\\"></a>
 
 \`\`\`java
-public java.util.List<Selector> getSelectors()
+public java.util.List<Selector> getSelectors();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.eks.Selector\`](#software.amazon.awscdk.services.eks.Selector)>
@@ -15894,7 +15818,7 @@ At least one selector is required and you may specify up to five selectors.
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.fargateProfileName\\"></a>
 
 \`\`\`java
-public java.lang.String getFargateProfileName()
+public java.lang.String getFargateProfileName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -15907,7 +15831,7 @@ The name of the Fargate profile.
 ##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.podExecutionRole\\"></a>
 
 \`\`\`java
-public IRole getPodExecutionRole()
+public IRole getPodExecutionRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -15926,7 +15850,7 @@ ECR image repositories.
 ##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.subnetSelection\\"></a>
 
 \`\`\`java
-public SubnetSelection getSubnetSelection()
+public SubnetSelection getSubnetSelection();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
@@ -15943,7 +15867,7 @@ on Fargate are not assigned public IP addresses, so only private subnets
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.vpc\\"></a>
 
 \`\`\`java
-public IVpc getVpc()
+public IVpc getVpc();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
@@ -15959,7 +15883,7 @@ By default, all private subnets are selected. You can customize this using
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.cluster\\"></a>
 
 \`\`\`java
-public Cluster getCluster()
+public Cluster getCluster();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.Cluster\`](#software.amazon.awscdk.services.eks.Cluster)
@@ -15995,7 +15919,7 @@ HelmChartOptions.builder()
 ##### \`chart\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.chart\\"></a>
 
 \`\`\`java
-public java.lang.String getChart()
+public java.lang.String getChart();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16007,7 +15931,7 @@ The name of the chart.
 ##### \`createNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.createNamespace\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getCreateNamespace()
+public java.lang.Boolean getCreateNamespace();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -16020,7 +15944,7 @@ create namespace if not exist.
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.namespace\\"></a>
 
 \`\`\`java
-public java.lang.String getNamespace()
+public java.lang.String getNamespace();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16033,7 +15957,7 @@ The Kubernetes namespace scope of the requests.
 ##### \`release\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.release\\"></a>
 
 \`\`\`java
-public java.lang.String getRelease()
+public java.lang.String getRelease();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16046,7 +15970,7 @@ The name of the release.
 ##### \`repository\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.repository\\"></a>
 
 \`\`\`java
-public java.lang.String getRepository()
+public java.lang.String getRepository();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16061,7 +15985,7 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.timeout\\"></a>
 
 \`\`\`java
-public Duration getTimeout()
+public Duration getTimeout();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Duration\`](#software.amazon.awscdk.Duration)
@@ -16076,7 +16000,7 @@ Maximum 15 minutes.
 ##### \`values\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.values\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.Object> getValues()
+public java.util.Map<java.lang.String, java.lang.Object> getValues();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
@@ -16089,7 +16013,7 @@ The values to be used by the chart.
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.version\\"></a>
 
 \`\`\`java
-public java.lang.String getVersion()
+public java.lang.String getVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16102,7 +16026,7 @@ The chart version to install.
 ##### \`wait\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.wait\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getWait()
+public java.lang.Boolean getWait();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -16138,7 +16062,7 @@ HelmChartProps.builder()
 ##### \`chart\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.chart\\"></a>
 
 \`\`\`java
-public java.lang.String getChart()
+public java.lang.String getChart();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16150,7 +16074,7 @@ The name of the chart.
 ##### \`createNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.createNamespace\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getCreateNamespace()
+public java.lang.Boolean getCreateNamespace();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -16163,7 +16087,7 @@ create namespace if not exist.
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.namespace\\"></a>
 
 \`\`\`java
-public java.lang.String getNamespace()
+public java.lang.String getNamespace();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16176,7 +16100,7 @@ The Kubernetes namespace scope of the requests.
 ##### \`release\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.release\\"></a>
 
 \`\`\`java
-public java.lang.String getRelease()
+public java.lang.String getRelease();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16189,7 +16113,7 @@ The name of the release.
 ##### \`repository\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.repository\\"></a>
 
 \`\`\`java
-public java.lang.String getRepository()
+public java.lang.String getRepository();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16204,7 +16128,7 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.timeout\\"></a>
 
 \`\`\`java
-public Duration getTimeout()
+public Duration getTimeout();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Duration\`](#software.amazon.awscdk.Duration)
@@ -16219,7 +16143,7 @@ Maximum 15 minutes.
 ##### \`values\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.values\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.Object> getValues()
+public java.util.Map<java.lang.String, java.lang.Object> getValues();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
@@ -16232,7 +16156,7 @@ The values to be used by the chart.
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.version\\"></a>
 
 \`\`\`java
-public java.lang.String getVersion()
+public java.lang.String getVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16245,7 +16169,7 @@ The chart version to install.
 ##### \`wait\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.wait\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getWait()
+public java.lang.Boolean getWait();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -16258,7 +16182,7 @@ Whether or not Helm should wait until all Pods, PVCs, Services, and minimum numb
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.cluster\\"></a>
 
 \`\`\`java
-public ICluster getCluster()
+public ICluster getCluster();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
@@ -16287,7 +16211,7 @@ KubernetesManifestOptions.builder()
 ##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestOptions.property.prune\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getPrune()
+public java.lang.Boolean getPrune();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -16317,7 +16241,7 @@ empty.
 ##### \`skipValidation\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestOptions.property.skipValidation\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getSkipValidation()
+public java.lang.Boolean getSkipValidation();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -16348,7 +16272,7 @@ KubernetesManifestProps.builder()
 ##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.prune\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getPrune()
+public java.lang.Boolean getPrune();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -16378,7 +16302,7 @@ empty.
 ##### \`skipValidation\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.skipValidation\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getSkipValidation()
+public java.lang.Boolean getSkipValidation();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -16391,7 +16315,7 @@ A flag to signify if the manifest validation should be skipped.
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.cluster\\"></a>
 
 \`\`\`java
-public ICluster getCluster()
+public ICluster getCluster();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
@@ -16405,7 +16329,7 @@ The EKS cluster to apply this manifest to.
 ##### \`manifest\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.manifest\\"></a>
 
 \`\`\`java
-public java.util.List<java.util.Map<java.lang.String, java.lang.Object>> getManifest()
+public java.util.List<java.util.Map<java.lang.String, java.lang.Object>> getManifest();
 \`\`\`
 
 - *Type:* java.util.List<java.util.Map<java.lang.String, \`java.lang.Object\`>>
@@ -16423,7 +16347,7 @@ deleted, the resources in the manifest will be deleted through \`kubectl delete\
 ##### \`overwrite\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.overwrite\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getOverwrite()
+public java.lang.Boolean getOverwrite();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -16454,7 +16378,7 @@ KubernetesNetworkConfigProperty.builder()
 ##### \`serviceIpv4Cidr\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty.property.serviceIpv4Cidr\\"></a>
 
 \`\`\`java
-public java.lang.String getServiceIpv4Cidr()
+public java.lang.String getServiceIpv4Cidr();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16487,7 +16411,7 @@ KubernetesObjectValueProps.builder()
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.cluster\\"></a>
 
 \`\`\`java
-public ICluster getCluster()
+public ICluster getCluster();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
@@ -16501,7 +16425,7 @@ The EKS cluster to fetch attributes from.
 ##### \`jsonPath\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.jsonPath\\"></a>
 
 \`\`\`java
-public java.lang.String getJsonPath()
+public java.lang.String getJsonPath();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16515,7 +16439,7 @@ JSONPath to the specific value.
 ##### \`objectName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.objectName\\"></a>
 
 \`\`\`java
-public java.lang.String getObjectName()
+public java.lang.String getObjectName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16527,7 +16451,7 @@ The name of the object to query.
 ##### \`objectType\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.objectType\\"></a>
 
 \`\`\`java
-public java.lang.String getObjectType()
+public java.lang.String getObjectType();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16541,7 +16465,7 @@ The object type to query.
 ##### \`objectNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.objectNamespace\\"></a>
 
 \`\`\`java
-public java.lang.String getObjectNamespace()
+public java.lang.String getObjectNamespace();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16554,7 +16478,7 @@ The namespace the object belongs to.
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.timeout\\"></a>
 
 \`\`\`java
-public Duration getTimeout()
+public Duration getTimeout();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Duration\`](#software.amazon.awscdk.Duration)
@@ -16586,7 +16510,7 @@ KubernetesPatchProps.builder()
 ##### \`applyPatch\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.applyPatch\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.Object> getApplyPatch()
+public java.util.Map<java.lang.String, java.lang.Object> getApplyPatch();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
@@ -16598,7 +16522,7 @@ The JSON object to pass to \`kubectl patch\` when the resource is created/update
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.cluster\\"></a>
 
 \`\`\`java
-public ICluster getCluster()
+public ICluster getCluster();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
@@ -16612,7 +16536,7 @@ The cluster to apply the patch to.
 ##### \`resourceName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.resourceName\\"></a>
 
 \`\`\`java
-public java.lang.String getResourceName()
+public java.lang.String getResourceName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16624,7 +16548,7 @@ The full name of the resource to patch (e.g. \`deployment/coredns\`).
 ##### \`restorePatch\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.restorePatch\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.Object> getRestorePatch()
+public java.util.Map<java.lang.String, java.lang.Object> getRestorePatch();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
@@ -16636,7 +16560,7 @@ The JSON object to pass to \`kubectl patch\` when the resource is removed.
 ##### \`patchType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.patchType\\"></a>
 
 \`\`\`java
-public PatchType getPatchType()
+public PatchType getPatchType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.PatchType\`](#software.amazon.awscdk.services.eks.PatchType)
@@ -16651,7 +16575,7 @@ The default type used by \`kubectl patch\` is \\"strategic\\".
 ##### \`resourceNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.resourceNamespace\\"></a>
 
 \`\`\`java
-public java.lang.String getResourceNamespace()
+public java.lang.String getResourceNamespace();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16679,7 +16603,7 @@ LabelProperty.builder()
 ##### \`key\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty.property.key\\"></a>
 
 \`\`\`java
-public java.lang.String getKey()
+public java.lang.String getKey();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16693,7 +16617,7 @@ public java.lang.String getKey()
 ##### \`value\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty.property.value\\"></a>
 
 \`\`\`java
-public java.lang.String getValue()
+public java.lang.String getValue();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16722,7 +16646,7 @@ LaunchTemplateSpec.builder()
 ##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.LaunchTemplateSpec.property.id\\"></a>
 
 \`\`\`java
-public java.lang.String getId()
+public java.lang.String getId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16734,7 +16658,7 @@ The Launch template ID.
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.LaunchTemplateSpec.property.version\\"></a>
 
 \`\`\`java
-public java.lang.String getVersion()
+public java.lang.String getVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16763,7 +16687,7 @@ LaunchTemplateSpecificationProperty.builder()
 ##### \`id\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.id\\"></a>
 
 \`\`\`java
-public java.lang.String getId()
+public java.lang.String getId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16777,7 +16701,7 @@ public java.lang.String getId()
 ##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.name\\"></a>
 
 \`\`\`java
-public java.lang.String getName()
+public java.lang.String getName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16791,7 +16715,7 @@ public java.lang.String getName()
 ##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.version\\"></a>
 
 \`\`\`java
-public java.lang.String getVersion()
+public java.lang.String getVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16834,7 +16758,7 @@ NodegroupOptions.builder()
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.amiType\\"></a>
 
 \`\`\`java
-public NodegroupAmiType getAmiType()
+public NodegroupAmiType getAmiType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.NodegroupAmiType\`](#software.amazon.awscdk.services.eks.NodegroupAmiType)
@@ -16847,7 +16771,7 @@ The AMI type for your node group.
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.capacityType\\"></a>
 
 \`\`\`java
-public CapacityType getCapacityType()
+public CapacityType getCapacityType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CapacityType\`](#software.amazon.awscdk.services.eks.CapacityType)
@@ -16860,7 +16784,7 @@ The capacity type of the nodegroup.
 ##### \`desiredSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.desiredSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getDesiredSize()
+public java.lang.Number getDesiredSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -16876,7 +16800,7 @@ the nodewgroup will initially create \`minSize\` instances.
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.diskSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getDiskSize()
+public java.lang.Number getDiskSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -16889,7 +16813,7 @@ The root device disk size (in GiB) for your node group instances.
 ##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.forceUpdate\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getForceUpdate()
+public java.lang.Boolean getForceUpdate();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -16906,7 +16830,7 @@ running on the node.
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.instanceTypes\\"></a>
 
 \`\`\`java
-public java.util.List<InstanceType> getInstanceTypes()
+public java.util.List<InstanceType> getInstanceTypes();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)>
@@ -16921,7 +16845,7 @@ The instance types to use for your node group.
 ##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.labels\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getLabels()
+public java.util.Map<java.lang.String, java.lang.String> getLabels();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -16934,7 +16858,7 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 ##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.launchTemplateSpec\\"></a>
 
 \`\`\`java
-public LaunchTemplateSpec getLaunchTemplateSpec()
+public LaunchTemplateSpec getLaunchTemplateSpec();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.LaunchTemplateSpec\`](#software.amazon.awscdk.services.eks.LaunchTemplateSpec)
@@ -16949,7 +16873,7 @@ Launch template specification used for the nodegroup.
 ##### \`maxSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.maxSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getMaxSize()
+public java.lang.Number getMaxSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -16964,7 +16888,7 @@ Managed node groups can support up to 100 nodes by default.
 ##### \`minSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.minSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getMinSize()
+public java.lang.Number getMinSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -16979,7 +16903,7 @@ This number must be greater than zero.
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.nodegroupName\\"></a>
 
 \`\`\`java
-public java.lang.String getNodegroupName()
+public java.lang.String getNodegroupName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -16992,7 +16916,7 @@ Name of the Nodegroup.
 ##### \`nodeRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.nodeRole\\"></a>
 
 \`\`\`java
-public IRole getNodeRole()
+public IRole getNodeRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -17010,7 +16934,7 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.releaseVersion\\"></a>
 
 \`\`\`java
-public java.lang.String getReleaseVersion()
+public java.lang.String getReleaseVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17023,7 +16947,7 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.remoteAccess\\"></a>
 
 \`\`\`java
-public NodegroupRemoteAccess getRemoteAccess()
+public NodegroupRemoteAccess getRemoteAccess();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.NodegroupRemoteAccess\`](#software.amazon.awscdk.services.eks.NodegroupRemoteAccess)
@@ -17040,7 +16964,7 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.subnets\\"></a>
 
 \`\`\`java
-public SubnetSelection getSubnets()
+public SubnetSelection getSubnets();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
@@ -17058,7 +16982,7 @@ the name of your cluster.
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.tags\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getTags()
+public java.util.Map<java.lang.String, java.lang.String> getTags();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -17105,7 +17029,7 @@ NodegroupProps.builder()
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.amiType\\"></a>
 
 \`\`\`java
-public NodegroupAmiType getAmiType()
+public NodegroupAmiType getAmiType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.NodegroupAmiType\`](#software.amazon.awscdk.services.eks.NodegroupAmiType)
@@ -17118,7 +17042,7 @@ The AMI type for your node group.
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.capacityType\\"></a>
 
 \`\`\`java
-public CapacityType getCapacityType()
+public CapacityType getCapacityType();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.CapacityType\`](#software.amazon.awscdk.services.eks.CapacityType)
@@ -17131,7 +17055,7 @@ The capacity type of the nodegroup.
 ##### \`desiredSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.desiredSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getDesiredSize()
+public java.lang.Number getDesiredSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -17147,7 +17071,7 @@ the nodewgroup will initially create \`minSize\` instances.
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.diskSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getDiskSize()
+public java.lang.Number getDiskSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -17160,7 +17084,7 @@ The root device disk size (in GiB) for your node group instances.
 ##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.forceUpdate\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getForceUpdate()
+public java.lang.Boolean getForceUpdate();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -17177,7 +17101,7 @@ running on the node.
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.instanceTypes\\"></a>
 
 \`\`\`java
-public java.util.List<InstanceType> getInstanceTypes()
+public java.util.List<InstanceType> getInstanceTypes();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)>
@@ -17192,7 +17116,7 @@ The instance types to use for your node group.
 ##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.labels\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getLabels()
+public java.util.Map<java.lang.String, java.lang.String> getLabels();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -17205,7 +17129,7 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 ##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.launchTemplateSpec\\"></a>
 
 \`\`\`java
-public LaunchTemplateSpec getLaunchTemplateSpec()
+public LaunchTemplateSpec getLaunchTemplateSpec();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.LaunchTemplateSpec\`](#software.amazon.awscdk.services.eks.LaunchTemplateSpec)
@@ -17220,7 +17144,7 @@ Launch template specification used for the nodegroup.
 ##### \`maxSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.maxSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getMaxSize()
+public java.lang.Number getMaxSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -17235,7 +17159,7 @@ Managed node groups can support up to 100 nodes by default.
 ##### \`minSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.minSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getMinSize()
+public java.lang.Number getMinSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -17250,7 +17174,7 @@ This number must be greater than zero.
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.nodegroupName\\"></a>
 
 \`\`\`java
-public java.lang.String getNodegroupName()
+public java.lang.String getNodegroupName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17263,7 +17187,7 @@ Name of the Nodegroup.
 ##### \`nodeRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.nodeRole\\"></a>
 
 \`\`\`java
-public IRole getNodeRole()
+public IRole getNodeRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -17281,7 +17205,7 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.releaseVersion\\"></a>
 
 \`\`\`java
-public java.lang.String getReleaseVersion()
+public java.lang.String getReleaseVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17294,7 +17218,7 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.remoteAccess\\"></a>
 
 \`\`\`java
-public NodegroupRemoteAccess getRemoteAccess()
+public NodegroupRemoteAccess getRemoteAccess();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.NodegroupRemoteAccess\`](#software.amazon.awscdk.services.eks.NodegroupRemoteAccess)
@@ -17311,7 +17235,7 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.subnets\\"></a>
 
 \`\`\`java
-public SubnetSelection getSubnets()
+public SubnetSelection getSubnets();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
@@ -17329,7 +17253,7 @@ the name of your cluster.
 ##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.tags\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getTags()
+public java.util.Map<java.lang.String, java.lang.String> getTags();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -17346,7 +17270,7 @@ associated with the node group, such as the Amazon EC2 instances or subnets.
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.cluster\\"></a>
 
 \`\`\`java
-public ICluster getCluster()
+public ICluster getCluster();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
@@ -17375,7 +17299,7 @@ NodegroupRemoteAccess.builder()
 ##### \`sshKeyName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupRemoteAccess.property.sshKeyName\\"></a>
 
 \`\`\`java
-public java.lang.String getSshKeyName()
+public java.lang.String getSshKeyName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17387,7 +17311,7 @@ The Amazon EC2 SSH key that provides access for SSH communication with the worke
 ##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupRemoteAccess.property.sourceSecurityGroups\\"></a>
 
 \`\`\`java
-public java.util.List<ISecurityGroup> getSourceSecurityGroups()
+public java.util.List<ISecurityGroup> getSourceSecurityGroups();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)>
@@ -17418,7 +17342,7 @@ OpenIdConnectProviderProps.builder()
 ##### \`url\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.OpenIdConnectProviderProps.property.url\\"></a>
 
 \`\`\`java
-public java.lang.String getUrl()
+public java.lang.String getUrl();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17453,7 +17377,7 @@ ProviderProperty.builder()
 ##### \`keyArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.ProviderProperty.property.keyArn\\"></a>
 
 \`\`\`java
-public java.lang.String getKeyArn()
+public java.lang.String getKeyArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17482,7 +17406,7 @@ RemoteAccessProperty.builder()
 ##### \`ec2SshKey\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty.property.ec2SshKey\\"></a>
 
 \`\`\`java
-public java.lang.String getEc2SshKey()
+public java.lang.String getEc2SshKey();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17496,7 +17420,7 @@ public java.lang.String getEc2SshKey()
 ##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty.property.sourceSecurityGroups\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getSourceSecurityGroups()
+public java.util.List<java.lang.String> getSourceSecurityGroups();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -17525,7 +17449,7 @@ ResourcesVpcConfigProperty.builder()
 ##### \`subnetIds\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty.property.subnetIds\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getSubnetIds()
+public java.util.List<java.lang.String> getSubnetIds();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -17539,7 +17463,7 @@ public java.util.List<java.lang.String> getSubnetIds()
 ##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty.property.securityGroupIds\\"></a>
 
 \`\`\`java
-public java.util.List<java.lang.String> getSecurityGroupIds()
+public java.util.List<java.lang.String> getSecurityGroupIds();
 \`\`\`
 
 - *Type:* java.util.List<\`java.lang.String\`>
@@ -17569,7 +17493,7 @@ ScalingConfigProperty.builder()
 ##### \`desiredSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty.property.desiredSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getDesiredSize()
+public java.lang.Number getDesiredSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -17583,7 +17507,7 @@ public java.lang.Number getDesiredSize()
 ##### \`maxSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty.property.maxSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getMaxSize()
+public java.lang.Number getMaxSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -17597,7 +17521,7 @@ public java.lang.Number getMaxSize()
 ##### \`minSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty.property.minSize\\"></a>
 
 \`\`\`java
-public java.lang.Number getMinSize()
+public java.lang.Number getMinSize();
 \`\`\`
 
 - *Type:* \`java.lang.Number\`
@@ -17626,7 +17550,7 @@ Selector.builder()
 ##### \`namespace\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Selector.property.namespace\\"></a>
 
 \`\`\`java
-public java.lang.String getNamespace()
+public java.lang.String getNamespace();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17642,7 +17566,7 @@ to target multiple namespaces.
 ##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Selector.property.labels\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getLabels()
+public java.util.Map<java.lang.String, java.lang.String> getLabels();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -17676,7 +17600,7 @@ SelectorProperty.builder()
 ##### \`namespace\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty.property.namespace\\"></a>
 
 \`\`\`java
-public java.lang.String getNamespace()
+public java.lang.String getNamespace();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17690,7 +17614,7 @@ public java.lang.String getNamespace()
 ##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty.property.labels\\"></a>
 
 \`\`\`java
-public java.lang.Object getLabels()
+public java.lang.Object getLabels();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty\`](#software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty) OR [\`software.amazon.awscdk.IResolvable\`](#software.amazon.awscdk.IResolvable)>
@@ -17719,7 +17643,7 @@ ServiceAccountOptions.builder()
 ##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountOptions.property.name\\"></a>
 
 \`\`\`java
-public java.lang.String getName()
+public java.lang.String getName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17732,7 +17656,7 @@ The name of the service account.
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountOptions.property.namespace\\"></a>
 
 \`\`\`java
-public java.lang.String getNamespace()
+public java.lang.String getNamespace();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17761,7 +17685,7 @@ ServiceAccountProps.builder()
 ##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps.property.name\\"></a>
 
 \`\`\`java
-public java.lang.String getName()
+public java.lang.String getName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17774,7 +17698,7 @@ The name of the service account.
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps.property.namespace\\"></a>
 
 \`\`\`java
-public java.lang.String getNamespace()
+public java.lang.String getNamespace();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17787,7 +17711,7 @@ The namespace of the service account.
 ##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps.property.cluster\\"></a>
 
 \`\`\`java
-public ICluster getCluster()
+public ICluster getCluster();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
@@ -17814,7 +17738,7 @@ ServiceLoadBalancerAddressOptions.builder()
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceLoadBalancerAddressOptions.property.namespace\\"></a>
 
 \`\`\`java
-public java.lang.String getNamespace()
+public java.lang.String getNamespace();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17827,7 +17751,7 @@ The namespace the service belongs to.
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceLoadBalancerAddressOptions.property.timeout\\"></a>
 
 \`\`\`java
-public Duration getTimeout()
+public Duration getTimeout();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Duration\`](#software.amazon.awscdk.Duration)
@@ -17856,7 +17780,7 @@ TaintProperty.builder()
 ##### \`effect\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty.property.effect\\"></a>
 
 \`\`\`java
-public java.lang.String getEffect()
+public java.lang.String getEffect();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17870,7 +17794,7 @@ public java.lang.String getEffect()
 ##### \`key\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty.property.key\\"></a>
 
 \`\`\`java
-public java.lang.String getKey()
+public java.lang.String getKey();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17884,7 +17808,7 @@ public java.lang.String getKey()
 ##### \`value\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty.property.value\\"></a>
 
 \`\`\`java
-public java.lang.String getValue()
+public java.lang.String getValue();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -17985,10 +17909,6 @@ CIDR blocks.
 
 ##### \`PRIVATE\` <a name=\\"software.amazon.awscdk.services.eks.EndpointAccess.property.PRIVATE\\"></a>
 
-\`\`\`java
-public EndpointAccess getPrivate()
-\`\`\`
-
 - *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
 
 The cluster endpoint is only accessible through your VPC.
@@ -17998,10 +17918,6 @@ Worker node traffic to the endpoint will stay within your VPC.
 ---
 
 ##### \`PUBLIC\` <a name=\\"software.amazon.awscdk.services.eks.EndpointAccess.property.PUBLIC\\"></a>
-
-\`\`\`java
-public EndpointAccess getPublic()
-\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
 
@@ -18017,10 +17933,6 @@ access the public endpoint from.
 ---
 
 ##### \`PUBLIC_AND_PRIVATE\` <a name=\\"software.amazon.awscdk.services.eks.EndpointAccess.property.PUBLIC_AND_PRIVATE\\"></a>
-
-\`\`\`java
-public EndpointAccess getPublicAndPrivate()
-\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
 
@@ -18063,7 +17975,7 @@ custom version number.
 ##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.version\\"></a>
 
 \`\`\`java
-public java.lang.String getVersion()
+public java.lang.String getVersion();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -18076,10 +17988,6 @@ cluster version number.
 
 ##### \`V1_14\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_14\\"></a>
 
-\`\`\`java
-public KubernetesVersion getV114()
-\`\`\`
-
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
 Kubernetes version 1.14.
@@ -18087,10 +17995,6 @@ Kubernetes version 1.14.
 ---
 
 ##### \`V1_15\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_15\\"></a>
-
-\`\`\`java
-public KubernetesVersion getV115()
-\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
@@ -18100,10 +18004,6 @@ Kubernetes version 1.15.
 
 ##### \`V1_16\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_16\\"></a>
 
-\`\`\`java
-public KubernetesVersion getV116()
-\`\`\`
-
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
 Kubernetes version 1.16.
@@ -18111,10 +18011,6 @@ Kubernetes version 1.16.
 ---
 
 ##### \`V1_17\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_17\\"></a>
-
-\`\`\`java
-public KubernetesVersion getV117()
-\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
@@ -18124,10 +18020,6 @@ Kubernetes version 1.17.
 
 ##### \`V1_18\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_18\\"></a>
 
-\`\`\`java
-public KubernetesVersion getV118()
-\`\`\`
-
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
 Kubernetes version 1.18.
@@ -18135,10 +18027,6 @@ Kubernetes version 1.18.
 ---
 
 ##### \`V1_19\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_19\\"></a>
-
-\`\`\`java
-public KubernetesVersion getV119()
-\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
 
@@ -18252,7 +18140,7 @@ service account options.
 ##### \`node\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.node\\"></a>
 
 \`\`\`java
-public Node getNode()
+public Node getNode();
 \`\`\`
 
 - *Type:* [\`software.constructs.Node\`](#software.constructs.Node)
@@ -18264,7 +18152,7 @@ The tree node.
 ##### \`env\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.env\\"></a>
 
 \`\`\`java
-public ResourceEnvironment getEnv()
+public ResourceEnvironment getEnv();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.ResourceEnvironment\`](#software.amazon.awscdk.ResourceEnvironment)
@@ -18283,7 +18171,7 @@ that might be different than the stack they were imported into.
 ##### \`stack\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.stack\\"></a>
 
 \`\`\`java
-public Stack getStack()
+public Stack getStack();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Stack\`](#software.amazon.awscdk.Stack)
@@ -18295,7 +18183,7 @@ The stack in which this resource is defined.
 ##### \`connections\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.connections\\"></a>
 
 \`\`\`java
-public Connections getConnections()
+public Connections getConnections();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.Connections\`](#software.amazon.awscdk.services.ec2.Connections)
@@ -18305,7 +18193,7 @@ public Connections getConnections()
 ##### \`clusterArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterArn\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterArn()
+public java.lang.String getClusterArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -18317,7 +18205,7 @@ The unique ARN assigned to the service by AWS in the form of arn:aws:eks:.
 ##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterCertificateAuthorityData\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterCertificateAuthorityData()
+public java.lang.String getClusterCertificateAuthorityData();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -18329,7 +18217,7 @@ The certificate-authority-data for your cluster.
 ##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterEncryptionConfigKeyArn\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterEncryptionConfigKeyArn()
+public java.lang.String getClusterEncryptionConfigKeyArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -18341,7 +18229,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 ##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterEndpoint\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterEndpoint()
+public java.lang.String getClusterEndpoint();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -18353,7 +18241,7 @@ The API Server endpoint URL.
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterName\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterName()
+public java.lang.String getClusterName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -18365,7 +18253,7 @@ The physical name of the Cluster.
 ##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterSecurityGroup\\"></a>
 
 \`\`\`java
-public ISecurityGroup getClusterSecurityGroup()
+public ISecurityGroup getClusterSecurityGroup();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
@@ -18377,7 +18265,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 ##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterSecurityGroupId\\"></a>
 
 \`\`\`java
-public java.lang.String getClusterSecurityGroupId()
+public java.lang.String getClusterSecurityGroupId();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -18389,7 +18277,7 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 ##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.openIdConnectProvider\\"></a>
 
 \`\`\`java
-public IOpenIdConnectProvider getOpenIdConnectProvider()
+public IOpenIdConnectProvider getOpenIdConnectProvider();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IOpenIdConnectProvider\`](#software.amazon.awscdk.services.iam.IOpenIdConnectProvider)
@@ -18401,7 +18289,7 @@ The Open ID Connect Provider of the cluster used to configure Service Accounts.
 ##### \`prune\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.prune\\"></a>
 
 \`\`\`java
-public java.lang.Boolean getPrune()
+public java.lang.Boolean getPrune();
 \`\`\`
 
 - *Type:* \`java.lang.Boolean\`
@@ -18418,7 +18306,7 @@ apply\` operation with the \`--prune\` switch.
 ##### \`vpc\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.vpc\\"></a>
 
 \`\`\`java
-public IVpc getVpc()
+public IVpc getVpc();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
@@ -18430,7 +18318,7 @@ The VPC in which this Cluster was created.
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlEnvironment\\"></a>
 
 \`\`\`java
-public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment()
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment();
 \`\`\`
 
 - *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
@@ -18442,7 +18330,7 @@ Custom environment variables when running \`kubectl\` against this cluster.
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlLayer\\"></a>
 
 \`\`\`java
-public ILayerVersion getKubectlLayer()
+public ILayerVersion getKubectlLayer();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
@@ -18456,7 +18344,7 @@ If not defined, a default layer will be used.
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlMemory\\"></a>
 
 \`\`\`java
-public Size getKubectlMemory()
+public Size getKubectlMemory();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Size\`](#software.amazon.awscdk.Size)
@@ -18468,7 +18356,7 @@ Amount of memory to allocate to the provider's lambda function.
 ##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlPrivateSubnets\\"></a>
 
 \`\`\`java
-public java.util.List<ISubnet> getKubectlPrivateSubnets()
+public java.util.List<ISubnet> getKubectlPrivateSubnets();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.ISubnet\`](#software.amazon.awscdk.services.ec2.ISubnet)>
@@ -18483,7 +18371,7 @@ publicly.
 ##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlRole\\"></a>
 
 \`\`\`java
-public IRole getKubectlRole()
+public IRole getKubectlRole();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
@@ -18497,7 +18385,7 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 ##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlSecurityGroup\\"></a>
 
 \`\`\`java
-public ISecurityGroup getKubectlSecurityGroup()
+public ISecurityGroup getKubectlSecurityGroup();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
@@ -18523,7 +18411,7 @@ NodeGroup interface.
 ##### \`node\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.INodegroup.property.node\\"></a>
 
 \`\`\`java
-public Node getNode()
+public Node getNode();
 \`\`\`
 
 - *Type:* [\`software.constructs.Node\`](#software.constructs.Node)
@@ -18535,7 +18423,7 @@ The tree node.
 ##### \`env\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.INodegroup.property.env\\"></a>
 
 \`\`\`java
-public ResourceEnvironment getEnv()
+public ResourceEnvironment getEnv();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.ResourceEnvironment\`](#software.amazon.awscdk.ResourceEnvironment)
@@ -18554,7 +18442,7 @@ that might be different than the stack they were imported into.
 ##### \`stack\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.INodegroup.property.stack\\"></a>
 
 \`\`\`java
-public Stack getStack()
+public Stack getStack();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Stack\`](#software.amazon.awscdk.Stack)
@@ -18566,7 +18454,7 @@ The stack in which this resource is defined.
 ##### \`nodegroupName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.INodegroup.property.nodegroupName\\"></a>
 
 \`\`\`java
-public java.lang.String getNodegroupName()
+public java.lang.String getNodegroupName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -19092,10 +18980,6 @@ repository_name: str
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
-
 - *Type:* \`str\`
 
 The CloudFormation resource type name for this resource class.
@@ -19197,10 +19081,6 @@ policy_text: typing.Any
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
-
 - *Type:* \`str\`
 
 The CloudFormation resource type name for this resource class.
@@ -19301,10 +19181,6 @@ replication_configuration: typing.Union[IResolvable, ReplicationConfigurationPro
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
 
 - *Type:* \`str\`
 
@@ -19566,10 +19442,6 @@ repository_name: str
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
 
 - *Type:* \`str\`
 
@@ -22085,10 +21957,6 @@ repository_name: str
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
-
 - *Type:* \`str\`
 
 The CloudFormation resource type name for this resource class.
@@ -22190,10 +22058,6 @@ policy_text: typing.Any
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
-
 - *Type:* \`str\`
 
 The CloudFormation resource type name for this resource class.
@@ -22294,10 +22158,6 @@ replication_configuration: typing.Union[IResolvable, ReplicationConfigurationPro
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
 
 - *Type:* \`str\`
 
@@ -22559,10 +22419,6 @@ repository_name: str
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
 
 - *Type:* \`str\`
 
@@ -26384,10 +26240,6 @@ service_account_role_arn: str
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnAddon.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
-
 - *Type:* \`str\`
 
 The CloudFormation resource type name for this resource class.
@@ -26664,10 +26516,6 @@ version: str
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnCluster.property.CFN_RESOURCE_TYPE_NAME\\"></a>
 
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
-
 - *Type:* \`str\`
 
 The CloudFormation resource type name for this resource class.
@@ -26893,10 +26741,6 @@ subnets: typing.List[str]
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnFargateProfile.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
 
 - *Type:* \`str\`
 
@@ -27418,10 +27262,6 @@ version: str
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws_cdk.aws_eks.CfnNodegroup.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`python
-CFN_RESOURCE_TYPE_NAME: str
-\`\`\`
 
 - *Type:* \`str\`
 
@@ -29813,10 +29653,6 @@ The EKS cluster to apply this configuration to.
 
 ##### \`RESOURCE_TYPE\` <a name=\\"aws_cdk.aws_eks.HelmChart.property.RESOURCE_TYPE\\"></a>
 
-\`\`\`python
-RESOURCE_TYPE: str
-\`\`\`
-
 - *Type:* \`str\`
 
 The CloudFormation resource type.
@@ -29939,10 +29775,6 @@ in the cluster with the same name, the operation will fail.
 
 ##### \`RESOURCE_TYPE\` <a name=\\"aws_cdk.aws_eks.KubernetesManifest.property.RESOURCE_TYPE\\"></a>
 
-\`\`\`python
-RESOURCE_TYPE: str
-\`\`\`
-
 - *Type:* \`str\`
 
 The CloudFormation reosurce type.
@@ -30059,10 +29891,6 @@ The value as a string token.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`RESOURCE_TYPE\` <a name=\\"aws_cdk.aws_eks.KubernetesObjectValue.property.RESOURCE_TYPE\\"></a>
-
-\`\`\`python
-RESOURCE_TYPE: str
-\`\`\`
 
 - *Type:* \`str\`
 
@@ -35759,10 +35587,6 @@ CIDR blocks.
 
 ##### \`PRIVATE\` <a name=\\"aws_cdk.aws_eks.EndpointAccess.property.PRIVATE\\"></a>
 
-\`\`\`python
-PRIVATE: EndpointAccess
-\`\`\`
-
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 
 The cluster endpoint is only accessible through your VPC.
@@ -35772,10 +35596,6 @@ Worker node traffic to the endpoint will stay within your VPC.
 ---
 
 ##### \`PUBLIC\` <a name=\\"aws_cdk.aws_eks.EndpointAccess.property.PUBLIC\\"></a>
-
-\`\`\`python
-PUBLIC: EndpointAccess
-\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 
@@ -35791,10 +35611,6 @@ access the public endpoint from.
 ---
 
 ##### \`PUBLIC_AND_PRIVATE\` <a name=\\"aws_cdk.aws_eks.EndpointAccess.property.PUBLIC_AND_PRIVATE\\"></a>
-
-\`\`\`python
-PUBLIC_AND_PRIVATE: EndpointAccess
-\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.EndpointAccess\`](#aws_cdk.aws_eks.EndpointAccess)
 
@@ -35852,10 +35668,6 @@ cluster version number.
 
 ##### \`V1_14\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_14\\"></a>
 
-\`\`\`python
-V1_14: KubernetesVersion
-\`\`\`
-
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
 Kubernetes version 1.14.
@@ -35863,10 +35675,6 @@ Kubernetes version 1.14.
 ---
 
 ##### \`V1_15\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_15\\"></a>
-
-\`\`\`python
-V1_15: KubernetesVersion
-\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -35876,10 +35684,6 @@ Kubernetes version 1.15.
 
 ##### \`V1_16\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_16\\"></a>
 
-\`\`\`python
-V1_16: KubernetesVersion
-\`\`\`
-
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
 Kubernetes version 1.16.
@@ -35887,10 +35691,6 @@ Kubernetes version 1.16.
 ---
 
 ##### \`V1_17\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_17\\"></a>
-
-\`\`\`python
-V1_17: KubernetesVersion
-\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -35900,10 +35700,6 @@ Kubernetes version 1.17.
 
 ##### \`V1_18\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_18\\"></a>
 
-\`\`\`python
-V1_18: KubernetesVersion
-\`\`\`
-
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
 Kubernetes version 1.18.
@@ -35911,10 +35707,6 @@ Kubernetes version 1.18.
 ---
 
 ##### \`V1_19\` <a name=\\"aws_cdk.aws_eks.KubernetesVersion.property.V1_19\\"></a>
-
-\`\`\`python
-V1_19: KubernetesVersion
-\`\`\`
 
 - *Type:* [\`aws_cdk.aws_eks.KubernetesVersion\`](#aws_cdk.aws_eks.KubernetesVersion)
 
@@ -36794,7 +36586,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.attrArn\\"></a>
 
 \`\`\`typescript
-public readonly attrArn: string
+public readonly attrArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -36804,7 +36596,7 @@ public readonly attrArn: string
 ##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: TagManager
+public readonly tags: TagManager;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.TagManager\`](#@aws-cdk/core.TagManager)
@@ -36818,7 +36610,7 @@ public readonly tags: TagManager
 ##### \`repositoryCatalogData\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryCatalogData\\"></a>
 
 \`\`\`typescript
-public readonly repositoryCatalogData: any
+public readonly repositoryCatalogData: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -36832,7 +36624,7 @@ public readonly repositoryCatalogData: any
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryPolicyText\\"></a>
 
 \`\`\`typescript
-public readonly repositoryPolicyText: any
+public readonly repositoryPolicyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -36846,7 +36638,7 @@ public readonly repositoryPolicyText: any
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -36860,10 +36652,6 @@ public readonly repositoryName: string
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`typescript
-public readonly CFN_RESOURCE_TYPE_NAME: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -36933,7 +36721,7 @@ tree inspector to collect and process attributes.
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.attrRegistryId\\"></a>
 
 \`\`\`typescript
-public readonly attrRegistryId: string
+public readonly attrRegistryId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -36943,7 +36731,7 @@ public readonly attrRegistryId: string
 ##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.policyText\\"></a>
 
 \`\`\`typescript
-public readonly policyText: any
+public readonly policyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -36957,10 +36745,6 @@ public readonly policyText: any
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`typescript
-public readonly CFN_RESOURCE_TYPE_NAME: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -37030,7 +36814,7 @@ tree inspector to collect and process attributes.
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.attrRegistryId\\"></a>
 
 \`\`\`typescript
-public readonly attrRegistryId: string
+public readonly attrRegistryId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37040,7 +36824,7 @@ public readonly attrRegistryId: string
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.replicationConfiguration\\"></a>
 
 \`\`\`typescript
-public readonly replicationConfiguration: IResolvable | ReplicationConfigurationProperty
+public readonly replicationConfiguration: IResolvable | ReplicationConfigurationProperty;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
@@ -37054,10 +36838,6 @@ public readonly replicationConfiguration: IResolvable | ReplicationConfiguration
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`typescript
-public readonly CFN_RESOURCE_TYPE_NAME: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -37127,7 +36907,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.attrArn\\"></a>
 
 \`\`\`typescript
-public readonly attrArn: string
+public readonly attrArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37137,7 +36917,7 @@ public readonly attrArn: string
 ##### \`attrRepositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.attrRepositoryUri\\"></a>
 
 \`\`\`typescript
-public readonly attrRepositoryUri: string
+public readonly attrRepositoryUri: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37147,7 +36927,7 @@ public readonly attrRepositoryUri: string
 ##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: TagManager
+public readonly tags: TagManager;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.TagManager\`](#@aws-cdk/core.TagManager)
@@ -37161,7 +36941,7 @@ public readonly tags: TagManager
 ##### \`encryptionConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.encryptionConfiguration\\"></a>
 
 \`\`\`typescript
-public readonly encryptionConfiguration: any
+public readonly encryptionConfiguration: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -37175,7 +36955,7 @@ public readonly encryptionConfiguration: any
 ##### \`imageScanningConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.imageScanningConfiguration\\"></a>
 
 \`\`\`typescript
-public readonly imageScanningConfiguration: any
+public readonly imageScanningConfiguration: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -37189,7 +36969,7 @@ public readonly imageScanningConfiguration: any
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.repositoryPolicyText\\"></a>
 
 \`\`\`typescript
-public readonly repositoryPolicyText: any
+public readonly repositoryPolicyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -37203,7 +36983,7 @@ public readonly repositoryPolicyText: any
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.imageTagMutability\\"></a>
 
 \`\`\`typescript
-public readonly imageTagMutability: string
+public readonly imageTagMutability: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37217,7 +36997,7 @@ public readonly imageTagMutability: string
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.lifecyclePolicy\\"></a>
 
 \`\`\`typescript
-public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty
+public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty\`](#@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty)
@@ -37231,7 +37011,7 @@ public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37245,10 +37025,6 @@ public readonly repositoryName: string
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`typescript
-public readonly CFN_RESOURCE_TYPE_NAME: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -37423,7 +37199,7 @@ Repository.fromRepositoryName(scope: Construct, id: string, repositoryName: stri
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.property.repositoryArn\\"></a>
 
 \`\`\`typescript
-public readonly repositoryArn: string
+public readonly repositoryArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37435,7 +37211,7 @@ The ARN of the repository.
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37653,7 +37429,7 @@ Optional image tag.
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryArn\\"></a>
 
 \`\`\`typescript
-public readonly repositoryArn: string
+public readonly repositoryArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37665,7 +37441,7 @@ The ARN of the repository.
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37677,7 +37453,7 @@ The name of the repository.
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryUri\\"></a>
 
 \`\`\`typescript
-public readonly repositoryUri: string
+public readonly repositoryUri: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37708,7 +37484,7 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 ##### \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 \`\`\`typescript
-public readonly repositoryCatalogData: any
+public readonly repositoryCatalogData: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -37722,7 +37498,7 @@ public readonly repositoryCatalogData: any
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37736,7 +37512,7 @@ public readonly repositoryName: string
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
 \`\`\`typescript
-public readonly repositoryPolicyText: any
+public readonly repositoryPolicyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -37750,7 +37526,7 @@ public readonly repositoryPolicyText: any
 ##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: CfnTag[]
+public readonly tags: CfnTag[];
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
@@ -37778,7 +37554,7 @@ const cfnRegistryPolicyProps: CfnRegistryPolicyProps = { ... }
 ##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicyProps.property.policyText\\"></a>
 
 \`\`\`typescript
-public readonly policyText: any
+public readonly policyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -37806,7 +37582,7 @@ const cfnReplicationConfigurationProps: CfnReplicationConfigurationProps = { ...
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfigurationProps.property.replicationConfiguration\\"></a>
 
 \`\`\`typescript
-public readonly replicationConfiguration: IResolvable | ReplicationConfigurationProperty
+public readonly replicationConfiguration: IResolvable | ReplicationConfigurationProperty;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
@@ -37834,7 +37610,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 ##### \`encryptionConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.encryptionConfiguration\\"></a>
 
 \`\`\`typescript
-public readonly encryptionConfiguration: any
+public readonly encryptionConfiguration: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -37848,7 +37624,7 @@ public readonly encryptionConfiguration: any
 ##### \`imageScanningConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.imageScanningConfiguration\\"></a>
 
 \`\`\`typescript
-public readonly imageScanningConfiguration: any
+public readonly imageScanningConfiguration: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -37862,7 +37638,7 @@ public readonly imageScanningConfiguration: any
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.imageTagMutability\\"></a>
 
 \`\`\`typescript
-public readonly imageTagMutability: string
+public readonly imageTagMutability: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37876,7 +37652,7 @@ public readonly imageTagMutability: string
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.lifecyclePolicy\\"></a>
 
 \`\`\`typescript
-public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty
+public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty\`](#@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty)
@@ -37890,7 +37666,7 @@ public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37904,7 +37680,7 @@ public readonly repositoryName: string
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.repositoryPolicyText\\"></a>
 
 \`\`\`typescript
-public readonly repositoryPolicyText: any
+public readonly repositoryPolicyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -37918,7 +37694,7 @@ public readonly repositoryPolicyText: any
 ##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: CfnTag[]
+public readonly tags: CfnTag[];
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
@@ -37944,7 +37720,7 @@ const lifecyclePolicyProperty: LifecyclePolicyProperty = { ... }
 ##### \`lifecyclePolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.property.lifecyclePolicyText\\"></a>
 
 \`\`\`typescript
-public readonly lifecyclePolicyText: string
+public readonly lifecyclePolicyText: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37958,7 +37734,7 @@ public readonly lifecyclePolicyText: string
 ##### \`registryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.property.registryId\\"></a>
 
 \`\`\`typescript
-public readonly registryId: string
+public readonly registryId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37984,7 +37760,7 @@ const lifecycleRule: LifecycleRule = { ... }
 ##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.description\\"></a>
 
 \`\`\`typescript
-public readonly description: string
+public readonly description: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -37997,7 +37773,7 @@ Describes the purpose of the rule.
 ##### \`maxImageAge\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.maxImageAge\\"></a>
 
 \`\`\`typescript
-public readonly maxImageAge: Duration
+public readonly maxImageAge: Duration;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.Duration\`](#@aws-cdk/core.Duration)
@@ -38011,7 +37787,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 ##### \`maxImageCount\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.maxImageCount\\"></a>
 
 \`\`\`typescript
-public readonly maxImageCount: number
+public readonly maxImageCount: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -38025,7 +37801,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 ##### \`rulePriority\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.rulePriority\\"></a>
 
 \`\`\`typescript
-public readonly rulePriority: number
+public readonly rulePriority: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -38047,7 +37823,7 @@ automatically assigned to them, higher than any rules that DO have priorities.
 ##### \`tagPrefixList\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.tagPrefixList\\"></a>
 
 \`\`\`typescript
-public readonly tagPrefixList: string[]
+public readonly tagPrefixList: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -38061,7 +37837,7 @@ Only if tagStatus == TagStatus.Tagged
 ##### \`tagStatus\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.tagStatus\\"></a>
 
 \`\`\`typescript
-public readonly tagStatus: TagStatus
+public readonly tagStatus: TagStatus;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-ecr.TagStatus\`](#@aws-cdk/aws-ecr.TagStatus)
@@ -38089,7 +37865,7 @@ const onCloudTrailImagePushedOptions: OnCloudTrailImagePushedOptions = { ... }
 ##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
 \`\`\`typescript
-public readonly description: string
+public readonly description: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38102,7 +37878,7 @@ A description of the rule's purpose.
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.eventPattern\\"></a>
 
 \`\`\`typescript
-public readonly eventPattern: EventPattern
+public readonly eventPattern: EventPattern;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-events.EventPattern\`](#@aws-cdk/aws-events.EventPattern)
@@ -38121,7 +37897,7 @@ on top of that filtering.
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.ruleName\\"></a>
 
 \`\`\`typescript
-public readonly ruleName: string
+public readonly ruleName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38134,7 +37910,7 @@ A name for the rule.
 ##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
 \`\`\`typescript
-public readonly target: IRuleTarget
+public readonly target: IRuleTarget;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-events.IRuleTarget\`](#@aws-cdk/aws-events.IRuleTarget)
@@ -38147,7 +37923,7 @@ The target to register for the event.
 ##### \`imageTag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.imageTag\\"></a>
 
 \`\`\`typescript
-public readonly imageTag: string
+public readonly imageTag: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38172,7 +37948,7 @@ const onImageScanCompletedOptions: OnImageScanCompletedOptions = { ... }
 ##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
 \`\`\`typescript
-public readonly description: string
+public readonly description: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38185,7 +37961,7 @@ A description of the rule's purpose.
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.eventPattern\\"></a>
 
 \`\`\`typescript
-public readonly eventPattern: EventPattern
+public readonly eventPattern: EventPattern;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-events.EventPattern\`](#@aws-cdk/aws-events.EventPattern)
@@ -38204,7 +37980,7 @@ on top of that filtering.
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.ruleName\\"></a>
 
 \`\`\`typescript
-public readonly ruleName: string
+public readonly ruleName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38217,7 +37993,7 @@ A name for the rule.
 ##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
 \`\`\`typescript
-public readonly target: IRuleTarget
+public readonly target: IRuleTarget;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-events.IRuleTarget\`](#@aws-cdk/aws-events.IRuleTarget)
@@ -38230,7 +38006,7 @@ The target to register for the event.
 ##### \`imageTags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.imageTags\\"></a>
 
 \`\`\`typescript
-public readonly imageTags: string[]
+public readonly imageTags: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -38257,7 +38033,7 @@ const replicationConfigurationProperty: ReplicationConfigurationProperty = { ...
 ##### \`rules\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
 \`\`\`typescript
-public readonly rules: IResolvable | IResolvable | ReplicationRuleProperty[]
+public readonly rules: IResolvable | IResolvable | ReplicationRuleProperty[];
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty)[]
@@ -38283,7 +38059,7 @@ const replicationDestinationProperty: ReplicationDestinationProperty = { ... }
 ##### \`region\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
 \`\`\`typescript
-public readonly region: string
+public readonly region: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38297,7 +38073,7 @@ public readonly region: string
 ##### \`registryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registryId\\"></a>
 
 \`\`\`typescript
-public readonly registryId: string
+public readonly registryId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38323,7 +38099,7 @@ const replicationRuleProperty: ReplicationRuleProperty = { ... }
 ##### \`destinations\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
 \`\`\`typescript
-public readonly destinations: IResolvable | IResolvable | ReplicationDestinationProperty[]
+public readonly destinations: IResolvable | IResolvable | ReplicationDestinationProperty[];
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)[]
@@ -38347,7 +38123,7 @@ const repositoryAttributes: RepositoryAttributes = { ... }
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.property.repositoryArn\\"></a>
 
 \`\`\`typescript
-public readonly repositoryArn: string
+public readonly repositoryArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38357,7 +38133,7 @@ public readonly repositoryArn: string
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38377,7 +38153,7 @@ const repositoryProps: RepositoryProps = { ... }
 ##### \`imageScanOnPush\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.imageScanOnPush\\"></a>
 
 \`\`\`typescript
-public readonly imageScanOnPush: boolean
+public readonly imageScanOnPush: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -38390,7 +38166,7 @@ Enable the scan on push when creating the repository.
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.imageTagMutability\\"></a>
 
 \`\`\`typescript
-public readonly imageTagMutability: TagMutability
+public readonly imageTagMutability: TagMutability;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-ecr.TagMutability\`](#@aws-cdk/aws-ecr.TagMutability)
@@ -38405,7 +38181,7 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 ##### \`lifecycleRegistryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.lifecycleRegistryId\\"></a>
 
 \`\`\`typescript
-public readonly lifecycleRegistryId: string
+public readonly lifecycleRegistryId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38420,7 +38196,7 @@ The AWS account ID associated with the registry that contains the repository.
 ##### \`lifecycleRules\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.lifecycleRules\\"></a>
 
 \`\`\`typescript
-public readonly lifecycleRules: LifecycleRule[]
+public readonly lifecycleRules: LifecycleRule[];
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-ecr.LifecycleRule\`](#@aws-cdk/aws-ecr.LifecycleRule)[]
@@ -38433,7 +38209,7 @@ Life cycle rules to apply to this registry.
 ##### \`removalPolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.removalPolicy\\"></a>
 
 \`\`\`typescript
-public readonly removalPolicy: RemovalPolicy
+public readonly removalPolicy: RemovalPolicy;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.RemovalPolicy\`](#@aws-cdk/core.RemovalPolicy)
@@ -38446,7 +38222,7 @@ Determine what happens to the repository when the resource/stack is deleted.
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38691,7 +38467,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 ##### \`node\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.node\\"></a>
 
 \`\`\`typescript
-public readonly node: ConstructNode
+public readonly node: ConstructNode;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.ConstructNode\`](#@aws-cdk/core.ConstructNode)
@@ -38703,7 +38479,7 @@ The construct tree node for this construct.
 ##### \`env\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.env\\"></a>
 
 \`\`\`typescript
-public readonly env: ResourceEnvironment
+public readonly env: ResourceEnvironment;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.ResourceEnvironment\`](#@aws-cdk/core.ResourceEnvironment)
@@ -38722,7 +38498,7 @@ that might be different than the stack they were imported into.
 ##### \`stack\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.stack\\"></a>
 
 \`\`\`typescript
-public readonly stack: Stack
+public readonly stack: Stack;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.Stack\`](#@aws-cdk/core.Stack)
@@ -38734,7 +38510,7 @@ The stack in which this resource is defined.
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryArn\\"></a>
 
 \`\`\`typescript
-public readonly repositoryArn: string
+public readonly repositoryArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38746,7 +38522,7 @@ The ARN of the repository.
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38758,7 +38534,7 @@ The name of the repository.
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryUri\\"></a>
 
 \`\`\`typescript
-public readonly repositoryUri: string
+public readonly repositoryUri: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38980,7 +38756,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.attrArn\\"></a>
 
 \`\`\`typescript
-public readonly attrArn: string
+public readonly attrArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -38990,7 +38766,7 @@ public readonly attrArn: string
 ##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: TagManager
+public readonly tags: TagManager;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.TagManager\`](#@aws-cdk/core.TagManager)
@@ -39004,7 +38780,7 @@ public readonly tags: TagManager
 ##### \`repositoryCatalogData\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryCatalogData\\"></a>
 
 \`\`\`typescript
-public readonly repositoryCatalogData: any
+public readonly repositoryCatalogData: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -39018,7 +38794,7 @@ public readonly repositoryCatalogData: any
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryPolicyText\\"></a>
 
 \`\`\`typescript
-public readonly repositoryPolicyText: any
+public readonly repositoryPolicyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -39032,7 +38808,7 @@ public readonly repositoryPolicyText: any
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39046,10 +38822,6 @@ public readonly repositoryName: string
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`typescript
-public readonly CFN_RESOURCE_TYPE_NAME: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -39119,7 +38891,7 @@ tree inspector to collect and process attributes.
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.attrRegistryId\\"></a>
 
 \`\`\`typescript
-public readonly attrRegistryId: string
+public readonly attrRegistryId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39129,7 +38901,7 @@ public readonly attrRegistryId: string
 ##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.policyText\\"></a>
 
 \`\`\`typescript
-public readonly policyText: any
+public readonly policyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -39143,10 +38915,6 @@ public readonly policyText: any
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`typescript
-public readonly CFN_RESOURCE_TYPE_NAME: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -39216,7 +38984,7 @@ tree inspector to collect and process attributes.
 ##### \`attrRegistryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.attrRegistryId\\"></a>
 
 \`\`\`typescript
-public readonly attrRegistryId: string
+public readonly attrRegistryId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39226,7 +38994,7 @@ public readonly attrRegistryId: string
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.replicationConfiguration\\"></a>
 
 \`\`\`typescript
-public readonly replicationConfiguration: IResolvable | ReplicationConfigurationProperty
+public readonly replicationConfiguration: IResolvable | ReplicationConfigurationProperty;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
@@ -39240,10 +39008,6 @@ public readonly replicationConfiguration: IResolvable | ReplicationConfiguration
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`typescript
-public readonly CFN_RESOURCE_TYPE_NAME: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -39313,7 +39077,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.attrArn\\"></a>
 
 \`\`\`typescript
-public readonly attrArn: string
+public readonly attrArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39323,7 +39087,7 @@ public readonly attrArn: string
 ##### \`attrRepositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.attrRepositoryUri\\"></a>
 
 \`\`\`typescript
-public readonly attrRepositoryUri: string
+public readonly attrRepositoryUri: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39333,7 +39097,7 @@ public readonly attrRepositoryUri: string
 ##### \`tags\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: TagManager
+public readonly tags: TagManager;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.TagManager\`](#@aws-cdk/core.TagManager)
@@ -39347,7 +39111,7 @@ public readonly tags: TagManager
 ##### \`encryptionConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.encryptionConfiguration\\"></a>
 
 \`\`\`typescript
-public readonly encryptionConfiguration: any
+public readonly encryptionConfiguration: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -39361,7 +39125,7 @@ public readonly encryptionConfiguration: any
 ##### \`imageScanningConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.imageScanningConfiguration\\"></a>
 
 \`\`\`typescript
-public readonly imageScanningConfiguration: any
+public readonly imageScanningConfiguration: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -39375,7 +39139,7 @@ public readonly imageScanningConfiguration: any
 ##### \`repositoryPolicyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.repositoryPolicyText\\"></a>
 
 \`\`\`typescript
-public readonly repositoryPolicyText: any
+public readonly repositoryPolicyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -39389,7 +39153,7 @@ public readonly repositoryPolicyText: any
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.imageTagMutability\\"></a>
 
 \`\`\`typescript
-public readonly imageTagMutability: string
+public readonly imageTagMutability: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39403,7 +39167,7 @@ public readonly imageTagMutability: string
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.lifecyclePolicy\\"></a>
 
 \`\`\`typescript
-public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty
+public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty\`](#@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty)
@@ -39417,7 +39181,7 @@ public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39431,10 +39195,6 @@ public readonly repositoryName: string
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"@aws-cdk/aws-ecr.CfnRepository.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`typescript
-public readonly CFN_RESOURCE_TYPE_NAME: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -39609,7 +39369,7 @@ Repository.fromRepositoryName(scope: Construct, id: string, repositoryName: stri
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.property.repositoryArn\\"></a>
 
 \`\`\`typescript
-public readonly repositoryArn: string
+public readonly repositoryArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39621,7 +39381,7 @@ The ARN of the repository.
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.Repository.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39839,7 +39599,7 @@ Optional image tag.
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryArn\\"></a>
 
 \`\`\`typescript
-public readonly repositoryArn: string
+public readonly repositoryArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39851,7 +39611,7 @@ The ARN of the repository.
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39863,7 +39623,7 @@ The name of the repository.
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryBase.property.repositoryUri\\"></a>
 
 \`\`\`typescript
-public readonly repositoryUri: string
+public readonly repositoryUri: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39894,7 +39654,7 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 ##### \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 \`\`\`typescript
-public readonly repositoryCatalogData: any
+public readonly repositoryCatalogData: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -39908,7 +39668,7 @@ public readonly repositoryCatalogData: any
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -39922,7 +39682,7 @@ public readonly repositoryName: string
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
 \`\`\`typescript
-public readonly repositoryPolicyText: any
+public readonly repositoryPolicyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -39936,7 +39696,7 @@ public readonly repositoryPolicyText: any
 ##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: CfnTag[]
+public readonly tags: CfnTag[];
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
@@ -39964,7 +39724,7 @@ const cfnRegistryPolicyProps: CfnRegistryPolicyProps = { ... }
 ##### \`policyText\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRegistryPolicyProps.property.policyText\\"></a>
 
 \`\`\`typescript
-public readonly policyText: any
+public readonly policyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -39992,7 +39752,7 @@ const cfnReplicationConfigurationProps: CfnReplicationConfigurationProps = { ...
 ##### \`replicationConfiguration\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfigurationProps.property.replicationConfiguration\\"></a>
 
 \`\`\`typescript
-public readonly replicationConfiguration: IResolvable | ReplicationConfigurationProperty
+public readonly replicationConfiguration: IResolvable | ReplicationConfigurationProperty;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty)
@@ -40020,7 +39780,7 @@ const cfnRepositoryProps: CfnRepositoryProps = { ... }
 ##### \`encryptionConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.encryptionConfiguration\\"></a>
 
 \`\`\`typescript
-public readonly encryptionConfiguration: any
+public readonly encryptionConfiguration: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -40034,7 +39794,7 @@ public readonly encryptionConfiguration: any
 ##### \`imageScanningConfiguration\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.imageScanningConfiguration\\"></a>
 
 \`\`\`typescript
-public readonly imageScanningConfiguration: any
+public readonly imageScanningConfiguration: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -40048,7 +39808,7 @@ public readonly imageScanningConfiguration: any
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.imageTagMutability\\"></a>
 
 \`\`\`typescript
-public readonly imageTagMutability: string
+public readonly imageTagMutability: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40062,7 +39822,7 @@ public readonly imageTagMutability: string
 ##### \`lifecyclePolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.lifecyclePolicy\\"></a>
 
 \`\`\`typescript
-public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty
+public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty\`](#@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty)
@@ -40076,7 +39836,7 @@ public readonly lifecyclePolicy: IResolvable | LifecyclePolicyProperty
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40090,7 +39850,7 @@ public readonly repositoryName: string
 ##### \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.repositoryPolicyText\\"></a>
 
 \`\`\`typescript
-public readonly repositoryPolicyText: any
+public readonly repositoryPolicyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -40104,7 +39864,7 @@ public readonly repositoryPolicyText: any
 ##### \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepositoryProps.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: CfnTag[]
+public readonly tags: CfnTag[];
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
@@ -40130,7 +39890,7 @@ const lifecyclePolicyProperty: LifecyclePolicyProperty = { ... }
 ##### \`lifecyclePolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.property.lifecyclePolicyText\\"></a>
 
 \`\`\`typescript
-public readonly lifecyclePolicyText: string
+public readonly lifecyclePolicyText: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40144,7 +39904,7 @@ public readonly lifecyclePolicyText: string
 ##### \`registryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnRepository.LifecyclePolicyProperty.property.registryId\\"></a>
 
 \`\`\`typescript
-public readonly registryId: string
+public readonly registryId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40170,7 +39930,7 @@ const lifecycleRule: LifecycleRule = { ... }
 ##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.description\\"></a>
 
 \`\`\`typescript
-public readonly description: string
+public readonly description: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40183,7 +39943,7 @@ Describes the purpose of the rule.
 ##### \`maxImageAge\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.maxImageAge\\"></a>
 
 \`\`\`typescript
-public readonly maxImageAge: Duration
+public readonly maxImageAge: Duration;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.Duration\`](#@aws-cdk/core.Duration)
@@ -40197,7 +39957,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 ##### \`maxImageCount\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.maxImageCount\\"></a>
 
 \`\`\`typescript
-public readonly maxImageCount: number
+public readonly maxImageCount: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -40211,7 +39971,7 @@ Specify exactly one of maxImageCount and maxImageAge.
 ##### \`rulePriority\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.rulePriority\\"></a>
 
 \`\`\`typescript
-public readonly rulePriority: number
+public readonly rulePriority: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -40233,7 +39993,7 @@ automatically assigned to them, higher than any rules that DO have priorities.
 ##### \`tagPrefixList\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.tagPrefixList\\"></a>
 
 \`\`\`typescript
-public readonly tagPrefixList: string[]
+public readonly tagPrefixList: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -40247,7 +40007,7 @@ Only if tagStatus == TagStatus.Tagged
 ##### \`tagStatus\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.LifecycleRule.property.tagStatus\\"></a>
 
 \`\`\`typescript
-public readonly tagStatus: TagStatus
+public readonly tagStatus: TagStatus;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-ecr.TagStatus\`](#@aws-cdk/aws-ecr.TagStatus)
@@ -40275,7 +40035,7 @@ const onCloudTrailImagePushedOptions: OnCloudTrailImagePushedOptions = { ... }
 ##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.description\\"></a>
 
 \`\`\`typescript
-public readonly description: string
+public readonly description: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40288,7 +40048,7 @@ A description of the rule's purpose.
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.eventPattern\\"></a>
 
 \`\`\`typescript
-public readonly eventPattern: EventPattern
+public readonly eventPattern: EventPattern;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-events.EventPattern\`](#@aws-cdk/aws-events.EventPattern)
@@ -40307,7 +40067,7 @@ on top of that filtering.
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.ruleName\\"></a>
 
 \`\`\`typescript
-public readonly ruleName: string
+public readonly ruleName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40320,7 +40080,7 @@ A name for the rule.
 ##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.target\\"></a>
 
 \`\`\`typescript
-public readonly target: IRuleTarget
+public readonly target: IRuleTarget;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-events.IRuleTarget\`](#@aws-cdk/aws-events.IRuleTarget)
@@ -40333,7 +40093,7 @@ The target to register for the event.
 ##### \`imageTag\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions.property.imageTag\\"></a>
 
 \`\`\`typescript
-public readonly imageTag: string
+public readonly imageTag: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40358,7 +40118,7 @@ const onImageScanCompletedOptions: OnImageScanCompletedOptions = { ... }
 ##### \`description\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.description\\"></a>
 
 \`\`\`typescript
-public readonly description: string
+public readonly description: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40371,7 +40131,7 @@ A description of the rule's purpose.
 ##### \`eventPattern\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.eventPattern\\"></a>
 
 \`\`\`typescript
-public readonly eventPattern: EventPattern
+public readonly eventPattern: EventPattern;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-events.EventPattern\`](#@aws-cdk/aws-events.EventPattern)
@@ -40390,7 +40150,7 @@ on top of that filtering.
 ##### \`ruleName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.ruleName\\"></a>
 
 \`\`\`typescript
-public readonly ruleName: string
+public readonly ruleName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40403,7 +40163,7 @@ A name for the rule.
 ##### \`target\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.target\\"></a>
 
 \`\`\`typescript
-public readonly target: IRuleTarget
+public readonly target: IRuleTarget;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-events.IRuleTarget\`](#@aws-cdk/aws-events.IRuleTarget)
@@ -40416,7 +40176,7 @@ The target to register for the event.
 ##### \`imageTags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.OnImageScanCompletedOptions.property.imageTags\\"></a>
 
 \`\`\`typescript
-public readonly imageTags: string[]
+public readonly imageTags: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -40443,7 +40203,7 @@ const replicationConfigurationProperty: ReplicationConfigurationProperty = { ...
 ##### \`rules\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationConfigurationProperty.property.rules\\"></a>
 
 \`\`\`typescript
-public readonly rules: IResolvable | IResolvable | ReplicationRuleProperty[]
+public readonly rules: IResolvable | IResolvable | ReplicationRuleProperty[];
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty)[]
@@ -40469,7 +40229,7 @@ const replicationDestinationProperty: ReplicationDestinationProperty = { ... }
 ##### \`region\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.region\\"></a>
 
 \`\`\`typescript
-public readonly region: string
+public readonly region: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40483,7 +40243,7 @@ public readonly region: string
 ##### \`registryId\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty.property.registryId\\"></a>
 
 \`\`\`typescript
-public readonly registryId: string
+public readonly registryId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40509,7 +40269,7 @@ const replicationRuleProperty: ReplicationRuleProperty = { ... }
 ##### \`destinations\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationRuleProperty.property.destinations\\"></a>
 
 \`\`\`typescript
-public readonly destinations: IResolvable | IResolvable | ReplicationDestinationProperty[]
+public readonly destinations: IResolvable | IResolvable | ReplicationDestinationProperty[];
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/core.IResolvable\`](#@aws-cdk/core.IResolvable) | [\`@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty\`](#@aws-cdk/aws-ecr.CfnReplicationConfiguration.ReplicationDestinationProperty)[]
@@ -40533,7 +40293,7 @@ const repositoryAttributes: RepositoryAttributes = { ... }
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.property.repositoryArn\\"></a>
 
 \`\`\`typescript
-public readonly repositoryArn: string
+public readonly repositoryArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40543,7 +40303,7 @@ public readonly repositoryArn: string
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryAttributes.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40563,7 +40323,7 @@ const repositoryProps: RepositoryProps = { ... }
 ##### \`imageScanOnPush\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.imageScanOnPush\\"></a>
 
 \`\`\`typescript
-public readonly imageScanOnPush: boolean
+public readonly imageScanOnPush: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -40576,7 +40336,7 @@ Enable the scan on push when creating the repository.
 ##### \`imageTagMutability\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.imageTagMutability\\"></a>
 
 \`\`\`typescript
-public readonly imageTagMutability: TagMutability
+public readonly imageTagMutability: TagMutability;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-ecr.TagMutability\`](#@aws-cdk/aws-ecr.TagMutability)
@@ -40591,7 +40351,7 @@ If this parameter is omitted, the default setting of MUTABLE will be used which 
 ##### \`lifecycleRegistryId\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.lifecycleRegistryId\\"></a>
 
 \`\`\`typescript
-public readonly lifecycleRegistryId: string
+public readonly lifecycleRegistryId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40606,7 +40366,7 @@ The AWS account ID associated with the registry that contains the repository.
 ##### \`lifecycleRules\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.lifecycleRules\\"></a>
 
 \`\`\`typescript
-public readonly lifecycleRules: LifecycleRule[]
+public readonly lifecycleRules: LifecycleRule[];
 \`\`\`
 
 - *Type:* [\`@aws-cdk/aws-ecr.LifecycleRule\`](#@aws-cdk/aws-ecr.LifecycleRule)[]
@@ -40619,7 +40379,7 @@ Life cycle rules to apply to this registry.
 ##### \`removalPolicy\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.removalPolicy\\"></a>
 
 \`\`\`typescript
-public readonly removalPolicy: RemovalPolicy
+public readonly removalPolicy: RemovalPolicy;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.RemovalPolicy\`](#@aws-cdk/core.RemovalPolicy)
@@ -40632,7 +40392,7 @@ Determine what happens to the repository when the resource/stack is deleted.
 ##### \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.RepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40877,7 +40637,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 ##### \`node\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.node\\"></a>
 
 \`\`\`typescript
-public readonly node: ConstructNode
+public readonly node: ConstructNode;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.ConstructNode\`](#@aws-cdk/core.ConstructNode)
@@ -40889,7 +40649,7 @@ The construct tree node for this construct.
 ##### \`env\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.env\\"></a>
 
 \`\`\`typescript
-public readonly env: ResourceEnvironment
+public readonly env: ResourceEnvironment;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.ResourceEnvironment\`](#@aws-cdk/core.ResourceEnvironment)
@@ -40908,7 +40668,7 @@ that might be different than the stack they were imported into.
 ##### \`stack\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.stack\\"></a>
 
 \`\`\`typescript
-public readonly stack: Stack
+public readonly stack: Stack;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.Stack\`](#@aws-cdk/core.Stack)
@@ -40920,7 +40680,7 @@ The stack in which this resource is defined.
 ##### \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryArn\\"></a>
 
 \`\`\`typescript
-public readonly repositoryArn: string
+public readonly repositoryArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40932,7 +40692,7 @@ The ARN of the repository.
 ##### \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -40944,7 +40704,7 @@ The name of the repository.
 ##### \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryUri\\"></a>
 
 \`\`\`typescript
-public readonly repositoryUri: string
+public readonly repositoryUri: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42397,7 +42157,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.attrArn\\"></a>
 
 \`\`\`typescript
-public readonly attrArn: string
+public readonly attrArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42407,7 +42167,7 @@ public readonly attrArn: string
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: TagManager
+public readonly tags: TagManager;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.TagManager\`](#aws-cdk-lib.TagManager)
@@ -42421,7 +42181,7 @@ public readonly tags: TagManager
 ##### \`addonName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.addonName\\"></a>
 
 \`\`\`typescript
-public readonly addonName: string
+public readonly addonName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42435,7 +42195,7 @@ public readonly addonName: string
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42449,7 +42209,7 @@ public readonly clusterName: string
 ##### \`addonVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.addonVersion\\"></a>
 
 \`\`\`typescript
-public readonly addonVersion: string
+public readonly addonVersion: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42463,7 +42223,7 @@ public readonly addonVersion: string
 ##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.resolveConflicts\\"></a>
 
 \`\`\`typescript
-public readonly resolveConflicts: string
+public readonly resolveConflicts: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42477,7 +42237,7 @@ public readonly resolveConflicts: string
 ##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.serviceAccountRoleArn\\"></a>
 
 \`\`\`typescript
-public readonly serviceAccountRoleArn: string
+public readonly serviceAccountRoleArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42491,10 +42251,6 @@ public readonly serviceAccountRoleArn: string
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnAddon.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`typescript
-public readonly CFN_RESOURCE_TYPE_NAME: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -42564,7 +42320,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrArn\\"></a>
 
 \`\`\`typescript
-public readonly attrArn: string
+public readonly attrArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42574,7 +42330,7 @@ public readonly attrArn: string
 ##### \`attrCertificateAuthorityData\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrCertificateAuthorityData\\"></a>
 
 \`\`\`typescript
-public readonly attrCertificateAuthorityData: string
+public readonly attrCertificateAuthorityData: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42584,7 +42340,7 @@ public readonly attrCertificateAuthorityData: string
 ##### \`attrClusterSecurityGroupId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrClusterSecurityGroupId\\"></a>
 
 \`\`\`typescript
-public readonly attrClusterSecurityGroupId: string
+public readonly attrClusterSecurityGroupId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42594,7 +42350,7 @@ public readonly attrClusterSecurityGroupId: string
 ##### \`attrEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrEncryptionConfigKeyArn\\"></a>
 
 \`\`\`typescript
-public readonly attrEncryptionConfigKeyArn: string
+public readonly attrEncryptionConfigKeyArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42604,7 +42360,7 @@ public readonly attrEncryptionConfigKeyArn: string
 ##### \`attrEndpoint\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrEndpoint\\"></a>
 
 \`\`\`typescript
-public readonly attrEndpoint: string
+public readonly attrEndpoint: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42614,7 +42370,7 @@ public readonly attrEndpoint: string
 ##### \`attrOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.attrOpenIdConnectIssuerUrl\\"></a>
 
 \`\`\`typescript
-public readonly attrOpenIdConnectIssuerUrl: string
+public readonly attrOpenIdConnectIssuerUrl: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42624,7 +42380,7 @@ public readonly attrOpenIdConnectIssuerUrl: string
 ##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.resourcesVpcConfig\\"></a>
 
 \`\`\`typescript
-public readonly resourcesVpcConfig: ResourcesVpcConfigProperty | IResolvable
+public readonly resourcesVpcConfig: ResourcesVpcConfigProperty | IResolvable;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -42638,7 +42394,7 @@ public readonly resourcesVpcConfig: ResourcesVpcConfigProperty | IResolvable
 ##### \`roleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.roleArn\\"></a>
 
 \`\`\`typescript
-public readonly roleArn: string
+public readonly roleArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42652,7 +42408,7 @@ public readonly roleArn: string
 ##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.encryptionConfig\\"></a>
 
 \`\`\`typescript
-public readonly encryptionConfig: IResolvable | EncryptionConfigProperty | IResolvable[]
+public readonly encryptionConfig: IResolvable | EncryptionConfigProperty | IResolvable[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
@@ -42666,7 +42422,7 @@ public readonly encryptionConfig: IResolvable | EncryptionConfigProperty | IReso
 ##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.kubernetesNetworkConfig\\"></a>
 
 \`\`\`typescript
-public readonly kubernetesNetworkConfig: KubernetesNetworkConfigProperty | IResolvable
+public readonly kubernetesNetworkConfig: KubernetesNetworkConfigProperty | IResolvable;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -42680,7 +42436,7 @@ public readonly kubernetesNetworkConfig: KubernetesNetworkConfigProperty | IReso
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.name\\"></a>
 
 \`\`\`typescript
-public readonly name: string
+public readonly name: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42694,7 +42450,7 @@ public readonly name: string
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: string
+public readonly version: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42708,10 +42464,6 @@ public readonly version: string
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`typescript
-public readonly CFN_RESOURCE_TYPE_NAME: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -42781,7 +42533,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.attrArn\\"></a>
 
 \`\`\`typescript
-public readonly attrArn: string
+public readonly attrArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42791,7 +42543,7 @@ public readonly attrArn: string
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: TagManager
+public readonly tags: TagManager;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.TagManager\`](#aws-cdk-lib.TagManager)
@@ -42805,7 +42557,7 @@ public readonly tags: TagManager
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42819,7 +42571,7 @@ public readonly clusterName: string
 ##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.podExecutionRoleArn\\"></a>
 
 \`\`\`typescript
-public readonly podExecutionRoleArn: string
+public readonly podExecutionRoleArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42833,7 +42585,7 @@ public readonly podExecutionRoleArn: string
 ##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.selectors\\"></a>
 
 \`\`\`typescript
-public readonly selectors: IResolvable | SelectorProperty | IResolvable[]
+public readonly selectors: IResolvable | SelectorProperty | IResolvable[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
@@ -42847,7 +42599,7 @@ public readonly selectors: IResolvable | SelectorProperty | IResolvable[]
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.fargateProfileName\\"></a>
 
 \`\`\`typescript
-public readonly fargateProfileName: string
+public readonly fargateProfileName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42861,7 +42613,7 @@ public readonly fargateProfileName: string
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.subnets\\"></a>
 
 \`\`\`typescript
-public readonly subnets: string[]
+public readonly subnets: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -42875,10 +42627,6 @@ public readonly subnets: string[]
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`typescript
-public readonly CFN_RESOURCE_TYPE_NAME: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -42948,7 +42696,7 @@ tree inspector to collect and process attributes.
 ##### \`attrArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.attrArn\\"></a>
 
 \`\`\`typescript
-public readonly attrArn: string
+public readonly attrArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42958,7 +42706,7 @@ public readonly attrArn: string
 ##### \`attrClusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.attrClusterName\\"></a>
 
 \`\`\`typescript
-public readonly attrClusterName: string
+public readonly attrClusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42968,7 +42716,7 @@ public readonly attrClusterName: string
 ##### \`attrNodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.attrNodegroupName\\"></a>
 
 \`\`\`typescript
-public readonly attrNodegroupName: string
+public readonly attrNodegroupName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -42978,7 +42726,7 @@ public readonly attrNodegroupName: string
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: TagManager
+public readonly tags: TagManager;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.TagManager\`](#aws-cdk-lib.TagManager)
@@ -42992,7 +42740,7 @@ public readonly tags: TagManager
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43006,7 +42754,7 @@ public readonly clusterName: string
 ##### \`labels\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.labels\\"></a>
 
 \`\`\`typescript
-public readonly labels: any
+public readonly labels: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -43020,7 +42768,7 @@ public readonly labels: any
 ##### \`nodeRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.nodeRole\\"></a>
 
 \`\`\`typescript
-public readonly nodeRole: string
+public readonly nodeRole: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43034,7 +42782,7 @@ public readonly nodeRole: string
 ##### \`subnets\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.subnets\\"></a>
 
 \`\`\`typescript
-public readonly subnets: string[]
+public readonly subnets: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -43048,7 +42796,7 @@ public readonly subnets: string[]
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.amiType\\"></a>
 
 \`\`\`typescript
-public readonly amiType: string
+public readonly amiType: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43062,7 +42810,7 @@ public readonly amiType: string
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.capacityType\\"></a>
 
 \`\`\`typescript
-public readonly capacityType: string
+public readonly capacityType: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43076,7 +42824,7 @@ public readonly capacityType: string
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.diskSize\\"></a>
 
 \`\`\`typescript
-public readonly diskSize: number
+public readonly diskSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -43090,7 +42838,7 @@ public readonly diskSize: number
 ##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.forceUpdateEnabled\\"></a>
 
 \`\`\`typescript
-public readonly forceUpdateEnabled: boolean | IResolvable
+public readonly forceUpdateEnabled: boolean | IResolvable;
 \`\`\`
 
 - *Type:* \`boolean\` | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -43104,7 +42852,7 @@ public readonly forceUpdateEnabled: boolean | IResolvable
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.instanceTypes\\"></a>
 
 \`\`\`typescript
-public readonly instanceTypes: string[]
+public readonly instanceTypes: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -43118,7 +42866,7 @@ public readonly instanceTypes: string[]
 ##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.launchTemplate\\"></a>
 
 \`\`\`typescript
-public readonly launchTemplate: LaunchTemplateSpecificationProperty | IResolvable
+public readonly launchTemplate: LaunchTemplateSpecificationProperty | IResolvable;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -43132,7 +42880,7 @@ public readonly launchTemplate: LaunchTemplateSpecificationProperty | IResolvabl
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.nodegroupName\\"></a>
 
 \`\`\`typescript
-public readonly nodegroupName: string
+public readonly nodegroupName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43146,7 +42894,7 @@ public readonly nodegroupName: string
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.releaseVersion\\"></a>
 
 \`\`\`typescript
-public readonly releaseVersion: string
+public readonly releaseVersion: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43160,7 +42908,7 @@ public readonly releaseVersion: string
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.remoteAccess\\"></a>
 
 \`\`\`typescript
-public readonly remoteAccess: RemoteAccessProperty | IResolvable
+public readonly remoteAccess: RemoteAccessProperty | IResolvable;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -43174,7 +42922,7 @@ public readonly remoteAccess: RemoteAccessProperty | IResolvable
 ##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.scalingConfig\\"></a>
 
 \`\`\`typescript
-public readonly scalingConfig: ScalingConfigProperty | IResolvable
+public readonly scalingConfig: ScalingConfigProperty | IResolvable;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -43188,7 +42936,7 @@ public readonly scalingConfig: ScalingConfigProperty | IResolvable
 ##### \`taints\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.taints\\"></a>
 
 \`\`\`typescript
-public readonly taints: IResolvable | TaintProperty | IResolvable[]
+public readonly taints: IResolvable | TaintProperty | IResolvable[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
@@ -43202,7 +42950,7 @@ public readonly taints: IResolvable | TaintProperty | IResolvable[]
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: string
+public readonly version: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43216,10 +42964,6 @@ public readonly version: string
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.property.CFN_RESOURCE_TYPE_NAME\\"></a>
-
-\`\`\`typescript
-public readonly CFN_RESOURCE_TYPE_NAME: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -43499,7 +43243,7 @@ the cluster properties to use for importing information.
 ##### \`adminRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.adminRole\\"></a>
 
 \`\`\`typescript
-public readonly adminRole: Role
+public readonly adminRole: Role;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.Role\`](#aws-cdk-lib.aws_iam.Role)
@@ -43513,7 +43257,7 @@ This role also has \`systems:master\` permissions.
 ##### \`awsAuth\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.awsAuth\\"></a>
 
 \`\`\`typescript
-public readonly awsAuth: AwsAuth
+public readonly awsAuth: AwsAuth;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.AwsAuth\`](#aws-cdk-lib.aws_eks.AwsAuth)
@@ -43525,7 +43269,7 @@ Lazily creates the AwsAuth resource, which manages AWS authentication mapping.
 ##### \`clusterArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterArn\\"></a>
 
 \`\`\`typescript
-public readonly clusterArn: string
+public readonly clusterArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43537,7 +43281,7 @@ The AWS generated ARN for the Cluster resource.
 ##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterCertificateAuthorityData\\"></a>
 
 \`\`\`typescript
-public readonly clusterCertificateAuthorityData: string
+public readonly clusterCertificateAuthorityData: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43549,7 +43293,7 @@ The certificate-authority-data for your cluster.
 ##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterEncryptionConfigKeyArn\\"></a>
 
 \`\`\`typescript
-public readonly clusterEncryptionConfigKeyArn: string
+public readonly clusterEncryptionConfigKeyArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43561,7 +43305,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 ##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterEndpoint\\"></a>
 
 \`\`\`typescript
-public readonly clusterEndpoint: string
+public readonly clusterEndpoint: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43575,7 +43319,7 @@ This is the URL inside the kubeconfig file to use with kubectl
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43587,7 +43331,7 @@ The Name of the created EKS Cluster.
 ##### \`clusterOpenIdConnectIssuer\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterOpenIdConnectIssuer\\"></a>
 
 \`\`\`typescript
-public readonly clusterOpenIdConnectIssuer: string
+public readonly clusterOpenIdConnectIssuer: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43603,7 +43347,7 @@ stock \`CfnCluster\`), this is \`undefined\`.
 ##### \`clusterOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterOpenIdConnectIssuerUrl\\"></a>
 
 \`\`\`typescript
-public readonly clusterOpenIdConnectIssuerUrl: string
+public readonly clusterOpenIdConnectIssuerUrl: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43619,7 +43363,7 @@ stock \`CfnCluster\`), this is \`undefined\`.
 ##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterSecurityGroup\\"></a>
 
 \`\`\`typescript
-public readonly clusterSecurityGroup: ISecurityGroup
+public readonly clusterSecurityGroup: ISecurityGroup;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
@@ -43631,7 +43375,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 ##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.clusterSecurityGroupId\\"></a>
 
 \`\`\`typescript
-public readonly clusterSecurityGroupId: string
+public readonly clusterSecurityGroupId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43643,7 +43387,7 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 ##### \`connections\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.connections\\"></a>
 
 \`\`\`typescript
-public readonly connections: Connections
+public readonly connections: Connections;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.Connections\`](#aws-cdk-lib.aws_ec2.Connections)
@@ -43655,7 +43399,7 @@ Manages connection rules (Security Group Rules) for the cluster.
 ##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.openIdConnectProvider\\"></a>
 
 \`\`\`typescript
-public readonly openIdConnectProvider: IOpenIdConnectProvider
+public readonly openIdConnectProvider: IOpenIdConnectProvider;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IOpenIdConnectProvider\`](#aws-cdk-lib.aws_iam.IOpenIdConnectProvider)
@@ -43669,7 +43413,7 @@ A provider will only be defined if this property is accessed (lazy initializatio
 ##### \`prune\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.prune\\"></a>
 
 \`\`\`typescript
-public readonly prune: boolean
+public readonly prune: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -43681,7 +43425,7 @@ Determines if Kubernetes resources can be pruned automatically.
 ##### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.role\\"></a>
 
 \`\`\`typescript
-public readonly role: IRole
+public readonly role: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -43693,7 +43437,7 @@ IAM role assumed by the EKS Control Plane.
 ##### \`vpc\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.vpc\\"></a>
 
 \`\`\`typescript
-public readonly vpc: IVpc
+public readonly vpc: IVpc;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
@@ -43705,7 +43449,7 @@ The VPC in which this Cluster was created.
 ##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.defaultCapacity\\"></a>
 
 \`\`\`typescript
-public readonly defaultCapacity: AutoScalingGroup
+public readonly defaultCapacity: AutoScalingGroup;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.AutoScalingGroup\`](#aws-cdk-lib.aws_autoscaling.AutoScalingGroup)
@@ -43720,7 +43464,7 @@ This will be \`undefined\` if the \`defaultCapacityType\` is not \`EC2\` or
 ##### \`defaultNodegroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.defaultNodegroup\\"></a>
 
 \`\`\`typescript
-public readonly defaultNodegroup: Nodegroup
+public readonly defaultNodegroup: Nodegroup;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.Nodegroup\`](#aws-cdk-lib.aws_eks.Nodegroup)
@@ -43735,7 +43479,7 @@ This will be \`undefined\` if the \`defaultCapacityType\` is \`EC2\` or
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlEnvironment\\"></a>
 
 \`\`\`typescript
-public readonly kubectlEnvironment: {[ key: string ]: string}
+public readonly kubectlEnvironment: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -43747,7 +43491,7 @@ Custom environment variables when running \`kubectl\` against this cluster.
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlLayer\\"></a>
 
 \`\`\`typescript
-public readonly kubectlLayer: ILayerVersion
+public readonly kubectlLayer: ILayerVersion;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
@@ -43762,7 +43506,7 @@ undefined, a SAR app that contains this layer will be used.
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlMemory\\"></a>
 
 \`\`\`typescript
-public readonly kubectlMemory: Size
+public readonly kubectlMemory: Size;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
@@ -43774,7 +43518,7 @@ The amount of memory allocated to the kubectl provider's lambda function.
 ##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlPrivateSubnets\\"></a>
 
 \`\`\`typescript
-public readonly kubectlPrivateSubnets: ISubnet[]
+public readonly kubectlPrivateSubnets: ISubnet[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISubnet\`](#aws-cdk-lib.aws_ec2.ISubnet)[]
@@ -43788,7 +43532,7 @@ Subnets to host the \`kubectl\` compute resources.
 ##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlRole\\"></a>
 
 \`\`\`typescript
-public readonly kubectlRole: IRole
+public readonly kubectlRole: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -43802,7 +43546,7 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 ##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Cluster.property.kubectlSecurityGroup\\"></a>
 
 \`\`\`typescript
-public readonly kubectlSecurityGroup: ISecurityGroup
+public readonly kubectlSecurityGroup: ISecurityGroup;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
@@ -43908,7 +43652,7 @@ new aws_eks.FargateProfile(scope: Construct, id: string, props: FargateProfilePr
 ##### \`fargateProfileArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.property.fargateProfileArn\\"></a>
 
 \`\`\`typescript
-public readonly fargateProfileArn: string
+public readonly fargateProfileArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43920,7 +43664,7 @@ The full Amazon Resource Name (ARN) of the Fargate profile.
 ##### \`fargateProfileName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.property.fargateProfileName\\"></a>
 
 \`\`\`typescript
-public readonly fargateProfileName: string
+public readonly fargateProfileName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -43932,7 +43676,7 @@ The name of the Fargate profile.
 ##### \`podExecutionRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.property.podExecutionRole\\"></a>
 
 \`\`\`typescript
-public readonly podExecutionRole: IRole
+public readonly podExecutionRole: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -43948,7 +43692,7 @@ ECR image repositories.
 ##### \`tags\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfile.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: TagManager
+public readonly tags: TagManager;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.TagManager\`](#aws-cdk-lib.TagManager)
@@ -43996,10 +43740,6 @@ new aws_eks.HelmChart(scope: Construct, id: string, props: HelmChartProps)
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`RESOURCE_TYPE\` <a name=\\"aws-cdk-lib.aws_eks.HelmChart.property.RESOURCE_TYPE\\"></a>
-
-\`\`\`typescript
-public readonly RESOURCE_TYPE: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -44049,10 +43789,6 @@ new aws_eks.KubernetesManifest(scope: Construct, id: string, props: KubernetesMa
 
 ##### \`RESOURCE_TYPE\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifest.property.RESOURCE_TYPE\\"></a>
 
-\`\`\`typescript
-public readonly RESOURCE_TYPE: string
-\`\`\`
-
 - *Type:* \`string\`
 
 The CloudFormation reosurce type.
@@ -44098,7 +43834,7 @@ new aws_eks.KubernetesObjectValue(scope: Construct, id: string, props: Kubernete
 ##### \`value\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.property.value\\"></a>
 
 \`\`\`typescript
-public readonly value: string
+public readonly value: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -44110,10 +43846,6 @@ The value as a string token.
 #### Constants <a name=\\"Constants\\"></a>
 
 ##### \`RESOURCE_TYPE\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValue.property.RESOURCE_TYPE\\"></a>
-
-\`\`\`typescript
-public readonly RESOURCE_TYPE: string
-\`\`\`
 
 - *Type:* \`string\`
 
@@ -44223,7 +43955,7 @@ aws_eks.Nodegroup.fromNodegroupName(scope: Construct, id: string, nodegroupName:
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.property.cluster\\"></a>
 
 \`\`\`typescript
-public readonly cluster: ICluster
+public readonly cluster: ICluster;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
@@ -44235,7 +43967,7 @@ the Amazon EKS cluster resource.
 ##### \`nodegroupArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.property.nodegroupArn\\"></a>
 
 \`\`\`typescript
-public readonly nodegroupArn: string
+public readonly nodegroupArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -44247,7 +43979,7 @@ ARN of the nodegroup.
 ##### \`nodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.property.nodegroupName\\"></a>
 
 \`\`\`typescript
-public readonly nodegroupName: string
+public readonly nodegroupName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -44259,7 +43991,7 @@ Nodegroup name.
 ##### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Nodegroup.property.role\\"></a>
 
 \`\`\`typescript
-public readonly role: IRole
+public readonly role: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -44370,7 +44102,7 @@ public addToPrincipalPolicy(statement: PolicyStatement)
 ##### \`assumeRoleAction\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.assumeRoleAction\\"></a>
 
 \`\`\`typescript
-public readonly assumeRoleAction: string
+public readonly assumeRoleAction: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -44382,7 +44114,7 @@ When this Principal is used in an AssumeRole policy, the action to use.
 ##### \`grantPrincipal\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.grantPrincipal\\"></a>
 
 \`\`\`typescript
-public readonly grantPrincipal: IPrincipal
+public readonly grantPrincipal: IPrincipal;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IPrincipal\`](#aws-cdk-lib.aws_iam.IPrincipal)
@@ -44394,7 +44126,7 @@ The principal to grant permissions to.
 ##### \`policyFragment\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.policyFragment\\"></a>
 
 \`\`\`typescript
-public readonly policyFragment: PrincipalPolicyFragment
+public readonly policyFragment: PrincipalPolicyFragment;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.PrincipalPolicyFragment\`](#aws-cdk-lib.aws_iam.PrincipalPolicyFragment)
@@ -44406,7 +44138,7 @@ Return the policy fragment that identifies this principal in a Policy.
 ##### \`role\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.role\\"></a>
 
 \`\`\`typescript
-public readonly role: IRole
+public readonly role: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -44418,7 +44150,7 @@ The role which is linked to the service account.
 ##### \`serviceAccountName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.serviceAccountName\\"></a>
 
 \`\`\`typescript
-public readonly serviceAccountName: string
+public readonly serviceAccountName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -44430,7 +44162,7 @@ The name of the service account.
 ##### \`serviceAccountNamespace\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccount.property.serviceAccountNamespace\\"></a>
 
 \`\`\`typescript
-public readonly serviceAccountNamespace: string
+public readonly serviceAccountNamespace: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -44457,7 +44189,7 @@ const autoScalingGroupCapacityOptions: aws_eks.AutoScalingGroupCapacityOptions =
 ##### \`allowAllOutbound\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.allowAllOutbound\\"></a>
 
 \`\`\`typescript
-public readonly allowAllOutbound: boolean
+public readonly allowAllOutbound: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -44470,7 +44202,7 @@ Whether the instances can initiate connections to anywhere by default.
 ##### \`associatePublicIpAddress\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.associatePublicIpAddress\\"></a>
 
 \`\`\`typescript
-public readonly associatePublicIpAddress: boolean
+public readonly associatePublicIpAddress: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -44483,7 +44215,7 @@ Whether instances in the Auto Scaling Group should have public IP addresses asso
 ##### \`autoScalingGroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.autoScalingGroupName\\"></a>
 
 \`\`\`typescript
-public readonly autoScalingGroupName: string
+public readonly autoScalingGroupName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -44498,7 +44230,7 @@ This name must be unique per Region per account.
 ##### \`blockDevices\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.blockDevices\\"></a>
 
 \`\`\`typescript
-public readonly blockDevices: BlockDevice[]
+public readonly blockDevices: BlockDevice[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.BlockDevice\`](#aws-cdk-lib.aws_autoscaling.BlockDevice)[]
@@ -44518,7 +44250,7 @@ instance store volumes to attach to an instance when it is launched.
 ##### \`cooldown\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.cooldown\\"></a>
 
 \`\`\`typescript
-public readonly cooldown: Duration
+public readonly cooldown: Duration;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
@@ -44531,7 +44263,7 @@ Default scaling cooldown for this AutoScalingGroup.
 ##### \`desiredCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.desiredCapacity\\"></a>
 
 \`\`\`typescript
-public readonly desiredCapacity: number
+public readonly desiredCapacity: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -44549,7 +44281,7 @@ instances to this number. It is recommended to leave this value blank.
 ##### \`groupMetrics\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.groupMetrics\\"></a>
 
 \`\`\`typescript
-public readonly groupMetrics: GroupMetrics[]
+public readonly groupMetrics: GroupMetrics[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.GroupMetrics\`](#aws-cdk-lib.aws_autoscaling.GroupMetrics)[]
@@ -44565,7 +44297,7 @@ Group metrics are reported in a granularity of 1 minute at no additional charge.
 ##### \`healthCheck\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.healthCheck\\"></a>
 
 \`\`\`typescript
-public readonly healthCheck: HealthCheck
+public readonly healthCheck: HealthCheck;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.HealthCheck\`](#aws-cdk-lib.aws_autoscaling.HealthCheck)
@@ -44578,7 +44310,7 @@ Configuration for health checks.
 ##### \`ignoreUnmodifiedSizeProperties\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.ignoreUnmodifiedSizeProperties\\"></a>
 
 \`\`\`typescript
-public readonly ignoreUnmodifiedSizeProperties: boolean
+public readonly ignoreUnmodifiedSizeProperties: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -44597,7 +44329,7 @@ on deployment.
 ##### \`instanceMonitoring\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.instanceMonitoring\\"></a>
 
 \`\`\`typescript
-public readonly instanceMonitoring: Monitoring
+public readonly instanceMonitoring: Monitoring;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.Monitoring\`](#aws-cdk-lib.aws_autoscaling.Monitoring)
@@ -44615,7 +44347,7 @@ is charged a fee. When you disable detailed monitoring, CloudWatch generates met
 ##### \`keyName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.keyName\\"></a>
 
 \`\`\`typescript
-public readonly keyName: string
+public readonly keyName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -44628,7 +44360,7 @@ Name of SSH keypair to grant access to instances.
 ##### \`maxCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.maxCapacity\\"></a>
 
 \`\`\`typescript
-public readonly maxCapacity: number
+public readonly maxCapacity: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -44641,7 +44373,7 @@ Maximum number of instances in the fleet.
 ##### \`maxInstanceLifetime\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.maxInstanceLifetime\\"></a>
 
 \`\`\`typescript
-public readonly maxInstanceLifetime: Duration
+public readonly maxInstanceLifetime: Duration;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
@@ -44663,7 +44395,7 @@ leave this property undefined.
 ##### \`minCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.minCapacity\\"></a>
 
 \`\`\`typescript
-public readonly minCapacity: number
+public readonly minCapacity: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -44676,7 +44408,7 @@ Minimum number of instances in the fleet.
 ##### \`newInstancesProtectedFromScaleIn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.newInstancesProtectedFromScaleIn\\"></a>
 
 \`\`\`typescript
-public readonly newInstancesProtectedFromScaleIn: boolean
+public readonly newInstancesProtectedFromScaleIn: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -44698,7 +44430,7 @@ an ECS Capacity Provider with managed termination protection.
 ##### \`notifications\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.notifications\\"></a>
 
 \`\`\`typescript
-public readonly notifications: NotificationConfiguration[]
+public readonly notifications: NotificationConfiguration[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.NotificationConfiguration\`](#aws-cdk-lib.aws_autoscaling.NotificationConfiguration)[]
@@ -44713,7 +44445,7 @@ Configure autoscaling group to send notifications about fleet changes to an SNS 
 ##### \`signals\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.signals\\"></a>
 
 \`\`\`typescript
-public readonly signals: Signals
+public readonly signals: Signals;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.Signals\`](#aws-cdk-lib.aws_autoscaling.Signals)
@@ -44742,7 +44474,7 @@ https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services
 ##### \`spotPrice\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.spotPrice\\"></a>
 
 \`\`\`typescript
-public readonly spotPrice: string
+public readonly spotPrice: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -44758,7 +44490,7 @@ launched when the price you specify exceeds the current Spot market price.
 ##### \`updatePolicy\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.updatePolicy\\"></a>
 
 \`\`\`typescript
-public readonly updatePolicy: UpdatePolicy
+public readonly updatePolicy: UpdatePolicy;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_autoscaling.UpdatePolicy\`](#aws-cdk-lib.aws_autoscaling.UpdatePolicy)
@@ -44777,7 +44509,7 @@ is done and only new instances are launched with the new config.
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.vpcSubnets\\"></a>
 
 \`\`\`typescript
-public readonly vpcSubnets: SubnetSelection
+public readonly vpcSubnets: SubnetSelection;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
@@ -44790,7 +44522,7 @@ Where to place instances within the VPC.
 ##### \`instanceType\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.instanceType\\"></a>
 
 \`\`\`typescript
-public readonly instanceType: InstanceType
+public readonly instanceType: InstanceType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.InstanceType\`](#aws-cdk-lib.aws_ec2.InstanceType)
@@ -44802,7 +44534,7 @@ Instance type of the instances to start.
 ##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.bootstrapEnabled\\"></a>
 
 \`\`\`typescript
-public readonly bootstrapEnabled: boolean
+public readonly bootstrapEnabled: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -44818,7 +44550,7 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 ##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.bootstrapOptions\\"></a>
 
 \`\`\`typescript
-public readonly bootstrapOptions: BootstrapOptions
+public readonly bootstrapOptions: BootstrapOptions;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.BootstrapOptions\`](#aws-cdk-lib.aws_eks.BootstrapOptions)
@@ -44831,7 +44563,7 @@ EKS node bootstrapping options.
 ##### \`machineImageType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.machineImageType\\"></a>
 
 \`\`\`typescript
-public readonly machineImageType: MachineImageType
+public readonly machineImageType: MachineImageType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.MachineImageType\`](#aws-cdk-lib.aws_eks.MachineImageType)
@@ -44844,7 +44576,7 @@ Machine image type.
 ##### \`mapRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.mapRole\\"></a>
 
 \`\`\`typescript
-public readonly mapRole: boolean
+public readonly mapRole: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -44859,7 +44591,7 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 ##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupCapacityOptions.property.spotInterruptHandler\\"></a>
 
 \`\`\`typescript
-public readonly spotInterruptHandler: boolean
+public readonly spotInterruptHandler: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -44886,7 +44618,7 @@ const autoScalingGroupOptions: aws_eks.AutoScalingGroupOptions = { ... }
 ##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.bootstrapEnabled\\"></a>
 
 \`\`\`typescript
-public readonly bootstrapEnabled: boolean
+public readonly bootstrapEnabled: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -44902,7 +44634,7 @@ manually invoke \`autoscalingGroup.addUserData()\`.
 ##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.bootstrapOptions\\"></a>
 
 \`\`\`typescript
-public readonly bootstrapOptions: BootstrapOptions
+public readonly bootstrapOptions: BootstrapOptions;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.BootstrapOptions\`](#aws-cdk-lib.aws_eks.BootstrapOptions)
@@ -44915,7 +44647,7 @@ Allows options for node bootstrapping through EC2 user data.
 ##### \`machineImageType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.machineImageType\\"></a>
 
 \`\`\`typescript
-public readonly machineImageType: MachineImageType
+public readonly machineImageType: MachineImageType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.MachineImageType\`](#aws-cdk-lib.aws_eks.MachineImageType)
@@ -44928,7 +44660,7 @@ Allow options to specify different machine image type.
 ##### \`mapRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.mapRole\\"></a>
 
 \`\`\`typescript
-public readonly mapRole: boolean
+public readonly mapRole: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -44943,7 +44675,7 @@ This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
 ##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AutoScalingGroupOptions.property.spotInterruptHandler\\"></a>
 
 \`\`\`typescript
-public readonly spotInterruptHandler: boolean
+public readonly spotInterruptHandler: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -44970,7 +44702,7 @@ const awsAuthMapping: aws_eks.AwsAuthMapping = { ... }
 ##### \`groups\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuthMapping.property.groups\\"></a>
 
 \`\`\`typescript
-public readonly groups: string[]
+public readonly groups: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -44984,7 +44716,7 @@ A list of groups within Kubernetes to which the role is mapped.
 ##### \`username\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuthMapping.property.username\\"></a>
 
 \`\`\`typescript
-public readonly username: string
+public readonly username: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45009,7 +44741,7 @@ const awsAuthProps: aws_eks.AwsAuthProps = { ... }
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.AwsAuthProps.property.cluster\\"></a>
 
 \`\`\`typescript
-public readonly cluster: Cluster
+public readonly cluster: Cluster;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.Cluster\`](#aws-cdk-lib.aws_eks.Cluster)
@@ -45035,7 +44767,7 @@ const bootstrapOptions: aws_eks.BootstrapOptions = { ... }
 ##### \`additionalArgs\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.additionalArgs\\"></a>
 
 \`\`\`typescript
-public readonly additionalArgs: string
+public readonly additionalArgs: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45050,7 +44782,7 @@ Additional command line arguments to pass to the \`/etc/eks/bootstrap.sh\` comma
 ##### \`awsApiRetryAttempts\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.awsApiRetryAttempts\\"></a>
 
 \`\`\`typescript
-public readonly awsApiRetryAttempts: number
+public readonly awsApiRetryAttempts: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -45063,7 +44795,7 @@ Number of retry attempts for AWS API call (DescribeCluster).
 ##### \`dnsClusterIp\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.dnsClusterIp\\"></a>
 
 \`\`\`typescript
-public readonly dnsClusterIp: string
+public readonly dnsClusterIp: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45077,7 +44809,7 @@ Overrides the IP address to use for DNS queries within the cluster.
 ##### \`dockerConfigJson\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.dockerConfigJson\\"></a>
 
 \`\`\`typescript
-public readonly dockerConfigJson: string
+public readonly dockerConfigJson: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45090,7 +44822,7 @@ The contents of the \`/etc/docker/daemon.json\` file. Useful if you want a custo
 ##### \`enableDockerBridge\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.enableDockerBridge\\"></a>
 
 \`\`\`typescript
-public readonly enableDockerBridge: boolean
+public readonly enableDockerBridge: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -45103,7 +44835,7 @@ Restores the docker default bridge network.
 ##### \`kubeletExtraArgs\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.kubeletExtraArgs\\"></a>
 
 \`\`\`typescript
-public readonly kubeletExtraArgs: string
+public readonly kubeletExtraArgs: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45118,7 +44850,7 @@ Useful for adding labels or taints.
 ##### \`useMaxPods\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.BootstrapOptions.property.useMaxPods\\"></a>
 
 \`\`\`typescript
-public readonly useMaxPods: boolean
+public readonly useMaxPods: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -45145,7 +44877,7 @@ const cfnAddonProps: aws_eks.CfnAddonProps = { ... }
 ##### \`addonName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.addonName\\"></a>
 
 \`\`\`typescript
-public readonly addonName: string
+public readonly addonName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45159,7 +44891,7 @@ public readonly addonName: string
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45173,7 +44905,7 @@ public readonly clusterName: string
 ##### \`addonVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.addonVersion\\"></a>
 
 \`\`\`typescript
-public readonly addonVersion: string
+public readonly addonVersion: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45187,7 +44919,7 @@ public readonly addonVersion: string
 ##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.resolveConflicts\\"></a>
 
 \`\`\`typescript
-public readonly resolveConflicts: string
+public readonly resolveConflicts: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45201,7 +44933,7 @@ public readonly resolveConflicts: string
 ##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.serviceAccountRoleArn\\"></a>
 
 \`\`\`typescript
-public readonly serviceAccountRoleArn: string
+public readonly serviceAccountRoleArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45215,7 +44947,7 @@ public readonly serviceAccountRoleArn: string
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnAddonProps.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: CfnTag[]
+public readonly tags: CfnTag[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.CfnTag\`](#aws-cdk-lib.CfnTag)[]
@@ -45243,7 +44975,7 @@ const cfnClusterProps: aws_eks.CfnClusterProps = { ... }
 ##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.resourcesVpcConfig\\"></a>
 
 \`\`\`typescript
-public readonly resourcesVpcConfig: ResourcesVpcConfigProperty | IResolvable
+public readonly resourcesVpcConfig: ResourcesVpcConfigProperty | IResolvable;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -45257,7 +44989,7 @@ public readonly resourcesVpcConfig: ResourcesVpcConfigProperty | IResolvable
 ##### \`roleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.roleArn\\"></a>
 
 \`\`\`typescript
-public readonly roleArn: string
+public readonly roleArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45271,7 +45003,7 @@ public readonly roleArn: string
 ##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.encryptionConfig\\"></a>
 
 \`\`\`typescript
-public readonly encryptionConfig: IResolvable | EncryptionConfigProperty | IResolvable[]
+public readonly encryptionConfig: IResolvable | EncryptionConfigProperty | IResolvable[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
@@ -45285,7 +45017,7 @@ public readonly encryptionConfig: IResolvable | EncryptionConfigProperty | IReso
 ##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.kubernetesNetworkConfig\\"></a>
 
 \`\`\`typescript
-public readonly kubernetesNetworkConfig: KubernetesNetworkConfigProperty | IResolvable
+public readonly kubernetesNetworkConfig: KubernetesNetworkConfigProperty | IResolvable;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -45299,7 +45031,7 @@ public readonly kubernetesNetworkConfig: KubernetesNetworkConfigProperty | IReso
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.name\\"></a>
 
 \`\`\`typescript
-public readonly name: string
+public readonly name: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45313,7 +45045,7 @@ public readonly name: string
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnClusterProps.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: string
+public readonly version: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45341,7 +45073,7 @@ const cfnFargateProfileProps: aws_eks.CfnFargateProfileProps = { ... }
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45355,7 +45087,7 @@ public readonly clusterName: string
 ##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.podExecutionRoleArn\\"></a>
 
 \`\`\`typescript
-public readonly podExecutionRoleArn: string
+public readonly podExecutionRoleArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45369,7 +45101,7 @@ public readonly podExecutionRoleArn: string
 ##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.selectors\\"></a>
 
 \`\`\`typescript
-public readonly selectors: IResolvable | SelectorProperty | IResolvable[]
+public readonly selectors: IResolvable | SelectorProperty | IResolvable[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty\`](#aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
@@ -45383,7 +45115,7 @@ public readonly selectors: IResolvable | SelectorProperty | IResolvable[]
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.fargateProfileName\\"></a>
 
 \`\`\`typescript
-public readonly fargateProfileName: string
+public readonly fargateProfileName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45397,7 +45129,7 @@ public readonly fargateProfileName: string
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.subnets\\"></a>
 
 \`\`\`typescript
-public readonly subnets: string[]
+public readonly subnets: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -45411,7 +45143,7 @@ public readonly subnets: string[]
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfileProps.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: CfnTag[]
+public readonly tags: CfnTag[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.CfnTag\`](#aws-cdk-lib.CfnTag)[]
@@ -45439,7 +45171,7 @@ const cfnNodegroupProps: aws_eks.CfnNodegroupProps = { ... }
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45453,7 +45185,7 @@ public readonly clusterName: string
 ##### \`nodeRole\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.nodeRole\\"></a>
 
 \`\`\`typescript
-public readonly nodeRole: string
+public readonly nodeRole: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45467,7 +45199,7 @@ public readonly nodeRole: string
 ##### \`subnets\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.subnets\\"></a>
 
 \`\`\`typescript
-public readonly subnets: string[]
+public readonly subnets: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -45481,7 +45213,7 @@ public readonly subnets: string[]
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.amiType\\"></a>
 
 \`\`\`typescript
-public readonly amiType: string
+public readonly amiType: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45495,7 +45227,7 @@ public readonly amiType: string
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.capacityType\\"></a>
 
 \`\`\`typescript
-public readonly capacityType: string
+public readonly capacityType: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45509,7 +45241,7 @@ public readonly capacityType: string
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.diskSize\\"></a>
 
 \`\`\`typescript
-public readonly diskSize: number
+public readonly diskSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -45523,7 +45255,7 @@ public readonly diskSize: number
 ##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.forceUpdateEnabled\\"></a>
 
 \`\`\`typescript
-public readonly forceUpdateEnabled: boolean | IResolvable
+public readonly forceUpdateEnabled: boolean | IResolvable;
 \`\`\`
 
 - *Type:* \`boolean\` | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -45537,7 +45269,7 @@ public readonly forceUpdateEnabled: boolean | IResolvable
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.instanceTypes\\"></a>
 
 \`\`\`typescript
-public readonly instanceTypes: string[]
+public readonly instanceTypes: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -45551,7 +45283,7 @@ public readonly instanceTypes: string[]
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.labels\\"></a>
 
 \`\`\`typescript
-public readonly labels: any
+public readonly labels: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -45565,7 +45297,7 @@ public readonly labels: any
 ##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.launchTemplate\\"></a>
 
 \`\`\`typescript
-public readonly launchTemplate: LaunchTemplateSpecificationProperty | IResolvable
+public readonly launchTemplate: LaunchTemplateSpecificationProperty | IResolvable;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -45579,7 +45311,7 @@ public readonly launchTemplate: LaunchTemplateSpecificationProperty | IResolvabl
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.nodegroupName\\"></a>
 
 \`\`\`typescript
-public readonly nodegroupName: string
+public readonly nodegroupName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45593,7 +45325,7 @@ public readonly nodegroupName: string
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.releaseVersion\\"></a>
 
 \`\`\`typescript
-public readonly releaseVersion: string
+public readonly releaseVersion: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45607,7 +45339,7 @@ public readonly releaseVersion: string
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.remoteAccess\\"></a>
 
 \`\`\`typescript
-public readonly remoteAccess: RemoteAccessProperty | IResolvable
+public readonly remoteAccess: RemoteAccessProperty | IResolvable;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -45621,7 +45353,7 @@ public readonly remoteAccess: RemoteAccessProperty | IResolvable
 ##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.scalingConfig\\"></a>
 
 \`\`\`typescript
-public readonly scalingConfig: ScalingConfigProperty | IResolvable
+public readonly scalingConfig: ScalingConfigProperty | IResolvable;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -45635,7 +45367,7 @@ public readonly scalingConfig: ScalingConfigProperty | IResolvable
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: any
+public readonly tags: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -45649,7 +45381,7 @@ public readonly tags: any
 ##### \`taints\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.taints\\"></a>
 
 \`\`\`typescript
-public readonly taints: IResolvable | TaintProperty | IResolvable[]
+public readonly taints: IResolvable | TaintProperty | IResolvable[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty\`](#aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
@@ -45663,7 +45395,7 @@ public readonly taints: IResolvable | TaintProperty | IResolvable[]
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroupProps.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: string
+public readonly version: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45689,7 +45421,7 @@ const clusterAttributes: aws_eks.ClusterAttributes = { ... }
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45701,7 +45433,7 @@ The physical name of the Cluster.
 ##### \`clusterCertificateAuthorityData\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterCertificateAuthorityData\\"></a>
 
 \`\`\`typescript
-public readonly clusterCertificateAuthorityData: string
+public readonly clusterCertificateAuthorityData: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45715,7 +45447,7 @@ The certificate-authority-data for your cluster.
 ##### \`clusterEncryptionConfigKeyArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterEncryptionConfigKeyArn\\"></a>
 
 \`\`\`typescript
-public readonly clusterEncryptionConfigKeyArn: string
+public readonly clusterEncryptionConfigKeyArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45729,7 +45461,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 ##### \`clusterEndpoint\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterEndpoint\\"></a>
 
 \`\`\`typescript
-public readonly clusterEndpoint: string
+public readonly clusterEndpoint: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45742,7 +45474,7 @@ The API Server endpoint URL.
 ##### \`clusterSecurityGroupId\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.clusterSecurityGroupId\\"></a>
 
 \`\`\`typescript
-public readonly clusterSecurityGroupId: string
+public readonly clusterSecurityGroupId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45756,7 +45488,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlEnvironment\\"></a>
 
 \`\`\`typescript
-public readonly kubectlEnvironment: {[ key: string ]: string}
+public readonly kubectlEnvironment: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -45769,7 +45501,7 @@ Environment variables to use when running \`kubectl\` against this cluster.
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlLayer\\"></a>
 
 \`\`\`typescript
-public readonly kubectlLayer: ILayerVersion
+public readonly kubectlLayer: ILayerVersion;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
@@ -45791,7 +45523,7 @@ The handler expects the layer to include the following executables:
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlMemory\\"></a>
 
 \`\`\`typescript
-public readonly kubectlMemory: Size
+public readonly kubectlMemory: Size;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
@@ -45804,7 +45536,7 @@ Amount of memory to allocate to the provider's lambda function.
 ##### \`kubectlPrivateSubnetIds\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlPrivateSubnetIds\\"></a>
 
 \`\`\`typescript
-public readonly kubectlPrivateSubnetIds: string[]
+public readonly kubectlPrivateSubnetIds: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -45820,7 +45552,7 @@ endpoint is expected to be accessible publicly.
 ##### \`kubectlRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlRoleArn\\"></a>
 
 \`\`\`typescript
-public readonly kubectlRoleArn: string
+public readonly kubectlRoleArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45834,7 +45566,7 @@ An IAM role with cluster administrator and \\"system:masters\\" permissions.
 ##### \`kubectlSecurityGroupId\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.kubectlSecurityGroupId\\"></a>
 
 \`\`\`typescript
-public readonly kubectlSecurityGroupId: string
+public readonly kubectlSecurityGroupId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45850,7 +45582,7 @@ endpoint is expected to be accessible publicly.
 ##### \`openIdConnectProvider\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.openIdConnectProvider\\"></a>
 
 \`\`\`typescript
-public readonly openIdConnectProvider: IOpenIdConnectProvider
+public readonly openIdConnectProvider: IOpenIdConnectProvider;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IOpenIdConnectProvider\`](#aws-cdk-lib.aws_iam.IOpenIdConnectProvider)
@@ -45866,7 +45598,7 @@ or create a new provider using \`new eks.OpenIdConnectProvider\`
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.prune\\"></a>
 
 \`\`\`typescript
-public readonly prune: boolean
+public readonly prune: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -45883,7 +45615,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 ##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.securityGroupIds\\"></a>
 
 \`\`\`typescript
-public readonly securityGroupIds: string[]
+public readonly securityGroupIds: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -45897,7 +45629,7 @@ Additional security groups associated with this cluster.
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterAttributes.property.vpc\\"></a>
 
 \`\`\`typescript
-public readonly vpc: IVpc
+public readonly vpc: IVpc;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
@@ -45922,7 +45654,7 @@ const clusterOptions: aws_eks.ClusterOptions = { ... }
 ##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: KubernetesVersion
+public readonly version: KubernetesVersion;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
@@ -45934,7 +45666,7 @@ The Kubernetes version to run in the cluster.
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -45947,7 +45679,7 @@ Name for the cluster.
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.outputClusterName\\"></a>
 
 \`\`\`typescript
-public readonly outputClusterName: boolean
+public readonly outputClusterName: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -45960,7 +45692,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.outputConfigCommand\\"></a>
 
 \`\`\`typescript
-public readonly outputConfigCommand: boolean
+public readonly outputConfigCommand: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -45976,7 +45708,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 ##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.role\\"></a>
 
 \`\`\`typescript
-public readonly role: IRole
+public readonly role: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -45989,7 +45721,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.securityGroup\\"></a>
 
 \`\`\`typescript
-public readonly securityGroup: ISecurityGroup
+public readonly securityGroup: ISecurityGroup;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
@@ -46002,7 +45734,7 @@ Security Group to use for Control Plane ENIs.
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.vpc\\"></a>
 
 \`\`\`typescript
-public readonly vpc: IVpc
+public readonly vpc: IVpc;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
@@ -46015,7 +45747,7 @@ The VPC in which to create the Cluster.
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.vpcSubnets\\"></a>
 
 \`\`\`typescript
-public readonly vpcSubnets: SubnetSelection[]
+public readonly vpcSubnets: SubnetSelection[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)[]
@@ -46038,7 +45770,7 @@ vpcSubnets: [
 ##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.clusterHandlerEnvironment\\"></a>
 
 \`\`\`typescript
-public readonly clusterHandlerEnvironment: {[ key: string ]: string}
+public readonly clusterHandlerEnvironment: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -46051,7 +45783,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 ##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.coreDnsComputeType\\"></a>
 
 \`\`\`typescript
-public readonly coreDnsComputeType: CoreDnsComputeType
+public readonly coreDnsComputeType: CoreDnsComputeType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CoreDnsComputeType\`](#aws-cdk-lib.aws_eks.CoreDnsComputeType)
@@ -46064,7 +45796,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.endpointAccess\\"></a>
 
 \`\`\`typescript
-public readonly endpointAccess: EndpointAccess
+public readonly endpointAccess: EndpointAccess;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
@@ -46079,7 +45811,7 @@ Configure access to the Kubernetes API server endpoint..
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.kubectlEnvironment\\"></a>
 
 \`\`\`typescript
-public readonly kubectlEnvironment: {[ key: string ]: string}
+public readonly kubectlEnvironment: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -46094,7 +45826,7 @@ Only relevant for kubectl enabled clusters.
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.kubectlLayer\\"></a>
 
 \`\`\`typescript
-public readonly kubectlLayer: ILayerVersion
+public readonly kubectlLayer: ILayerVersion;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
@@ -46125,7 +45857,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.kubectlMemory\\"></a>
 
 \`\`\`typescript
-public readonly kubectlMemory: Size
+public readonly kubectlMemory: Size;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
@@ -46138,7 +45870,7 @@ Amount of memory to allocate to the provider's lambda function.
 ##### \`mastersRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.mastersRole\\"></a>
 
 \`\`\`typescript
-public readonly mastersRole: IRole
+public readonly mastersRole: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -46154,7 +45886,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 ##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.outputMastersRoleArn\\"></a>
 
 \`\`\`typescript
-public readonly outputMastersRoleArn: boolean
+public readonly outputMastersRoleArn: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -46167,7 +45899,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 ##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.placeClusterHandlerInVpc\\"></a>
 
 \`\`\`typescript
-public readonly placeClusterHandlerInVpc: boolean
+public readonly placeClusterHandlerInVpc: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -46180,7 +45912,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.prune\\"></a>
 
 \`\`\`typescript
-public readonly prune: boolean
+public readonly prune: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -46197,7 +45929,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 ##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterOptions.property.secretsEncryptionKey\\"></a>
 
 \`\`\`typescript
-public readonly secretsEncryptionKey: IKey
+public readonly secretsEncryptionKey: IKey;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_kms.IKey\`](#aws-cdk-lib.aws_kms.IKey)
@@ -46224,7 +45956,7 @@ const clusterProps: aws_eks.ClusterProps = { ... }
 ##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: KubernetesVersion
+public readonly version: KubernetesVersion;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
@@ -46236,7 +45968,7 @@ The Kubernetes version to run in the cluster.
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -46249,7 +45981,7 @@ Name for the cluster.
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.outputClusterName\\"></a>
 
 \`\`\`typescript
-public readonly outputClusterName: boolean
+public readonly outputClusterName: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -46262,7 +45994,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.outputConfigCommand\\"></a>
 
 \`\`\`typescript
-public readonly outputConfigCommand: boolean
+public readonly outputConfigCommand: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -46278,7 +46010,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 ##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.role\\"></a>
 
 \`\`\`typescript
-public readonly role: IRole
+public readonly role: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -46291,7 +46023,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.securityGroup\\"></a>
 
 \`\`\`typescript
-public readonly securityGroup: ISecurityGroup
+public readonly securityGroup: ISecurityGroup;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
@@ -46304,7 +46036,7 @@ Security Group to use for Control Plane ENIs.
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.vpc\\"></a>
 
 \`\`\`typescript
-public readonly vpc: IVpc
+public readonly vpc: IVpc;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
@@ -46317,7 +46049,7 @@ The VPC in which to create the Cluster.
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.vpcSubnets\\"></a>
 
 \`\`\`typescript
-public readonly vpcSubnets: SubnetSelection[]
+public readonly vpcSubnets: SubnetSelection[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)[]
@@ -46340,7 +46072,7 @@ vpcSubnets: [
 ##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.clusterHandlerEnvironment\\"></a>
 
 \`\`\`typescript
-public readonly clusterHandlerEnvironment: {[ key: string ]: string}
+public readonly clusterHandlerEnvironment: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -46353,7 +46085,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 ##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.coreDnsComputeType\\"></a>
 
 \`\`\`typescript
-public readonly coreDnsComputeType: CoreDnsComputeType
+public readonly coreDnsComputeType: CoreDnsComputeType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CoreDnsComputeType\`](#aws-cdk-lib.aws_eks.CoreDnsComputeType)
@@ -46366,7 +46098,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.endpointAccess\\"></a>
 
 \`\`\`typescript
-public readonly endpointAccess: EndpointAccess
+public readonly endpointAccess: EndpointAccess;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
@@ -46381,7 +46113,7 @@ Configure access to the Kubernetes API server endpoint..
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.kubectlEnvironment\\"></a>
 
 \`\`\`typescript
-public readonly kubectlEnvironment: {[ key: string ]: string}
+public readonly kubectlEnvironment: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -46396,7 +46128,7 @@ Only relevant for kubectl enabled clusters.
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.kubectlLayer\\"></a>
 
 \`\`\`typescript
-public readonly kubectlLayer: ILayerVersion
+public readonly kubectlLayer: ILayerVersion;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
@@ -46427,7 +46159,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.kubectlMemory\\"></a>
 
 \`\`\`typescript
-public readonly kubectlMemory: Size
+public readonly kubectlMemory: Size;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
@@ -46440,7 +46172,7 @@ Amount of memory to allocate to the provider's lambda function.
 ##### \`mastersRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.mastersRole\\"></a>
 
 \`\`\`typescript
-public readonly mastersRole: IRole
+public readonly mastersRole: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -46456,7 +46188,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 ##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.outputMastersRoleArn\\"></a>
 
 \`\`\`typescript
-public readonly outputMastersRoleArn: boolean
+public readonly outputMastersRoleArn: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -46469,7 +46201,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 ##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.placeClusterHandlerInVpc\\"></a>
 
 \`\`\`typescript
-public readonly placeClusterHandlerInVpc: boolean
+public readonly placeClusterHandlerInVpc: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -46482,7 +46214,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.prune\\"></a>
 
 \`\`\`typescript
-public readonly prune: boolean
+public readonly prune: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -46499,7 +46231,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 ##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.secretsEncryptionKey\\"></a>
 
 \`\`\`typescript
-public readonly secretsEncryptionKey: IKey
+public readonly secretsEncryptionKey: IKey;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_kms.IKey\`](#aws-cdk-lib.aws_kms.IKey)
@@ -46514,7 +46246,7 @@ KMS secret for envelope encryption for Kubernetes secrets.
 ##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.defaultCapacity\\"></a>
 
 \`\`\`typescript
-public readonly defaultCapacity: number
+public readonly defaultCapacity: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -46533,7 +46265,7 @@ to \`0\` is you wish to avoid the initial capacity allocation.
 ##### \`defaultCapacityInstance\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.defaultCapacityInstance\\"></a>
 
 \`\`\`typescript
-public readonly defaultCapacityInstance: InstanceType
+public readonly defaultCapacityInstance: InstanceType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.InstanceType\`](#aws-cdk-lib.aws_ec2.InstanceType)
@@ -46549,7 +46281,7 @@ into account if \`defaultCapacity\` is > 0.
 ##### \`defaultCapacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ClusterProps.property.defaultCapacityType\\"></a>
 
 \`\`\`typescript
-public readonly defaultCapacityType: DefaultCapacityType
+public readonly defaultCapacityType: DefaultCapacityType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.DefaultCapacityType\`](#aws-cdk-lib.aws_eks.DefaultCapacityType)
@@ -46574,7 +46306,7 @@ const commonClusterOptions: aws_eks.CommonClusterOptions = { ... }
 ##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: KubernetesVersion
+public readonly version: KubernetesVersion;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
@@ -46586,7 +46318,7 @@ The Kubernetes version to run in the cluster.
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -46599,7 +46331,7 @@ Name for the cluster.
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.outputClusterName\\"></a>
 
 \`\`\`typescript
-public readonly outputClusterName: boolean
+public readonly outputClusterName: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -46612,7 +46344,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.outputConfigCommand\\"></a>
 
 \`\`\`typescript
-public readonly outputConfigCommand: boolean
+public readonly outputConfigCommand: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -46628,7 +46360,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 ##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.role\\"></a>
 
 \`\`\`typescript
-public readonly role: IRole
+public readonly role: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -46641,7 +46373,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.securityGroup\\"></a>
 
 \`\`\`typescript
-public readonly securityGroup: ISecurityGroup
+public readonly securityGroup: ISecurityGroup;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
@@ -46654,7 +46386,7 @@ Security Group to use for Control Plane ENIs.
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.vpc\\"></a>
 
 \`\`\`typescript
-public readonly vpc: IVpc
+public readonly vpc: IVpc;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
@@ -46667,7 +46399,7 @@ The VPC in which to create the Cluster.
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CommonClusterOptions.property.vpcSubnets\\"></a>
 
 \`\`\`typescript
-public readonly vpcSubnets: SubnetSelection[]
+public readonly vpcSubnets: SubnetSelection[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)[]
@@ -46702,7 +46434,7 @@ const eksOptimizedImageProps: aws_eks.EksOptimizedImageProps = { ... }
 ##### \`cpuArch\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImageProps.property.cpuArch\\"></a>
 
 \`\`\`typescript
-public readonly cpuArch: CpuArch
+public readonly cpuArch: CpuArch;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CpuArch\`](#aws-cdk-lib.aws_eks.CpuArch)
@@ -46715,7 +46447,7 @@ What cpu architecture to retrieve the image for (arm64 or x86_64).
 ##### \`kubernetesVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImageProps.property.kubernetesVersion\\"></a>
 
 \`\`\`typescript
-public readonly kubernetesVersion: string
+public readonly kubernetesVersion: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -46728,7 +46460,7 @@ The Kubernetes version to use.
 ##### \`nodeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.EksOptimizedImageProps.property.nodeType\\"></a>
 
 \`\`\`typescript
-public readonly nodeType: NodeType
+public readonly nodeType: NodeType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodeType\`](#aws-cdk-lib.aws_eks.NodeType)
@@ -46753,7 +46485,7 @@ const encryptionConfigProperty: aws_eks.CfnCluster.EncryptionConfigProperty = { 
 ##### \`provider\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty.property.provider\\"></a>
 
 \`\`\`typescript
-public readonly provider: ProviderProperty | IResolvable
+public readonly provider: ProviderProperty | IResolvable;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CfnCluster.ProviderProperty\`](#aws-cdk-lib.aws_eks.CfnCluster.ProviderProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)
@@ -46767,7 +46499,7 @@ public readonly provider: ProviderProperty | IResolvable
 ##### \`resources\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.EncryptionConfigProperty.property.resources\\"></a>
 
 \`\`\`typescript
-public readonly resources: string[]
+public readonly resources: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -46793,7 +46525,7 @@ const fargateClusterProps: aws_eks.FargateClusterProps = { ... }
 ##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: KubernetesVersion
+public readonly version: KubernetesVersion;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
@@ -46805,7 +46537,7 @@ The Kubernetes version to run in the cluster.
 ##### \`clusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -46818,7 +46550,7 @@ Name for the cluster.
 ##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.outputClusterName\\"></a>
 
 \`\`\`typescript
-public readonly outputClusterName: boolean
+public readonly outputClusterName: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -46831,7 +46563,7 @@ Determines whether a CloudFormation output with the name of the cluster will be 
 ##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.outputConfigCommand\\"></a>
 
 \`\`\`typescript
-public readonly outputConfigCommand: boolean
+public readonly outputConfigCommand: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -46847,7 +46579,7 @@ the cluster name and, if applicable, the ARN of the masters IAM role.
 ##### \`role\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.role\\"></a>
 
 \`\`\`typescript
-public readonly role: IRole
+public readonly role: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -46860,7 +46592,7 @@ Role that provides permissions for the Kubernetes control plane to make calls to
 ##### \`securityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.securityGroup\\"></a>
 
 \`\`\`typescript
-public readonly securityGroup: ISecurityGroup
+public readonly securityGroup: ISecurityGroup;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
@@ -46873,7 +46605,7 @@ Security Group to use for Control Plane ENIs.
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.vpc\\"></a>
 
 \`\`\`typescript
-public readonly vpc: IVpc
+public readonly vpc: IVpc;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
@@ -46886,7 +46618,7 @@ The VPC in which to create the Cluster.
 ##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.vpcSubnets\\"></a>
 
 \`\`\`typescript
-public readonly vpcSubnets: SubnetSelection[]
+public readonly vpcSubnets: SubnetSelection[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)[]
@@ -46909,7 +46641,7 @@ vpcSubnets: [
 ##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.clusterHandlerEnvironment\\"></a>
 
 \`\`\`typescript
-public readonly clusterHandlerEnvironment: {[ key: string ]: string}
+public readonly clusterHandlerEnvironment: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -46922,7 +46654,7 @@ Custom environment variables when interacting with the EKS endpoint to manage th
 ##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.coreDnsComputeType\\"></a>
 
 \`\`\`typescript
-public readonly coreDnsComputeType: CoreDnsComputeType
+public readonly coreDnsComputeType: CoreDnsComputeType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CoreDnsComputeType\`](#aws-cdk-lib.aws_eks.CoreDnsComputeType)
@@ -46935,7 +46667,7 @@ Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS conf
 ##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.endpointAccess\\"></a>
 
 \`\`\`typescript
-public readonly endpointAccess: EndpointAccess
+public readonly endpointAccess: EndpointAccess;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
@@ -46950,7 +46682,7 @@ Configure access to the Kubernetes API server endpoint..
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.kubectlEnvironment\\"></a>
 
 \`\`\`typescript
-public readonly kubectlEnvironment: {[ key: string ]: string}
+public readonly kubectlEnvironment: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -46965,7 +46697,7 @@ Only relevant for kubectl enabled clusters.
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.kubectlLayer\\"></a>
 
 \`\`\`typescript
-public readonly kubectlLayer: ILayerVersion
+public readonly kubectlLayer: ILayerVersion;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
@@ -46996,7 +46728,7 @@ const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.kubectlMemory\\"></a>
 
 \`\`\`typescript
-public readonly kubectlMemory: Size
+public readonly kubectlMemory: Size;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
@@ -47009,7 +46741,7 @@ Amount of memory to allocate to the provider's lambda function.
 ##### \`mastersRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.mastersRole\\"></a>
 
 \`\`\`typescript
-public readonly mastersRole: IRole
+public readonly mastersRole: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -47025,7 +46757,7 @@ An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
 ##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.outputMastersRoleArn\\"></a>
 
 \`\`\`typescript
-public readonly outputMastersRoleArn: boolean
+public readonly outputMastersRoleArn: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -47038,7 +46770,7 @@ Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM
 ##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.placeClusterHandlerInVpc\\"></a>
 
 \`\`\`typescript
-public readonly placeClusterHandlerInVpc: boolean
+public readonly placeClusterHandlerInVpc: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -47051,7 +46783,7 @@ If set to true, the cluster handler functions will be placed in the private subn
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.prune\\"></a>
 
 \`\`\`typescript
-public readonly prune: boolean
+public readonly prune: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -47068,7 +46800,7 @@ when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
 ##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.secretsEncryptionKey\\"></a>
 
 \`\`\`typescript
-public readonly secretsEncryptionKey: IKey
+public readonly secretsEncryptionKey: IKey;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_kms.IKey\`](#aws-cdk-lib.aws_kms.IKey)
@@ -47083,7 +46815,7 @@ KMS secret for envelope encryption for Kubernetes secrets.
 ##### \`defaultProfile\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateClusterProps.property.defaultProfile\\"></a>
 
 \`\`\`typescript
-public readonly defaultProfile: FargateProfileOptions
+public readonly defaultProfile: FargateProfileOptions;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.FargateProfileOptions\`](#aws-cdk-lib.aws_eks.FargateProfileOptions)
@@ -47109,7 +46841,7 @@ const fargateProfileOptions: aws_eks.FargateProfileOptions = { ... }
 ##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.selectors\\"></a>
 
 \`\`\`typescript
-public readonly selectors: Selector[]
+public readonly selectors: Selector[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.Selector\`](#aws-cdk-lib.aws_eks.Selector)[]
@@ -47127,7 +46859,7 @@ At least one selector is required and you may specify up to five selectors.
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.fargateProfileName\\"></a>
 
 \`\`\`typescript
-public readonly fargateProfileName: string
+public readonly fargateProfileName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47140,7 +46872,7 @@ The name of the Fargate profile.
 ##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.podExecutionRole\\"></a>
 
 \`\`\`typescript
-public readonly podExecutionRole: IRole
+public readonly podExecutionRole: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -47159,7 +46891,7 @@ ECR image repositories.
 ##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.subnetSelection\\"></a>
 
 \`\`\`typescript
-public readonly subnetSelection: SubnetSelection
+public readonly subnetSelection: SubnetSelection;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
@@ -47176,7 +46908,7 @@ on Fargate are not assigned public IP addresses, so only private subnets
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileOptions.property.vpc\\"></a>
 
 \`\`\`typescript
-public readonly vpc: IVpc
+public readonly vpc: IVpc;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
@@ -47204,7 +46936,7 @@ const fargateProfileProps: aws_eks.FargateProfileProps = { ... }
 ##### \`selectors\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.selectors\\"></a>
 
 \`\`\`typescript
-public readonly selectors: Selector[]
+public readonly selectors: Selector[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.Selector\`](#aws-cdk-lib.aws_eks.Selector)[]
@@ -47222,7 +46954,7 @@ At least one selector is required and you may specify up to five selectors.
 ##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.fargateProfileName\\"></a>
 
 \`\`\`typescript
-public readonly fargateProfileName: string
+public readonly fargateProfileName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47235,7 +46967,7 @@ The name of the Fargate profile.
 ##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.podExecutionRole\\"></a>
 
 \`\`\`typescript
-public readonly podExecutionRole: IRole
+public readonly podExecutionRole: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -47254,7 +46986,7 @@ ECR image repositories.
 ##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.subnetSelection\\"></a>
 
 \`\`\`typescript
-public readonly subnetSelection: SubnetSelection
+public readonly subnetSelection: SubnetSelection;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
@@ -47271,7 +47003,7 @@ on Fargate are not assigned public IP addresses, so only private subnets
 ##### \`vpc\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.vpc\\"></a>
 
 \`\`\`typescript
-public readonly vpc: IVpc
+public readonly vpc: IVpc;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
@@ -47287,7 +47019,7 @@ By default, all private subnets are selected. You can customize this using
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.FargateProfileProps.property.cluster\\"></a>
 
 \`\`\`typescript
-public readonly cluster: Cluster
+public readonly cluster: Cluster;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.Cluster\`](#aws-cdk-lib.aws_eks.Cluster)
@@ -47313,7 +47045,7 @@ const helmChartOptions: aws_eks.HelmChartOptions = { ... }
 ##### \`chart\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.chart\\"></a>
 
 \`\`\`typescript
-public readonly chart: string
+public readonly chart: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47325,7 +47057,7 @@ The name of the chart.
 ##### \`createNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.createNamespace\\"></a>
 
 \`\`\`typescript
-public readonly createNamespace: boolean
+public readonly createNamespace: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -47338,7 +47070,7 @@ create namespace if not exist.
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.namespace\\"></a>
 
 \`\`\`typescript
-public readonly namespace: string
+public readonly namespace: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47351,7 +47083,7 @@ The Kubernetes namespace scope of the requests.
 ##### \`release\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.release\\"></a>
 
 \`\`\`typescript
-public readonly release: string
+public readonly release: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47364,7 +47096,7 @@ The name of the release.
 ##### \`repository\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.repository\\"></a>
 
 \`\`\`typescript
-public readonly repository: string
+public readonly repository: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47379,7 +47111,7 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.timeout\\"></a>
 
 \`\`\`typescript
-public readonly timeout: Duration
+public readonly timeout: Duration;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
@@ -47394,7 +47126,7 @@ Maximum 15 minutes.
 ##### \`values\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.values\\"></a>
 
 \`\`\`typescript
-public readonly values: {[ key: string ]: any}
+public readonly values: {[ key: string ]: any};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`any\`}
@@ -47407,7 +47139,7 @@ The values to be used by the chart.
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: string
+public readonly version: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47420,7 +47152,7 @@ The chart version to install.
 ##### \`wait\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartOptions.property.wait\\"></a>
 
 \`\`\`typescript
-public readonly wait: boolean
+public readonly wait: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -47445,7 +47177,7 @@ const helmChartProps: aws_eks.HelmChartProps = { ... }
 ##### \`chart\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.chart\\"></a>
 
 \`\`\`typescript
-public readonly chart: string
+public readonly chart: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47457,7 +47189,7 @@ The name of the chart.
 ##### \`createNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.createNamespace\\"></a>
 
 \`\`\`typescript
-public readonly createNamespace: boolean
+public readonly createNamespace: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -47470,7 +47202,7 @@ create namespace if not exist.
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.namespace\\"></a>
 
 \`\`\`typescript
-public readonly namespace: string
+public readonly namespace: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47483,7 +47215,7 @@ The Kubernetes namespace scope of the requests.
 ##### \`release\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.release\\"></a>
 
 \`\`\`typescript
-public readonly release: string
+public readonly release: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47496,7 +47228,7 @@ The name of the release.
 ##### \`repository\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.repository\\"></a>
 
 \`\`\`typescript
-public readonly repository: string
+public readonly repository: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47511,7 +47243,7 @@ For example: https://kubernetes-charts.storage.googleapis.com/
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.timeout\\"></a>
 
 \`\`\`typescript
-public readonly timeout: Duration
+public readonly timeout: Duration;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
@@ -47526,7 +47258,7 @@ Maximum 15 minutes.
 ##### \`values\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.values\\"></a>
 
 \`\`\`typescript
-public readonly values: {[ key: string ]: any}
+public readonly values: {[ key: string ]: any};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`any\`}
@@ -47539,7 +47271,7 @@ The values to be used by the chart.
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: string
+public readonly version: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47552,7 +47284,7 @@ The chart version to install.
 ##### \`wait\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.wait\\"></a>
 
 \`\`\`typescript
-public readonly wait: boolean
+public readonly wait: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -47565,7 +47297,7 @@ Whether or not Helm should wait until all Pods, PVCs, Services, and minimum numb
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.HelmChartProps.property.cluster\\"></a>
 
 \`\`\`typescript
-public readonly cluster: ICluster
+public readonly cluster: ICluster;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
@@ -47591,7 +47323,7 @@ const kubernetesManifestOptions: aws_eks.KubernetesManifestOptions = { ... }
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestOptions.property.prune\\"></a>
 
 \`\`\`typescript
-public readonly prune: boolean
+public readonly prune: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -47621,7 +47353,7 @@ empty.
 ##### \`skipValidation\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestOptions.property.skipValidation\\"></a>
 
 \`\`\`typescript
-public readonly skipValidation: boolean
+public readonly skipValidation: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -47646,7 +47378,7 @@ const kubernetesManifestProps: aws_eks.KubernetesManifestProps = { ... }
 ##### \`prune\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.prune\\"></a>
 
 \`\`\`typescript
-public readonly prune: boolean
+public readonly prune: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -47676,7 +47408,7 @@ empty.
 ##### \`skipValidation\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.skipValidation\\"></a>
 
 \`\`\`typescript
-public readonly skipValidation: boolean
+public readonly skipValidation: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -47689,7 +47421,7 @@ A flag to signify if the manifest validation should be skipped.
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.cluster\\"></a>
 
 \`\`\`typescript
-public readonly cluster: ICluster
+public readonly cluster: ICluster;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
@@ -47703,7 +47435,7 @@ The EKS cluster to apply this manifest to.
 ##### \`manifest\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.manifest\\"></a>
 
 \`\`\`typescript
-public readonly manifest: {[ key: string ]: any}[]
+public readonly manifest: {[ key: string ]: any}[];
 \`\`\`
 
 - *Type:* {[ key: string ]: \`any\`}[]
@@ -47721,7 +47453,7 @@ deleted, the resources in the manifest will be deleted through \`kubectl delete\
 ##### \`overwrite\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesManifestProps.property.overwrite\\"></a>
 
 \`\`\`typescript
-public readonly overwrite: boolean
+public readonly overwrite: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -47750,7 +47482,7 @@ const kubernetesNetworkConfigProperty: aws_eks.CfnCluster.KubernetesNetworkConfi
 ##### \`serviceIpv4Cidr\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.KubernetesNetworkConfigProperty.property.serviceIpv4Cidr\\"></a>
 
 \`\`\`typescript
-public readonly serviceIpv4Cidr: string
+public readonly serviceIpv4Cidr: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47776,7 +47508,7 @@ const kubernetesObjectValueProps: aws_eks.KubernetesObjectValueProps = { ... }
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.cluster\\"></a>
 
 \`\`\`typescript
-public readonly cluster: ICluster
+public readonly cluster: ICluster;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
@@ -47790,7 +47522,7 @@ The EKS cluster to fetch attributes from.
 ##### \`jsonPath\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.jsonPath\\"></a>
 
 \`\`\`typescript
-public readonly jsonPath: string
+public readonly jsonPath: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47804,7 +47536,7 @@ JSONPath to the specific value.
 ##### \`objectName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.objectName\\"></a>
 
 \`\`\`typescript
-public readonly objectName: string
+public readonly objectName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47816,7 +47548,7 @@ The name of the object to query.
 ##### \`objectType\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.objectType\\"></a>
 
 \`\`\`typescript
-public readonly objectType: string
+public readonly objectType: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47830,7 +47562,7 @@ The object type to query.
 ##### \`objectNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.objectNamespace\\"></a>
 
 \`\`\`typescript
-public readonly objectNamespace: string
+public readonly objectNamespace: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47843,7 +47575,7 @@ The namespace the object belongs to.
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesObjectValueProps.property.timeout\\"></a>
 
 \`\`\`typescript
-public readonly timeout: Duration
+public readonly timeout: Duration;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
@@ -47868,7 +47600,7 @@ const kubernetesPatchProps: aws_eks.KubernetesPatchProps = { ... }
 ##### \`applyPatch\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.applyPatch\\"></a>
 
 \`\`\`typescript
-public readonly applyPatch: {[ key: string ]: any}
+public readonly applyPatch: {[ key: string ]: any};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`any\`}
@@ -47880,7 +47612,7 @@ The JSON object to pass to \`kubectl patch\` when the resource is created/update
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.cluster\\"></a>
 
 \`\`\`typescript
-public readonly cluster: ICluster
+public readonly cluster: ICluster;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
@@ -47894,7 +47626,7 @@ The cluster to apply the patch to.
 ##### \`resourceName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.resourceName\\"></a>
 
 \`\`\`typescript
-public readonly resourceName: string
+public readonly resourceName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47906,7 +47638,7 @@ The full name of the resource to patch (e.g. \`deployment/coredns\`).
 ##### \`restorePatch\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.restorePatch\\"></a>
 
 \`\`\`typescript
-public readonly restorePatch: {[ key: string ]: any}
+public readonly restorePatch: {[ key: string ]: any};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`any\`}
@@ -47918,7 +47650,7 @@ The JSON object to pass to \`kubectl patch\` when the resource is removed.
 ##### \`patchType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.patchType\\"></a>
 
 \`\`\`typescript
-public readonly patchType: PatchType
+public readonly patchType: PatchType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.PatchType\`](#aws-cdk-lib.aws_eks.PatchType)
@@ -47933,7 +47665,7 @@ The default type used by \`kubectl patch\` is \\"strategic\\".
 ##### \`resourceNamespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesPatchProps.property.resourceNamespace\\"></a>
 
 \`\`\`typescript
-public readonly resourceNamespace: string
+public readonly resourceNamespace: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47958,7 +47690,7 @@ const labelProperty: aws_eks.CfnFargateProfile.LabelProperty = { ... }
 ##### \`key\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty.property.key\\"></a>
 
 \`\`\`typescript
-public readonly key: string
+public readonly key: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47972,7 +47704,7 @@ public readonly key: string
 ##### \`value\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty.property.value\\"></a>
 
 \`\`\`typescript
-public readonly value: string
+public readonly value: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -47998,7 +47730,7 @@ const launchTemplateSpec: aws_eks.LaunchTemplateSpec = { ... }
 ##### \`id\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.LaunchTemplateSpec.property.id\\"></a>
 
 \`\`\`typescript
-public readonly id: string
+public readonly id: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48010,7 +47742,7 @@ The Launch template ID.
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.LaunchTemplateSpec.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: string
+public readonly version: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48035,7 +47767,7 @@ const launchTemplateSpecificationProperty: aws_eks.CfnNodegroup.LaunchTemplateSp
 ##### \`id\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.id\\"></a>
 
 \`\`\`typescript
-public readonly id: string
+public readonly id: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48049,7 +47781,7 @@ public readonly id: string
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.name\\"></a>
 
 \`\`\`typescript
-public readonly name: string
+public readonly name: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48063,7 +47795,7 @@ public readonly name: string
 ##### \`version\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: string
+public readonly version: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48089,7 +47821,7 @@ const nodegroupOptions: aws_eks.NodegroupOptions = { ... }
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.amiType\\"></a>
 
 \`\`\`typescript
-public readonly amiType: NodegroupAmiType
+public readonly amiType: NodegroupAmiType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupAmiType\`](#aws-cdk-lib.aws_eks.NodegroupAmiType)
@@ -48102,7 +47834,7 @@ The AMI type for your node group.
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.capacityType\\"></a>
 
 \`\`\`typescript
-public readonly capacityType: CapacityType
+public readonly capacityType: CapacityType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CapacityType\`](#aws-cdk-lib.aws_eks.CapacityType)
@@ -48115,7 +47847,7 @@ The capacity type of the nodegroup.
 ##### \`desiredSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.desiredSize\\"></a>
 
 \`\`\`typescript
-public readonly desiredSize: number
+public readonly desiredSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -48131,7 +47863,7 @@ the nodewgroup will initially create \`minSize\` instances.
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.diskSize\\"></a>
 
 \`\`\`typescript
-public readonly diskSize: number
+public readonly diskSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -48144,7 +47876,7 @@ The root device disk size (in GiB) for your node group instances.
 ##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.forceUpdate\\"></a>
 
 \`\`\`typescript
-public readonly forceUpdate: boolean
+public readonly forceUpdate: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -48161,7 +47893,7 @@ running on the node.
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.instanceTypes\\"></a>
 
 \`\`\`typescript
-public readonly instanceTypes: InstanceType[]
+public readonly instanceTypes: InstanceType[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.InstanceType\`](#aws-cdk-lib.aws_ec2.InstanceType)[]
@@ -48176,7 +47908,7 @@ The instance types to use for your node group.
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.labels\\"></a>
 
 \`\`\`typescript
-public readonly labels: {[ key: string ]: string}
+public readonly labels: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -48189,7 +47921,7 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 ##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.launchTemplateSpec\\"></a>
 
 \`\`\`typescript
-public readonly launchTemplateSpec: LaunchTemplateSpec
+public readonly launchTemplateSpec: LaunchTemplateSpec;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.LaunchTemplateSpec\`](#aws-cdk-lib.aws_eks.LaunchTemplateSpec)
@@ -48204,7 +47936,7 @@ Launch template specification used for the nodegroup.
 ##### \`maxSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.maxSize\\"></a>
 
 \`\`\`typescript
-public readonly maxSize: number
+public readonly maxSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -48219,7 +47951,7 @@ Managed node groups can support up to 100 nodes by default.
 ##### \`minSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.minSize\\"></a>
 
 \`\`\`typescript
-public readonly minSize: number
+public readonly minSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -48234,7 +47966,7 @@ This number must be greater than zero.
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.nodegroupName\\"></a>
 
 \`\`\`typescript
-public readonly nodegroupName: string
+public readonly nodegroupName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48247,7 +47979,7 @@ Name of the Nodegroup.
 ##### \`nodeRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.nodeRole\\"></a>
 
 \`\`\`typescript
-public readonly nodeRole: IRole
+public readonly nodeRole: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -48265,7 +47997,7 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.releaseVersion\\"></a>
 
 \`\`\`typescript
-public readonly releaseVersion: string
+public readonly releaseVersion: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48278,7 +48010,7 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.remoteAccess\\"></a>
 
 \`\`\`typescript
-public readonly remoteAccess: NodegroupRemoteAccess
+public readonly remoteAccess: NodegroupRemoteAccess;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupRemoteAccess\`](#aws-cdk-lib.aws_eks.NodegroupRemoteAccess)
@@ -48295,7 +48027,7 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.subnets\\"></a>
 
 \`\`\`typescript
-public readonly subnets: SubnetSelection
+public readonly subnets: SubnetSelection;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
@@ -48313,7 +48045,7 @@ the name of your cluster.
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupOptions.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: {[ key: string ]: string}
+public readonly tags: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -48342,7 +48074,7 @@ const nodegroupProps: aws_eks.NodegroupProps = { ... }
 ##### \`amiType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.amiType\\"></a>
 
 \`\`\`typescript
-public readonly amiType: NodegroupAmiType
+public readonly amiType: NodegroupAmiType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupAmiType\`](#aws-cdk-lib.aws_eks.NodegroupAmiType)
@@ -48355,7 +48087,7 @@ The AMI type for your node group.
 ##### \`capacityType\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.capacityType\\"></a>
 
 \`\`\`typescript
-public readonly capacityType: CapacityType
+public readonly capacityType: CapacityType;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.CapacityType\`](#aws-cdk-lib.aws_eks.CapacityType)
@@ -48368,7 +48100,7 @@ The capacity type of the nodegroup.
 ##### \`desiredSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.desiredSize\\"></a>
 
 \`\`\`typescript
-public readonly desiredSize: number
+public readonly desiredSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -48384,7 +48116,7 @@ the nodewgroup will initially create \`minSize\` instances.
 ##### \`diskSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.diskSize\\"></a>
 
 \`\`\`typescript
-public readonly diskSize: number
+public readonly diskSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -48397,7 +48129,7 @@ The root device disk size (in GiB) for your node group instances.
 ##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.forceUpdate\\"></a>
 
 \`\`\`typescript
-public readonly forceUpdate: boolean
+public readonly forceUpdate: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -48414,7 +48146,7 @@ running on the node.
 ##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.instanceTypes\\"></a>
 
 \`\`\`typescript
-public readonly instanceTypes: InstanceType[]
+public readonly instanceTypes: InstanceType[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.InstanceType\`](#aws-cdk-lib.aws_ec2.InstanceType)[]
@@ -48429,7 +48161,7 @@ The instance types to use for your node group.
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.labels\\"></a>
 
 \`\`\`typescript
-public readonly labels: {[ key: string ]: string}
+public readonly labels: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -48442,7 +48174,7 @@ The Kubernetes labels to be applied to the nodes in the node group when they are
 ##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.launchTemplateSpec\\"></a>
 
 \`\`\`typescript
-public readonly launchTemplateSpec: LaunchTemplateSpec
+public readonly launchTemplateSpec: LaunchTemplateSpec;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.LaunchTemplateSpec\`](#aws-cdk-lib.aws_eks.LaunchTemplateSpec)
@@ -48457,7 +48189,7 @@ Launch template specification used for the nodegroup.
 ##### \`maxSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.maxSize\\"></a>
 
 \`\`\`typescript
-public readonly maxSize: number
+public readonly maxSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -48472,7 +48204,7 @@ Managed node groups can support up to 100 nodes by default.
 ##### \`minSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.minSize\\"></a>
 
 \`\`\`typescript
-public readonly minSize: number
+public readonly minSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -48487,7 +48219,7 @@ This number must be greater than zero.
 ##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.nodegroupName\\"></a>
 
 \`\`\`typescript
-public readonly nodegroupName: string
+public readonly nodegroupName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48500,7 +48232,7 @@ Name of the Nodegroup.
 ##### \`nodeRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.nodeRole\\"></a>
 
 \`\`\`typescript
-public readonly nodeRole: IRole
+public readonly nodeRole: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -48518,7 +48250,7 @@ into a cluster, you must create an IAM role for those worker nodes to use when t
 ##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.releaseVersion\\"></a>
 
 \`\`\`typescript
-public readonly releaseVersion: string
+public readonly releaseVersion: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48531,7 +48263,7 @@ The AMI version of the Amazon EKS-optimized AMI to use with your node group (for
 ##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.remoteAccess\\"></a>
 
 \`\`\`typescript
-public readonly remoteAccess: NodegroupRemoteAccess
+public readonly remoteAccess: NodegroupRemoteAccess;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.NodegroupRemoteAccess\`](#aws-cdk-lib.aws_eks.NodegroupRemoteAccess)
@@ -48548,7 +48280,7 @@ then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
 ##### \`subnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.subnets\\"></a>
 
 \`\`\`typescript
-public readonly subnets: SubnetSelection
+public readonly subnets: SubnetSelection;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.SubnetSelection\`](#aws-cdk-lib.aws_ec2.SubnetSelection)
@@ -48566,7 +48298,7 @@ the name of your cluster.
 ##### \`tags\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: {[ key: string ]: string}
+public readonly tags: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -48583,7 +48315,7 @@ associated with the node group, such as the Amazon EC2 instances or subnets.
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupProps.property.cluster\\"></a>
 
 \`\`\`typescript
-public readonly cluster: ICluster
+public readonly cluster: ICluster;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
@@ -48609,7 +48341,7 @@ const nodegroupRemoteAccess: aws_eks.NodegroupRemoteAccess = { ... }
 ##### \`sshKeyName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupRemoteAccess.property.sshKeyName\\"></a>
 
 \`\`\`typescript
-public readonly sshKeyName: string
+public readonly sshKeyName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48621,7 +48353,7 @@ The Amazon EC2 SSH key that provides access for SSH communication with the worke
 ##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.NodegroupRemoteAccess.property.sourceSecurityGroups\\"></a>
 
 \`\`\`typescript
-public readonly sourceSecurityGroups: ISecurityGroup[]
+public readonly sourceSecurityGroups: ISecurityGroup[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)[]
@@ -48650,7 +48382,7 @@ const openIdConnectProviderProps: aws_eks.OpenIdConnectProviderProps = { ... }
 ##### \`url\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.OpenIdConnectProviderProps.property.url\\"></a>
 
 \`\`\`typescript
-public readonly url: string
+public readonly url: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48683,7 +48415,7 @@ const providerProperty: aws_eks.CfnCluster.ProviderProperty = { ... }
 ##### \`keyArn\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.ProviderProperty.property.keyArn\\"></a>
 
 \`\`\`typescript
-public readonly keyArn: string
+public readonly keyArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48709,7 +48441,7 @@ const remoteAccessProperty: aws_eks.CfnNodegroup.RemoteAccessProperty = { ... }
 ##### \`ec2SshKey\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty.property.ec2SshKey\\"></a>
 
 \`\`\`typescript
-public readonly ec2SshKey: string
+public readonly ec2SshKey: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48723,7 +48455,7 @@ public readonly ec2SshKey: string
 ##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.RemoteAccessProperty.property.sourceSecurityGroups\\"></a>
 
 \`\`\`typescript
-public readonly sourceSecurityGroups: string[]
+public readonly sourceSecurityGroups: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -48749,7 +48481,7 @@ const resourcesVpcConfigProperty: aws_eks.CfnCluster.ResourcesVpcConfigProperty 
 ##### \`subnetIds\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty.property.subnetIds\\"></a>
 
 \`\`\`typescript
-public readonly subnetIds: string[]
+public readonly subnetIds: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -48763,7 +48495,7 @@ public readonly subnetIds: string[]
 ##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnCluster.ResourcesVpcConfigProperty.property.securityGroupIds\\"></a>
 
 \`\`\`typescript
-public readonly securityGroupIds: string[]
+public readonly securityGroupIds: string[];
 \`\`\`
 
 - *Type:* \`string\`[]
@@ -48789,7 +48521,7 @@ const scalingConfigProperty: aws_eks.CfnNodegroup.ScalingConfigProperty = { ... 
 ##### \`desiredSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty.property.desiredSize\\"></a>
 
 \`\`\`typescript
-public readonly desiredSize: number
+public readonly desiredSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -48803,7 +48535,7 @@ public readonly desiredSize: number
 ##### \`maxSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty.property.maxSize\\"></a>
 
 \`\`\`typescript
-public readonly maxSize: number
+public readonly maxSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -48817,7 +48549,7 @@ public readonly maxSize: number
 ##### \`minSize\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.ScalingConfigProperty.property.minSize\\"></a>
 
 \`\`\`typescript
-public readonly minSize: number
+public readonly minSize: number;
 \`\`\`
 
 - *Type:* \`number\`
@@ -48843,7 +48575,7 @@ const selector: aws_eks.Selector = { ... }
 ##### \`namespace\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.Selector.property.namespace\\"></a>
 
 \`\`\`typescript
-public readonly namespace: string
+public readonly namespace: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48859,7 +48591,7 @@ to target multiple namespaces.
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.Selector.property.labels\\"></a>
 
 \`\`\`typescript
-public readonly labels: {[ key: string ]: string}
+public readonly labels: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -48888,7 +48620,7 @@ const selectorProperty: aws_eks.CfnFargateProfile.SelectorProperty = { ... }
 ##### \`namespace\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty.property.namespace\\"></a>
 
 \`\`\`typescript
-public readonly namespace: string
+public readonly namespace: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48902,7 +48634,7 @@ public readonly namespace: string
 ##### \`labels\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnFargateProfile.SelectorProperty.property.labels\\"></a>
 
 \`\`\`typescript
-public readonly labels: IResolvable | LabelProperty | IResolvable[]
+public readonly labels: IResolvable | LabelProperty | IResolvable[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable) | [\`aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty\`](#aws-cdk-lib.aws_eks.CfnFargateProfile.LabelProperty) | [\`aws-cdk-lib.IResolvable\`](#aws-cdk-lib.IResolvable)[]
@@ -48928,7 +48660,7 @@ const serviceAccountOptions: aws_eks.ServiceAccountOptions = { ... }
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountOptions.property.name\\"></a>
 
 \`\`\`typescript
-public readonly name: string
+public readonly name: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48941,7 +48673,7 @@ The name of the service account.
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountOptions.property.namespace\\"></a>
 
 \`\`\`typescript
-public readonly namespace: string
+public readonly namespace: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48966,7 +48698,7 @@ const serviceAccountProps: aws_eks.ServiceAccountProps = { ... }
 ##### \`name\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountProps.property.name\\"></a>
 
 \`\`\`typescript
-public readonly name: string
+public readonly name: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48979,7 +48711,7 @@ The name of the service account.
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountProps.property.namespace\\"></a>
 
 \`\`\`typescript
-public readonly namespace: string
+public readonly namespace: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -48992,7 +48724,7 @@ The namespace of the service account.
 ##### \`cluster\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceAccountProps.property.cluster\\"></a>
 
 \`\`\`typescript
-public readonly cluster: ICluster
+public readonly cluster: ICluster;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.ICluster\`](#aws-cdk-lib.aws_eks.ICluster)
@@ -49016,7 +48748,7 @@ const serviceLoadBalancerAddressOptions: aws_eks.ServiceLoadBalancerAddressOptio
 ##### \`namespace\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceLoadBalancerAddressOptions.property.namespace\\"></a>
 
 \`\`\`typescript
-public readonly namespace: string
+public readonly namespace: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -49029,7 +48761,7 @@ The namespace the service belongs to.
 ##### \`timeout\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ServiceLoadBalancerAddressOptions.property.timeout\\"></a>
 
 \`\`\`typescript
-public readonly timeout: Duration
+public readonly timeout: Duration;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Duration\`](#aws-cdk-lib.Duration)
@@ -49054,7 +48786,7 @@ const taintProperty: aws_eks.CfnNodegroup.TaintProperty = { ... }
 ##### \`effect\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty.property.effect\\"></a>
 
 \`\`\`typescript
-public readonly effect: string
+public readonly effect: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -49068,7 +48800,7 @@ public readonly effect: string
 ##### \`key\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty.property.key\\"></a>
 
 \`\`\`typescript
-public readonly key: string
+public readonly key: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -49082,7 +48814,7 @@ public readonly key: string
 ##### \`value\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.CfnNodegroup.TaintProperty.property.value\\"></a>
 
 \`\`\`typescript
-public readonly value: string
+public readonly value: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -49158,10 +48890,6 @@ CIDR blocks.
 
 ##### \`PRIVATE\` <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.property.PRIVATE\\"></a>
 
-\`\`\`typescript
-public readonly PRIVATE: EndpointAccess
-\`\`\`
-
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 
 The cluster endpoint is only accessible through your VPC.
@@ -49171,10 +48899,6 @@ Worker node traffic to the endpoint will stay within your VPC.
 ---
 
 ##### \`PUBLIC\` <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.property.PUBLIC\\"></a>
-
-\`\`\`typescript
-public readonly PUBLIC: EndpointAccess
-\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 
@@ -49190,10 +48914,6 @@ access the public endpoint from.
 ---
 
 ##### \`PUBLIC_AND_PRIVATE\` <a name=\\"aws-cdk-lib.aws_eks.EndpointAccess.property.PUBLIC_AND_PRIVATE\\"></a>
-
-\`\`\`typescript
-public readonly PUBLIC_AND_PRIVATE: EndpointAccess
-\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.EndpointAccess\`](#aws-cdk-lib.aws_eks.EndpointAccess)
 
@@ -49236,7 +48956,7 @@ custom version number.
 ##### \`version\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.version\\"></a>
 
 \`\`\`typescript
-public readonly version: string
+public readonly version: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -49249,10 +48969,6 @@ cluster version number.
 
 ##### \`V1_14\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_14\\"></a>
 
-\`\`\`typescript
-public readonly V1_14: KubernetesVersion
-\`\`\`
-
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
 Kubernetes version 1.14.
@@ -49260,10 +48976,6 @@ Kubernetes version 1.14.
 ---
 
 ##### \`V1_15\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_15\\"></a>
-
-\`\`\`typescript
-public readonly V1_15: KubernetesVersion
-\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -49273,10 +48985,6 @@ Kubernetes version 1.15.
 
 ##### \`V1_16\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_16\\"></a>
 
-\`\`\`typescript
-public readonly V1_16: KubernetesVersion
-\`\`\`
-
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
 Kubernetes version 1.16.
@@ -49284,10 +48992,6 @@ Kubernetes version 1.16.
 ---
 
 ##### \`V1_17\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_17\\"></a>
-
-\`\`\`typescript
-public readonly V1_17: KubernetesVersion
-\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -49297,10 +49001,6 @@ Kubernetes version 1.17.
 
 ##### \`V1_18\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_18\\"></a>
 
-\`\`\`typescript
-public readonly V1_18: KubernetesVersion
-\`\`\`
-
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
 Kubernetes version 1.18.
@@ -49308,10 +49008,6 @@ Kubernetes version 1.18.
 ---
 
 ##### \`V1_19\` <a name=\\"aws-cdk-lib.aws_eks.KubernetesVersion.property.V1_19\\"></a>
-
-\`\`\`typescript
-public readonly V1_19: KubernetesVersion
-\`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_eks.KubernetesVersion\`](#aws-cdk-lib.aws_eks.KubernetesVersion)
 
@@ -49424,7 +49120,7 @@ service account options.
 ##### \`node\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.node\\"></a>
 
 \`\`\`typescript
-public readonly node: Node
+public readonly node: Node;
 \`\`\`
 
 - *Type:* [\`constructs.Node\`](#constructs.Node)
@@ -49436,7 +49132,7 @@ The tree node.
 ##### \`env\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.env\\"></a>
 
 \`\`\`typescript
-public readonly env: ResourceEnvironment
+public readonly env: ResourceEnvironment;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.ResourceEnvironment\`](#aws-cdk-lib.ResourceEnvironment)
@@ -49455,7 +49151,7 @@ that might be different than the stack they were imported into.
 ##### \`stack\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.stack\\"></a>
 
 \`\`\`typescript
-public readonly stack: Stack
+public readonly stack: Stack;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Stack\`](#aws-cdk-lib.Stack)
@@ -49467,7 +49163,7 @@ The stack in which this resource is defined.
 ##### \`connections\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.connections\\"></a>
 
 \`\`\`typescript
-public readonly connections: Connections
+public readonly connections: Connections;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.Connections\`](#aws-cdk-lib.aws_ec2.Connections)
@@ -49477,7 +49173,7 @@ public readonly connections: Connections
 ##### \`clusterArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterArn\\"></a>
 
 \`\`\`typescript
-public readonly clusterArn: string
+public readonly clusterArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -49489,7 +49185,7 @@ The unique ARN assigned to the service by AWS in the form of arn:aws:eks:.
 ##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterCertificateAuthorityData\\"></a>
 
 \`\`\`typescript
-public readonly clusterCertificateAuthorityData: string
+public readonly clusterCertificateAuthorityData: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -49501,7 +49197,7 @@ The certificate-authority-data for your cluster.
 ##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterEncryptionConfigKeyArn\\"></a>
 
 \`\`\`typescript
-public readonly clusterEncryptionConfigKeyArn: string
+public readonly clusterEncryptionConfigKeyArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -49513,7 +49209,7 @@ Amazon Resource Name (ARN) or alias of the customer master key (CMK).
 ##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterEndpoint\\"></a>
 
 \`\`\`typescript
-public readonly clusterEndpoint: string
+public readonly clusterEndpoint: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -49525,7 +49221,7 @@ The API Server endpoint URL.
 ##### \`clusterName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterName\\"></a>
 
 \`\`\`typescript
-public readonly clusterName: string
+public readonly clusterName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -49537,7 +49233,7 @@ The physical name of the Cluster.
 ##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterSecurityGroup\\"></a>
 
 \`\`\`typescript
-public readonly clusterSecurityGroup: ISecurityGroup
+public readonly clusterSecurityGroup: ISecurityGroup;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
@@ -49549,7 +49245,7 @@ The cluster security group that was created by Amazon EKS for the cluster.
 ##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.clusterSecurityGroupId\\"></a>
 
 \`\`\`typescript
-public readonly clusterSecurityGroupId: string
+public readonly clusterSecurityGroupId: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -49561,7 +49257,7 @@ The id of the cluster security group that was created by Amazon EKS for the clus
 ##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.openIdConnectProvider\\"></a>
 
 \`\`\`typescript
-public readonly openIdConnectProvider: IOpenIdConnectProvider
+public readonly openIdConnectProvider: IOpenIdConnectProvider;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IOpenIdConnectProvider\`](#aws-cdk-lib.aws_iam.IOpenIdConnectProvider)
@@ -49573,7 +49269,7 @@ The Open ID Connect Provider of the cluster used to configure Service Accounts.
 ##### \`prune\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.prune\\"></a>
 
 \`\`\`typescript
-public readonly prune: boolean
+public readonly prune: boolean;
 \`\`\`
 
 - *Type:* \`boolean\`
@@ -49590,7 +49286,7 @@ apply\` operation with the \`--prune\` switch.
 ##### \`vpc\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.vpc\\"></a>
 
 \`\`\`typescript
-public readonly vpc: IVpc
+public readonly vpc: IVpc;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.IVpc\`](#aws-cdk-lib.aws_ec2.IVpc)
@@ -49602,7 +49298,7 @@ The VPC in which this Cluster was created.
 ##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlEnvironment\\"></a>
 
 \`\`\`typescript
-public readonly kubectlEnvironment: {[ key: string ]: string}
+public readonly kubectlEnvironment: {[ key: string ]: string};
 \`\`\`
 
 - *Type:* {[ key: string ]: \`string\`}
@@ -49614,7 +49310,7 @@ Custom environment variables when running \`kubectl\` against this cluster.
 ##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlLayer\\"></a>
 
 \`\`\`typescript
-public readonly kubectlLayer: ILayerVersion
+public readonly kubectlLayer: ILayerVersion;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_lambda.ILayerVersion\`](#aws-cdk-lib.aws_lambda.ILayerVersion)
@@ -49628,7 +49324,7 @@ If not defined, a default layer will be used.
 ##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlMemory\\"></a>
 
 \`\`\`typescript
-public readonly kubectlMemory: Size
+public readonly kubectlMemory: Size;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Size\`](#aws-cdk-lib.Size)
@@ -49640,7 +49336,7 @@ Amount of memory to allocate to the provider's lambda function.
 ##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlPrivateSubnets\\"></a>
 
 \`\`\`typescript
-public readonly kubectlPrivateSubnets: ISubnet[]
+public readonly kubectlPrivateSubnets: ISubnet[];
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISubnet\`](#aws-cdk-lib.aws_ec2.ISubnet)[]
@@ -49655,7 +49351,7 @@ publicly.
 ##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlRole\\"></a>
 
 \`\`\`typescript
-public readonly kubectlRole: IRole
+public readonly kubectlRole: IRole;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_iam.IRole\`](#aws-cdk-lib.aws_iam.IRole)
@@ -49669,7 +49365,7 @@ The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
 ##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"aws-cdk-lib.aws_eks.ICluster.property.kubectlSecurityGroup\\"></a>
 
 \`\`\`typescript
-public readonly kubectlSecurityGroup: ISecurityGroup
+public readonly kubectlSecurityGroup: ISecurityGroup;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.aws_ec2.ISecurityGroup\`](#aws-cdk-lib.aws_ec2.ISecurityGroup)
@@ -49695,7 +49391,7 @@ NodeGroup interface.
 ##### \`node\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.property.node\\"></a>
 
 \`\`\`typescript
-public readonly node: Node
+public readonly node: Node;
 \`\`\`
 
 - *Type:* [\`constructs.Node\`](#constructs.Node)
@@ -49707,7 +49403,7 @@ The tree node.
 ##### \`env\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.property.env\\"></a>
 
 \`\`\`typescript
-public readonly env: ResourceEnvironment
+public readonly env: ResourceEnvironment;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.ResourceEnvironment\`](#aws-cdk-lib.ResourceEnvironment)
@@ -49726,7 +49422,7 @@ that might be different than the stack they were imported into.
 ##### \`stack\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.property.stack\\"></a>
 
 \`\`\`typescript
-public readonly stack: Stack
+public readonly stack: Stack;
 \`\`\`
 
 - *Type:* [\`aws-cdk-lib.Stack\`](#aws-cdk-lib.Stack)
@@ -49738,7 +49434,7 @@ The stack in which this resource is defined.
 ##### \`nodegroupName\`<sup>Required</sup> <a name=\\"aws-cdk-lib.aws_eks.INodegroup.property.nodegroupName\\"></a>
 
 \`\`\`typescript
-public readonly nodegroupName: string
+public readonly nodegroupName: string;
 \`\`\`
 
 - *Type:* \`string\`

--- a/test/docgen/view/__snapshots__/interface.test.ts.snap
+++ b/test/docgen/view/__snapshots__/interface.test.ts.snap
@@ -187,6 +187,10 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 ## \`node\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.node\\"></a>
 
+\`\`\`java
+public ConstructNode getNode()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.ConstructNode\`](#software.amazon.awscdk.core.ConstructNode)
 
 The construct tree node for this construct.
@@ -194,6 +198,10 @@ The construct tree node for this construct.
 ---
 
 ## \`env\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.env\\"></a>
+
+\`\`\`java
+public ResourceEnvironment getEnv()
+\`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.ResourceEnvironment\`](#software.amazon.awscdk.core.ResourceEnvironment)
 
@@ -210,6 +218,10 @@ that might be different than the stack they were imported into.
 
 ## \`stack\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.stack\\"></a>
 
+\`\`\`java
+public Stack getStack()
+\`\`\`
+
 - *Type:* [\`software.amazon.awscdk.core.Stack\`](#software.amazon.awscdk.core.Stack)
 
 The stack in which this resource is defined.
@@ -217,6 +229,10 @@ The stack in which this resource is defined.
 ---
 
 ## \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryArn\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryArn()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -226,6 +242,10 @@ The ARN of the repository.
 
 ## \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryName\\"></a>
 
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
+
 - *Type:* \`java.lang.String\`
 
 The name of the repository.
@@ -233,6 +253,10 @@ The name of the repository.
 ---
 
 ## \`repositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryUri\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryUri()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -622,6 +646,10 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 ## \`node\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.node\\"></a>
 
+\`\`\`python
+node: ConstructNode
+\`\`\`
+
 - *Type:* [\`aws_cdk.core.ConstructNode\`](#aws_cdk.core.ConstructNode)
 
 The construct tree node for this construct.
@@ -629,6 +657,10 @@ The construct tree node for this construct.
 ---
 
 ## \`env\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.env\\"></a>
+
+\`\`\`python
+env: ResourceEnvironment
+\`\`\`
 
 - *Type:* [\`aws_cdk.core.ResourceEnvironment\`](#aws_cdk.core.ResourceEnvironment)
 
@@ -645,6 +677,10 @@ that might be different than the stack they were imported into.
 
 ## \`stack\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.stack\\"></a>
 
+\`\`\`python
+stack: Stack
+\`\`\`
+
 - *Type:* [\`aws_cdk.core.Stack\`](#aws_cdk.core.Stack)
 
 The stack in which this resource is defined.
@@ -652,6 +688,10 @@ The stack in which this resource is defined.
 ---
 
 ## \`repository_arn\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_arn\\"></a>
+
+\`\`\`python
+repository_arn: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -661,6 +701,10 @@ The ARN of the repository.
 
 ## \`repository_name\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_name\\"></a>
 
+\`\`\`python
+repository_name: str
+\`\`\`
+
 - *Type:* \`str\`
 
 The name of the repository.
@@ -668,6 +712,10 @@ The name of the repository.
 ---
 
 ## \`repository_uri\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.IRepository.property.repository_uri\\"></a>
+
+\`\`\`python
+repository_uri: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -860,6 +908,10 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 
 ## \`node\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.node\\"></a>
 
+\`\`\`typescript
+public readonly node: ConstructNode
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.ConstructNode\`](#@aws-cdk/core.ConstructNode)
 
 The construct tree node for this construct.
@@ -867,6 +919,10 @@ The construct tree node for this construct.
 ---
 
 ## \`env\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.env\\"></a>
+
+\`\`\`typescript
+public readonly env: ResourceEnvironment
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.ResourceEnvironment\`](#@aws-cdk/core.ResourceEnvironment)
 
@@ -883,6 +939,10 @@ that might be different than the stack they were imported into.
 
 ## \`stack\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.stack\\"></a>
 
+\`\`\`typescript
+public readonly stack: Stack
+\`\`\`
+
 - *Type:* [\`@aws-cdk/core.Stack\`](#@aws-cdk/core.Stack)
 
 The stack in which this resource is defined.
@@ -890,6 +950,10 @@ The stack in which this resource is defined.
 ---
 
 ## \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryArn\\"></a>
+
+\`\`\`typescript
+public readonly repositoryArn: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -899,6 +963,10 @@ The ARN of the repository.
 
 ## \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryName\\"></a>
 
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
+
 - *Type:* \`string\`
 
 The name of the repository.
@@ -906,6 +974,10 @@ The name of the repository.
 ---
 
 ## \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryUri\\"></a>
+
+\`\`\`typescript
+public readonly repositoryUri: string
+\`\`\`
 
 - *Type:* \`string\`
 

--- a/test/docgen/view/__snapshots__/interface.test.ts.snap
+++ b/test/docgen/view/__snapshots__/interface.test.ts.snap
@@ -188,7 +188,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 ## \`node\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.node\\"></a>
 
 \`\`\`java
-public ConstructNode getNode()
+public ConstructNode getNode();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.ConstructNode\`](#software.amazon.awscdk.core.ConstructNode)
@@ -200,7 +200,7 @@ The construct tree node for this construct.
 ## \`env\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.env\\"></a>
 
 \`\`\`java
-public ResourceEnvironment getEnv()
+public ResourceEnvironment getEnv();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.ResourceEnvironment\`](#software.amazon.awscdk.core.ResourceEnvironment)
@@ -219,7 +219,7 @@ that might be different than the stack they were imported into.
 ## \`stack\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.stack\\"></a>
 
 \`\`\`java
-public Stack getStack()
+public Stack getStack();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.core.Stack\`](#software.amazon.awscdk.core.Stack)
@@ -231,7 +231,7 @@ The stack in which this resource is defined.
 ## \`repositoryArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryArn\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryArn()
+public java.lang.String getRepositoryArn();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -243,7 +243,7 @@ The ARN of the repository.
 ## \`repositoryName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -255,7 +255,7 @@ The name of the repository.
 ## \`repositoryUri\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.IRepository.property.repositoryUri\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryUri()
+public java.lang.String getRepositoryUri();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -909,7 +909,7 @@ Image tag to use (tools usually default to \\"latest\\" if omitted).
 ## \`node\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.node\\"></a>
 
 \`\`\`typescript
-public readonly node: ConstructNode
+public readonly node: ConstructNode;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.ConstructNode\`](#@aws-cdk/core.ConstructNode)
@@ -921,7 +921,7 @@ The construct tree node for this construct.
 ## \`env\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.env\\"></a>
 
 \`\`\`typescript
-public readonly env: ResourceEnvironment
+public readonly env: ResourceEnvironment;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.ResourceEnvironment\`](#@aws-cdk/core.ResourceEnvironment)
@@ -940,7 +940,7 @@ that might be different than the stack they were imported into.
 ## \`stack\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.stack\\"></a>
 
 \`\`\`typescript
-public readonly stack: Stack
+public readonly stack: Stack;
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.Stack\`](#@aws-cdk/core.Stack)
@@ -952,7 +952,7 @@ The stack in which this resource is defined.
 ## \`repositoryArn\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryArn\\"></a>
 
 \`\`\`typescript
-public readonly repositoryArn: string
+public readonly repositoryArn: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -964,7 +964,7 @@ The ARN of the repository.
 ## \`repositoryName\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -976,7 +976,7 @@ The name of the repository.
 ## \`repositoryUri\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.IRepository.property.repositoryUri\\"></a>
 
 \`\`\`typescript
-public readonly repositoryUri: string
+public readonly repositoryUri: string;
 \`\`\`
 
 - *Type:* \`string\`

--- a/test/docgen/view/__snapshots__/property.test.ts.snap
+++ b/test/docgen/view/__snapshots__/property.test.ts.snap
@@ -4,7 +4,7 @@ exports[`java snapshot 1`] = `
 " \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryCatalogData()
+public java.lang.Object getRepositoryCatalogData();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -38,7 +38,7 @@ exports[`typescript snapshot 1`] = `
 " \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 \`\`\`typescript
-public readonly repositoryCatalogData: any
+public readonly repositoryCatalogData: any;
 \`\`\`
 
 - *Type:* \`any\`

--- a/test/docgen/view/__snapshots__/property.test.ts.snap
+++ b/test/docgen/view/__snapshots__/property.test.ts.snap
@@ -3,6 +3,10 @@
 exports[`java snapshot 1`] = `
 " \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryCatalogData()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -16,6 +20,10 @@ exports[`java snapshot 1`] = `
 exports[`python snapshot 1`] = `
 " \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_catalog_data\\"></a>
 
+\`\`\`python
+repository_catalog_data: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -28,6 +36,10 @@ exports[`python snapshot 1`] = `
 
 exports[`typescript snapshot 1`] = `
 " \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
+
+\`\`\`typescript
+public readonly repositoryCatalogData: any
+\`\`\`
 
 - *Type:* \`any\`
 

--- a/test/docgen/view/__snapshots__/struct.test.ts.snap
+++ b/test/docgen/view/__snapshots__/struct.test.ts.snap
@@ -23,7 +23,7 @@ CfnPublicRepositoryProps.builder()
 ## \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryCatalogData()
+public java.lang.Object getRepositoryCatalogData();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -37,7 +37,7 @@ public java.lang.Object getRepositoryCatalogData()
 ## \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`java
-public java.lang.String getRepositoryName()
+public java.lang.String getRepositoryName();
 \`\`\`
 
 - *Type:* \`java.lang.String\`
@@ -51,7 +51,7 @@ public java.lang.String getRepositoryName()
 ## \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
 \`\`\`java
-public java.lang.Object getRepositoryPolicyText()
+public java.lang.Object getRepositoryPolicyText();
 \`\`\`
 
 - *Type:* \`java.lang.Object\`
@@ -65,7 +65,7 @@ public java.lang.Object getRepositoryPolicyText()
 ## \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 \`\`\`java
-public java.util.List<CfnTag> getTags()
+public java.util.List<CfnTag> getTags();
 \`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
@@ -174,7 +174,7 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 ## \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 \`\`\`typescript
-public readonly repositoryCatalogData: any
+public readonly repositoryCatalogData: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -188,7 +188,7 @@ public readonly repositoryCatalogData: any
 ## \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
 
 \`\`\`typescript
-public readonly repositoryName: string
+public readonly repositoryName: string;
 \`\`\`
 
 - *Type:* \`string\`
@@ -202,7 +202,7 @@ public readonly repositoryName: string
 ## \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
 \`\`\`typescript
-public readonly repositoryPolicyText: any
+public readonly repositoryPolicyText: any;
 \`\`\`
 
 - *Type:* \`any\`
@@ -216,7 +216,7 @@ public readonly repositoryPolicyText: any
 ## \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.tags\\"></a>
 
 \`\`\`typescript
-public readonly tags: CfnTag[]
+public readonly tags: CfnTag[];
 \`\`\`
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]

--- a/test/docgen/view/__snapshots__/struct.test.ts.snap
+++ b/test/docgen/view/__snapshots__/struct.test.ts.snap
@@ -22,6 +22,10 @@ CfnPublicRepositoryProps.builder()
 
 ## \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryCatalogData()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -31,6 +35,10 @@ CfnPublicRepositoryProps.builder()
 ---
 
 ## \`repositoryName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
+
+\`\`\`java
+public java.lang.String getRepositoryName()
+\`\`\`
 
 - *Type:* \`java.lang.String\`
 
@@ -42,6 +50,10 @@ CfnPublicRepositoryProps.builder()
 
 ## \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
+\`\`\`java
+public java.lang.Object getRepositoryPolicyText()
+\`\`\`
+
 - *Type:* \`java.lang.Object\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -51,6 +63,10 @@ CfnPublicRepositoryProps.builder()
 ---
 
 ## \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.tags\\"></a>
+
+\`\`\`java
+public java.util.List<CfnTag> getTags()
+\`\`\`
 
 - *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
 
@@ -84,6 +100,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 
 ## \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_catalog_data\\"></a>
 
+\`\`\`python
+repository_catalog_data: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -93,6 +113,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 ---
 
 ## \`repository_name\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_name\\"></a>
+
+\`\`\`python
+repository_name: str
+\`\`\`
 
 - *Type:* \`str\`
 
@@ -104,6 +128,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 
 ## \`repository_policy_text\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_policy_text\\"></a>
 
+\`\`\`python
+repository_policy_text: typing.Any
+\`\`\`
+
 - *Type:* \`typing.Any\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -113,6 +141,10 @@ aws_cdk.aws_ecr.CfnPublicRepositoryProps(
 ---
 
 ## \`tags\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.tags\\"></a>
+
+\`\`\`python
+tags: typing.List[CfnTag]
+\`\`\`
 
 - *Type:* typing.List[[\`aws_cdk.core.CfnTag\`](#aws_cdk.core.CfnTag)]
 
@@ -141,6 +173,10 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ## \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
+\`\`\`typescript
+public readonly repositoryCatalogData: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::PublicRepository.RepositoryCatalogData\`.
@@ -150,6 +186,10 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 ---
 
 ## \`repositoryName\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryName\\"></a>
+
+\`\`\`typescript
+public readonly repositoryName: string
+\`\`\`
 
 - *Type:* \`string\`
 
@@ -161,6 +201,10 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 
 ## \`repositoryPolicyText\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryPolicyText\\"></a>
 
+\`\`\`typescript
+public readonly repositoryPolicyText: any
+\`\`\`
+
 - *Type:* \`any\`
 
 \`AWS::ECR::PublicRepository.RepositoryPolicyText\`.
@@ -170,6 +214,10 @@ const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
 ---
 
 ## \`tags\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.tags\\"></a>
+
+\`\`\`typescript
+public readonly tags: CfnTag[]
+\`\`\`
 
 - *Type:* [\`@aws-cdk/core.CfnTag\`](#@aws-cdk/core.CfnTag)[]
 


### PR DESCRIPTION
Add code examples for all properties within "Properties" sections. This does not add code examples for parameters (e.g. for fields in constructors or methods).

Even though the code examples include the types of the properties, we cannot remove the "Type: xxx" labels below them because they may include _links_ to other types, and code snippets cannot include links in GitHub markdown. (We can probably work around this for the Construct Hub by using the JSON format instead).

Resolves https://github.com/cdklabs/jsii-docgen/issues/436