### PR TITLE
feat: improve signalling of ENOSPC during "npm install"

### DIFF
--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -327,7 +327,7 @@ async function spawn(command: string, args: ReadonlyArray<string> = [], options:
 }
 
 class SpawnFailure extends Error {
-  public constructor(message: string, public readonly code: number | undefined, public readonly signal: string | undefined) {
+  public constructor(message: string, public readonly code: number | null, public readonly signal: NodeJS.Signals | null) {
     super(message);
     Error.captureStackTrace(this, this.constructor);
   }

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -6,7 +6,7 @@ import * as glob from 'glob-promise';
 import * as reflect from 'jsii-reflect';
 import { TargetLanguage } from 'jsii-rosetta';
 import { transliterateAssembly } from 'jsii-rosetta/lib/commands/transliterate';
-import { NoSpaceLeftOnDevice } from '../..';
+import { NoSpaceLeftOnDevice } from '../../errors';
 import { Markdown } from '../render/markdown';
 import { JavaTranspile } from '../transpile/java';
 import { PythonTranspile } from '../transpile/python';

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -6,6 +6,7 @@ import * as glob from 'glob-promise';
 import * as reflect from 'jsii-reflect';
 import { TargetLanguage } from 'jsii-rosetta';
 import { transliterateAssembly } from 'jsii-rosetta/lib/commands/transliterate';
+import { NoSpaceLeftOnDevice } from '../..';
 import { Markdown } from '../render/markdown';
 import { JavaTranspile } from '../transpile/java';
 import { PythonTranspile } from '../transpile/python';
@@ -13,7 +14,6 @@ import { Transpile, Language, TranspiledType } from '../transpile/transpile';
 import { TypeScriptTranspile } from '../transpile/typescript';
 import { ApiReference } from './api-reference';
 import { Readme } from './readme';
-import { NoSpaceLeftOnDevice } from '../..';
 
 /**
  * Options for rendering a `Documentation` object.

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -154,9 +154,9 @@ export class Documentation {
             throw new NoSpaceLeftOnDevice(e.message, e.stack);
           } else if (e.code) {
             const maybeerrno = 256 - e.code;
-            for (const [name, errno] of Object.entries(os.constants.errno)) {
+            for (const [errname, errno] of Object.entries(os.constants.errno)) {
               if (maybeerrno === errno) {
-                console.error(`Exit code ${e.code} may correspond to ${name} (-${errno})`);
+                console.error(`Exit code ${e.code} may correspond to ${errname} (-${errno})`);
                 break;
               }
             }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,25 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { name } = require('../package.json');
+
+/**
+ * The error raised when processing a package fails due to running out of disk
+ * space while installing it's dependency closure in a temporary directory. This
+ * error cannot be immediately recovered, short of deleting files to make more
+ * space availabe, then retrying.
+ *
+ * Users may perform an `err instanceof NoSpaceLeftOnDevice` test to determine
+ * whether this error was raised or not, and cut retry attempts.
+ */
+export class NoSpaceLeftOnDevice extends Error {
+  public readonly name = `${name}.${this.constructor.name}`;
+
+  /** @internal */
+  public constructor(message: string, stack?: string) {
+    super(message);
+    if (this.stack) {
+      this.stack = stack;
+    } else {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export { Documentation } from './docgen/view/documentation';
 export { Language } from './docgen/transpile/transpile';
 export { UnsupportedLanguageError } from './docgen/transpile/transpile';
 export { TranspiledType } from './docgen/transpile/transpile';
+export * from './errors';


### PR DESCRIPTION
Allow consumer code to react differently to failures caused by running out of
disk space from other classes of failures. For example, this can be used to cut
retries when the disk is full.

This is done by recognizing the exit code returned by `npm install` when it hits
`ENOSPC` and throwing a dedicated exception type in this scenario, so that
consumers can catch, then `instanceof` test it.

Related to cdklabs/construct-hub-webapp#387