### PR TITLE
fix: generating Java docs fails for monocdk

### DIFF
--- a/src/docgen/transpile/python.ts
+++ b/src/docgen/transpile/python.ts
@@ -218,6 +218,28 @@ export class PythonTranspile extends transpile.TranspileBase {
     };
   }
 
+  public type(type: reflect.Type): transpile.TranspiledType {
+    const submodule = this.findSubmodule(type);
+    const moduleLike = this.moduleLike(submodule ? submodule : type.assembly);
+
+    const fqn = [moduleLike.name];
+
+    if (type.namespace) {
+      fqn.push(type.namespace);
+    }
+    fqn.push(type.name);
+
+    return {
+      fqn: fqn.join('.'),
+      name: type.name,
+      namespace: type.namespace,
+      module: moduleLike.name,
+      submodule: moduleLike.submodule,
+      source: type,
+      language: this.language,
+    };
+  }
+
   public moduleLike(
     moduleLike: reflect.ModuleLike,
   ): transpile.TranspiledModuleLike {

--- a/src/docgen/transpile/transpile.ts
+++ b/src/docgen/transpile/transpile.ts
@@ -577,35 +577,6 @@ export interface TranspileBase extends Transpile {}
 export abstract class TranspileBase implements Transpile {
   constructor(public readonly language: Language) {}
 
-  public type(type: reflect.Type): TranspiledType {
-    const submodule = this.findSubmodule(type);
-    const moduleLike = this.moduleLike(submodule ? submodule : type.assembly);
-
-    const fqn = [moduleLike.name];
-
-
-    let namespace = type.namespace;
-    if (namespace && submodule && moduleLike.submodule) {
-      // if the type is in a submodule, submodule.name is a part of the namespace
-      // so we update that part with the language-specific submodule string
-      namespace = namespace.replace(submodule.name, moduleLike.submodule);
-    }
-    if (namespace) {
-      fqn.push(namespace);
-    }
-    fqn.push(type.name);
-
-    return {
-      fqn: fqn.join('.'),
-      name: type.name,
-      namespace: namespace,
-      module: moduleLike.name,
-      submodule: moduleLike.submodule,
-      source: type,
-      language: this.language,
-    };
-  }
-
   public typeReference(ref: reflect.TypeReference): TranspiledTypeReference {
     if (ref.type) {
       const transpiled = this.type(ref.type);

--- a/src/docgen/transpile/typescript.ts
+++ b/src/docgen/transpile/typescript.ts
@@ -182,6 +182,28 @@ export class TypeScriptTranspile extends transpile.TranspileBase {
     };
   }
 
+  public type(type: reflect.Type): transpile.TranspiledType {
+    const submodule = this.findSubmodule(type);
+    const moduleLike = this.moduleLike(submodule ? submodule : type.assembly);
+
+    const fqn = [moduleLike.name];
+
+    if (type.namespace) {
+      fqn.push(type.namespace);
+    }
+    fqn.push(type.name);
+
+    return {
+      fqn: fqn.join('.'),
+      name: type.name,
+      namespace: type.namespace,
+      module: moduleLike.name,
+      submodule: moduleLike.submodule,
+      source: type,
+      language: this.language,
+    };
+  }
+
   public moduleLike(
     moduleLike: reflect.ModuleLike,
   ): transpile.TranspiledModuleLike {

--- a/test/docgen/view/__snapshots__/documentation.test.ts.snap
+++ b/test/docgen/view/__snapshots__/documentation.test.ts.snap
@@ -11040,7 +11040,7 @@ Additional operation options.
 \`\`\`java
 import software.amazon.awscdk.services.eks.Cluster;
 
-services.eks.Cluster.fromClusterAttributes(Construct scope, java.lang.String id, ClusterAttributes attrs)
+Cluster.fromClusterAttributes(Construct scope, java.lang.String id, ClusterAttributes attrs)
 \`\`\`
 
 ###### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.scope\\"></a>
@@ -12551,7 +12551,7 @@ Cluster resource.
 \`\`\`java
 import software.amazon.awscdk.services.eks.Nodegroup;
 
-services.eks.Nodegroup.fromNodegroupName(Construct scope, java.lang.String id, java.lang.String nodegroupName)
+Nodegroup.fromNodegroupName(Construct scope, java.lang.String id, java.lang.String nodegroupName)
 \`\`\`
 
 ###### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.parameter.scope\\"></a>
@@ -17959,7 +17959,7 @@ Kubernetes cluster version.
 \`\`\`java
 import software.amazon.awscdk.services.eks.KubernetesVersion;
 
-services.eks.KubernetesVersion.of(java.lang.String version)
+KubernetesVersion.of(java.lang.String version)
 \`\`\`
 
 ###### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.parameter.version\\"></a>
@@ -18446,6 +18446,10872 @@ public Stack getStack();
 \`\`\`
 
 - *Type:* [\`software.amazon.awscdk.Stack\`](#software.amazon.awscdk.Stack)
+
+The stack in which this resource is defined.
+
+---
+
+##### \`nodegroupName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.INodegroup.property.nodegroupName\\"></a>
+
+\`\`\`java
+public java.lang.String getNodegroupName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+Name of the nodegroup.
+
+---
+
+## Enums <a name=\\"Enums\\"></a>
+
+### CapacityType <a name=\\"CapacityType\\"></a>
+
+Capacity type of the managed node group.
+
+#### \`SPOT\` <a name=\\"software.amazon.awscdk.services.eks.CapacityType.SPOT\\"></a>
+
+spot instances.
+
+---
+
+
+#### \`ON_DEMAND\` <a name=\\"software.amazon.awscdk.services.eks.CapacityType.ON_DEMAND\\"></a>
+
+on-demand instances.
+
+---
+
+
+### CoreDnsComputeType <a name=\\"CoreDnsComputeType\\"></a>
+
+The type of compute resources to use for CoreDNS.
+
+#### \`EC2\` <a name=\\"software.amazon.awscdk.services.eks.CoreDnsComputeType.EC2\\"></a>
+
+Deploy CoreDNS on EC2 instances.
+
+---
+
+
+#### \`FARGATE\` <a name=\\"software.amazon.awscdk.services.eks.CoreDnsComputeType.FARGATE\\"></a>
+
+Deploy CoreDNS on Fargate-managed instances.
+
+---
+
+
+### CpuArch <a name=\\"CpuArch\\"></a>
+
+CPU architecture.
+
+#### \`ARM_64\` <a name=\\"software.amazon.awscdk.services.eks.CpuArch.ARM_64\\"></a>
+
+arm64 CPU type.
+
+---
+
+
+#### \`X86_64\` <a name=\\"software.amazon.awscdk.services.eks.CpuArch.X86_64\\"></a>
+
+x86_64 CPU type.
+
+---
+
+
+### DefaultCapacityType <a name=\\"DefaultCapacityType\\"></a>
+
+The default capacity type for the cluster.
+
+#### \`NODEGROUP\` <a name=\\"software.amazon.awscdk.services.eks.DefaultCapacityType.NODEGROUP\\"></a>
+
+managed node group.
+
+---
+
+
+#### \`EC2\` <a name=\\"software.amazon.awscdk.services.eks.DefaultCapacityType.EC2\\"></a>
+
+EC2 autoscaling group.
+
+---
+
+
+### MachineImageType <a name=\\"MachineImageType\\"></a>
+
+The machine image type.
+
+#### \`AMAZON_LINUX_2\` <a name=\\"software.amazon.awscdk.services.eks.MachineImageType.AMAZON_LINUX_2\\"></a>
+
+Amazon EKS-optimized Linux AMI.
+
+---
+
+
+#### \`BOTTLEROCKET\` <a name=\\"software.amazon.awscdk.services.eks.MachineImageType.BOTTLEROCKET\\"></a>
+
+Bottlerocket AMI.
+
+---
+
+
+### NodegroupAmiType <a name=\\"NodegroupAmiType\\"></a>
+
+The AMI type for your node group.
+
+GPU instance types should use the \`AL2_x86_64_GPU\` AMI type, which uses the
+Amazon EKS-optimized Linux AMI with GPU support. Non-GPU instances should use the \`AL2_x86_64\` AMI type, which
+uses the Amazon EKS-optimized Linux AMI.
+
+#### \`AL2_X86_64\` <a name=\\"software.amazon.awscdk.services.eks.NodegroupAmiType.AL2_X86_64\\"></a>
+
+Amazon Linux 2 (x86-64).
+
+---
+
+
+#### \`AL2_X86_64_GPU\` <a name=\\"software.amazon.awscdk.services.eks.NodegroupAmiType.AL2_X86_64_GPU\\"></a>
+
+Amazon Linux 2 with GPU support.
+
+---
+
+
+#### \`AL2_ARM_64\` <a name=\\"software.amazon.awscdk.services.eks.NodegroupAmiType.AL2_ARM_64\\"></a>
+
+Amazon Linux 2 (ARM-64).
+
+---
+
+
+### NodeType <a name=\\"NodeType\\"></a>
+
+Whether the worker nodes should support GPU or just standard instances.
+
+#### \`STANDARD\` <a name=\\"software.amazon.awscdk.services.eks.NodeType.STANDARD\\"></a>
+
+Standard instances.
+
+---
+
+
+#### \`GPU\` <a name=\\"software.amazon.awscdk.services.eks.NodeType.GPU\\"></a>
+
+GPU instances.
+
+---
+
+
+#### \`INFERENTIA\` <a name=\\"software.amazon.awscdk.services.eks.NodeType.INFERENTIA\\"></a>
+
+Inferentia instances.
+
+---
+
+
+### PatchType <a name=\\"PatchType\\"></a>
+
+Values for \`kubectl patch\` --type argument.
+
+#### \`JSON\` <a name=\\"software.amazon.awscdk.services.eks.PatchType.JSON\\"></a>
+
+JSON Patch, RFC 6902.
+
+---
+
+
+#### \`MERGE\` <a name=\\"software.amazon.awscdk.services.eks.PatchType.MERGE\\"></a>
+
+JSON Merge patch.
+
+---
+
+
+#### \`STRATEGIC\` <a name=\\"software.amazon.awscdk.services.eks.PatchType.STRATEGIC\\"></a>
+
+Strategic merge patch.
+
+---
+
+"
+`;
+
+exports[`java snapshot - submodules 2 1`] = `
+"# Amazon EKS Construct Library
+<!--BEGIN STABILITY BANNER-->
+
+---
+
+![cfn-resources: Stable](https://img.shields.io/badge/cfn--resources-stable-success.svg?style=for-the-badge)
+
+![cdk-constructs: Stable](https://img.shields.io/badge/cdk--constructs-stable-success.svg?style=for-the-badge)
+
+---
+
+<!--END STABILITY BANNER-->
+
+This construct library allows you to define [Amazon Elastic Container Service for Kubernetes (EKS)](https://aws.amazon.com/eks/) clusters.
+In addition, the library also supports defining Kubernetes resource manifests within EKS clusters.
+
+## Table Of Contents
+
+* [Quick Start](#quick-start)
+* [API Reference](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-eks-readme.html)
+* [Architectural Overview](#architectural-overview)
+* [Provisioning clusters](#provisioning-clusters)
+  * [Managed node groups](#managed-node-groups)
+  * [Fargate Profiles](#fargate-profiles)
+  * [Self-managed nodes](#self-managed-nodes)
+  * [Endpoint Access](#endpoint-access)
+  * [VPC Support](#vpc-support)
+  * [Kubectl Support](#kubectl-support)
+  * [ARM64 Support](#arm64-support)
+  * [Masters Role](#masters-role)
+  * [Encryption](#encryption)
+* [Permissions and Security](#permissions-and-security)
+* [Applying Kubernetes Resources](#applying-kubernetes-resources)
+  * [Kubernetes Manifests](#kubernetes-manifests)
+  * [Helm Charts](#helm-charts)
+  * [CDK8s Charts](#cdk8s-charts)
+* [Patching Kubernetes Resources](#patching-kubernetes-resources)
+* [Querying Kubernetes Resources](#querying-kubernetes-resources)
+* [Using existing clusters](#using-existing-clusters)
+* [Known Issues and Limitations](#known-issues-and-limitations)
+
+## Quick Start
+
+This example defines an Amazon EKS cluster with the following configuration:
+
+* Dedicated VPC with default configuration (Implicitly created using [ec2.Vpc](https://docs.aws.amazon.com/cdk/api/latest/docs/aws-ec2-readme.html#vpc))
+* A Kubernetes pod with a container based on the [paulbouwer/hello-kubernetes](https://github.com/paulbouwer/hello-kubernetes) image.
+
+\`\`\`ts
+// provisiong a cluster
+const cluster = new eks.Cluster(this, 'hello-eks', {
+  version: eks.KubernetesVersion.V1_19,
+});
+
+// apply a kubernetes manifest to the cluster
+cluster.addManifest('mypod', {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: { name: 'mypod' },
+  spec: {
+    containers: [
+      {
+        name: 'hello',
+        image: 'paulbouwer/hello-kubernetes:1.5',
+        ports: [ { containerPort: 8080 } ]
+      }
+    ]
+  }
+});
+\`\`\`
+
+In order to interact with your cluster through \`kubectl\`, you can use the \`aws eks update-kubeconfig\` [AWS CLI command](https://docs.aws.amazon.com/cli/latest/reference/eks/update-kubeconfig.html)
+to configure your local kubeconfig. The EKS module will define a CloudFormation output in your stack which contains the command to run. For example:
+
+\`\`\`plaintext
+Outputs:
+ClusterConfigCommand43AAE40F = aws eks update-kubeconfig --name cluster-xxxxx --role-arn arn:aws:iam::112233445566:role/yyyyy
+\`\`\`
+
+Execute the \`aws eks update-kubeconfig ...\` command in your terminal to create or update a local kubeconfig context:
+
+\`\`\`console
+$ aws eks update-kubeconfig --name cluster-xxxxx --role-arn arn:aws:iam::112233445566:role/yyyyy
+Added new context arn:aws:eks:rrrrr:112233445566:cluster/cluster-xxxxx to /home/boom/.kube/config
+\`\`\`
+
+And now you can simply use \`kubectl\`:
+
+\`\`\`console
+$ kubectl get all -n kube-system
+NAME                           READY   STATUS    RESTARTS   AGE
+pod/aws-node-fpmwv             1/1     Running   0          21m
+pod/aws-node-m9htf             1/1     Running   0          21m
+pod/coredns-5cb4fb54c7-q222j   1/1     Running   0          23m
+pod/coredns-5cb4fb54c7-v9nxx   1/1     Running   0          23m
+...
+\`\`\`
+
+## Architectural Overview
+
+The following is a qualitative diagram of the various possible components involved in the cluster deployment.
+
+\`\`\`text
+ +-----------------------------------------------+               +-----------------+
+ |                 EKS Cluster                   |    kubectl    |                 |
+ |-----------------------------------------------|<-------------+| Kubectl Handler |
+ |                                               |               |                 |
+ |                                               |               +-----------------+
+ | +--------------------+    +-----------------+ |
+ | |                    |    |                 | |
+ | | Managed Node Group |    | Fargate Profile | |               +-----------------+
+ | |                    |    |                 | |               |                 |
+ | +--------------------+    +-----------------+ |               | Cluster Handler |
+ |                                               |               |                 |
+ +-----------------------------------------------+               +-----------------+
+    ^                                   ^                          +
+    |                                   |                          |
+    | connect self managed capacity     |                          | aws-sdk
+    |                                   | create/update/delete     |
+    +                                   |                          v
+ +--------------------+                 +              +-------------------+
+ |                    |                 --------------+| eks.amazonaws.com |
+ | Auto Scaling Group |                                +-------------------+
+ |                    |
+ +--------------------+
+\`\`\`
+
+In a nutshell:
+
+* \`EKS Cluster\` - The cluster endpoint created by EKS.
+* \`Managed Node Group\` - EC2 worker nodes managed by EKS.
+* \`Fargate Profile\` - Fargate worker nodes managed by EKS.
+* \`Auto Scaling Group\` - EC2 worker nodes managed by the user.
+* \`KubectlHandler\` - Lambda function for invoking \`kubectl\` commands on the cluster - created by CDK.
+* \`ClusterHandler\` - Lambda function for interacting with EKS API to manage the cluster lifecycle - created by CDK.
+
+A more detailed breakdown of each is provided further down this README.
+
+## Provisioning clusters
+
+Creating a new cluster is done using the \`Cluster\` or \`FargateCluster\` constructs. The only required property is the kubernetes \`version\`.
+
+\`\`\`ts
+new eks.Cluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+});
+\`\`\`
+
+You can also use \`FargateCluster\` to provision a cluster that uses only fargate workers.
+
+\`\`\`ts
+new eks.FargateCluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+});
+\`\`\`
+
+> **NOTE: Only 1 cluster per stack is supported.** If you have a use-case for multiple clusters per stack, or would like to understand more about this limitation, see <https://github.com/aws/aws-cdk/issues/10073>.
+
+Below you'll find a few important cluster configuration options. First of which is Capacity.
+Capacity is the amount and the type of worker nodes that are available to the cluster for deploying resources. Amazon EKS offers 3 ways of configuring capacity, which you can combine as you like:
+
+### Managed node groups
+
+Amazon EKS managed node groups automate the provisioning and lifecycle management of nodes (Amazon EC2 instances) for Amazon EKS Kubernetes clusters.
+With Amazon EKS managed node groups, you don’t need to separately provision or register the Amazon EC2 instances that provide compute capacity to run your Kubernetes applications. You can create, update, or terminate nodes for your cluster with a single operation. Nodes run using the latest Amazon EKS optimized AMIs in your AWS account while node updates and terminations gracefully drain nodes to ensure that your applications stay available.
+
+> For more details visit [Amazon EKS Managed Node Groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html).
+
+**Managed Node Groups are the recommended way to allocate cluster capacity.**
+
+By default, this library will allocate a managed node group with 2 *m5.large* instances (this instance type suits most common use-cases, and is good value for money).
+
+At cluster instantiation time, you can customize the number of instances and their type:
+
+\`\`\`ts
+new eks.Cluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+  defaultCapacity: 5,
+  defaultCapacityInstance: ec2.InstanceType.of(ec2.InstanceClass.M5, ec2.InstanceSize.SMALL),
+});
+\`\`\`
+
+To access the node group that was created on your behalf, you can use \`cluster.defaultNodegroup\`.
+
+Additional customizations are available post instantiation. To apply them, set the default capacity to 0, and use the \`cluster.addNodegroupCapacity\` method:
+
+\`\`\`ts
+const cluster = new eks.Cluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+  defaultCapacity: 0,
+});
+
+cluster.addNodegroupCapacity('custom-node-group', {
+  instanceTypes: [new ec2.InstanceType('m5.large')],
+  minSize: 4,
+  diskSize: 100,
+  amiType: eks.NodegroupAmiType.AL2_X86_64_GPU,
+  ...
+});
+\`\`\`
+
+#### Spot Instances Support
+
+Use \`capacityType\` to create managed node groups comprised of spot instances. To maximize the availability of your applications while using
+Spot Instances, we recommend that you configure a Spot managed node group to use multiple instance types with the \`instanceTypes\` property.
+
+> For more details visit [Managed node group capacity types](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html#managed-node-group-capacity-types).
+
+
+\`\`\`ts
+cluster.addNodegroupCapacity('extra-ng-spot', {
+  instanceTypes: [
+    new ec2.InstanceType('c5.large'),
+    new ec2.InstanceType('c5a.large'),
+    new ec2.InstanceType('c5d.large'),
+  ],
+  minSize: 3,
+  capacityType: eks.CapacityType.SPOT,
+});
+
+\`\`\`
+
+#### Launch Template Support
+
+You can specify a launch template that the node group will use. For example, this can be useful if you want to use
+a custom AMI or add custom user data.
+
+When supplying a custom user data script, it must be encoded in the MIME multi-part archive format, since Amazon EKS merges with its own user data. Visit the [Launch Template Docs](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-user-data)
+for mode details.
+
+\`\`\`ts
+const userData = \`MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary=\\"==MYBOUNDARY==\\"
+
+--==MYBOUNDARY==
+Content-Type: text/x-shellscript; charset=\\"us-ascii\\"
+
+#!/bin/bash
+echo \\"Running custom user data script\\"
+
+--==MYBOUNDARY==--\\\\\\\\
+\`;
+const lt = new ec2.CfnLaunchTemplate(this, 'LaunchTemplate', {
+  launchTemplateData: {
+    instanceType: 't3.small',
+    userData: Fn.base64(userData),
+  },
+});
+cluster.addNodegroupCapacity('extra-ng', {
+  launchTemplateSpec: {
+    id: lt.ref,
+    version: lt.attrLatestVersionNumber,
+  },
+});
+
+\`\`\`
+
+Note that when using a custom AMI, Amazon EKS doesn't merge any user data. Which means you do not need the multi-part encoding. and are responsible for supplying the required bootstrap commands for nodes to join the cluster.
+In the following example, \`/ect/eks/bootstrap.sh\` from the AMI will be used to bootstrap the node.
+
+\`\`\`ts
+const userData = ec2.UserData.forLinux();
+userData.addCommands(
+  'set -o xtrace',
+  \`/etc/eks/bootstrap.sh \${cluster.clusterName}\`,
+);
+const lt = new ec2.CfnLaunchTemplate(this, 'LaunchTemplate', {
+  launchTemplateData: {
+    imageId: 'some-ami-id', // custom AMI
+    instanceType: 't3.small',
+    userData: Fn.base64(userData.render()),
+  },
+});
+cluster.addNodegroupCapacity('extra-ng', {
+  launchTemplateSpec: {
+    id: lt.ref,
+    version: lt.attrLatestVersionNumber,
+  },
+});
+\`\`\`
+
+You may specify one \`instanceType\` in the launch template or multiple \`instanceTypes\` in the node group, **but not both**.
+
+> For more details visit [Launch Template Support](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html).
+
+Graviton 2 instance types are supported including \`c6g\`, \`m6g\`, \`r6g\` and \`t4g\`.
+
+### Fargate profiles
+
+AWS Fargate is a technology that provides on-demand, right-sized compute
+capacity for containers. With AWS Fargate, you no longer have to provision,
+configure, or scale groups of virtual machines to run containers. This removes
+the need to choose server types, decide when to scale your node groups, or
+optimize cluster packing.
+
+You can control which pods start on Fargate and how they run with Fargate
+Profiles, which are defined as part of your Amazon EKS cluster.
+
+See [Fargate Considerations](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html#fargate-considerations) in the AWS EKS User Guide.
+
+You can add Fargate Profiles to any EKS cluster defined in your CDK app
+through the \`addFargateProfile()\` method. The following example adds a profile
+that will match all pods from the \\"default\\" namespace:
+
+\`\`\`ts
+cluster.addFargateProfile('MyProfile', {
+  selectors: [ { namespace: 'default' } ]
+});
+\`\`\`
+
+You can also directly use the \`FargateProfile\` construct to create profiles under different scopes:
+
+\`\`\`ts
+new eks.FargateProfile(scope, 'MyProfile', {
+  cluster,
+  ...
+});
+\`\`\`
+
+To create an EKS cluster that **only** uses Fargate capacity, you can use \`FargateCluster\`.
+The following code defines an Amazon EKS cluster with a default Fargate Profile that matches all pods from the \\"kube-system\\" and \\"default\\" namespaces. It is also configured to [run CoreDNS on Fargate](https://docs.aws.amazon.com/eks/latest/userguide/fargate-getting-started.html#fargate-gs-coredns).
+
+\`\`\`ts
+const cluster = new eks.FargateCluster(this, 'MyCluster', {
+  version: eks.KubernetesVersion.V1_19,
+});
+\`\`\`
+
+**NOTE**: Classic Load Balancers and Network Load Balancers are not supported on
+pods running on Fargate. For ingress, we recommend that you use the [ALB Ingress
+Controller](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html)
+on Amazon EKS (minimum version v1.1.4).
+
+### Self-managed nodes
+
+Another way of allocating capacity to an EKS cluster is by using self-managed nodes.
+EC2 instances that are part of the auto-scaling group will serve as worker nodes for the cluster.
+This type of capacity is also commonly referred to as *EC2 Capacity** or *EC2 Nodes*.
+
+For a detailed overview please visit [Self Managed Nodes](https://docs.aws.amazon.com/eks/latest/userguide/worker.html).
+
+Creating an auto-scaling group and connecting it to the cluster is done using the \`cluster.addAutoScalingGroupCapacity\` method:
+
+\`\`\`ts
+cluster.addAutoScalingGroupCapacity('frontend-nodes', {
+  instanceType: new ec2.InstanceType('t2.medium'),
+  minCapacity: 3,
+  vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC }
+});
+\`\`\`
+
+To connect an already initialized auto-scaling group, use the \`cluster.connectAutoScalingGroupCapacity()\` method:
+
+\`\`\`ts
+const asg = new ec2.AutoScalingGroup(...);
+cluster.connectAutoScalingGroupCapacity(asg);
+\`\`\`
+
+In both cases, the [cluster security group](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html#cluster-sg) will be automatically attached to
+the auto-scaling group, allowing for traffic to flow freely between managed and self-managed nodes.
+
+> **Note:** The default \`updateType\` for auto-scaling groups does not replace existing nodes. Since security groups are determined at launch time, self-managed nodes that were provisioned with version \`1.78.0\` or lower, will not be updated.
+> To apply the new configuration on all your self-managed nodes, you'll need to replace the nodes using the \`UpdateType.REPLACING_UPDATE\` policy for the [\`updateType\`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-autoscaling.AutoScalingGroup.html#updatetypespan-classapi-icon-api-icon-deprecated-titlethis-api-element-is-deprecated-its-use-is-not-recommended%EF%B8%8Fspan) property.
+
+You can customize the [/etc/eks/boostrap.sh](https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh) script, which is responsible
+for bootstrapping the node to the EKS cluster. For example, you can use \`kubeletExtraArgs\` to add custom node labels or taints.
+
+\`\`\`ts
+cluster.addAutoScalingGroupCapacity('spot', {
+  instanceType: new ec2.InstanceType('t3.large'),
+  minCapacity: 2,
+  bootstrapOptions: {
+    kubeletExtraArgs: '--node-labels foo=bar,goo=far',
+    awsApiRetryAttempts: 5
+  }
+});
+\`\`\`
+
+To disable bootstrapping altogether (i.e. to fully customize user-data), set \`bootstrapEnabled\` to \`false\`.
+You can also configure the cluster to use an auto-scaling group as the default capacity:
+
+\`\`\`ts
+cluster = new eks.Cluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+  defaultCapacityType: eks.DefaultCapacityType.EC2,
+});
+\`\`\`
+
+This will allocate an auto-scaling group with 2 *m5.large* instances (this instance type suits most common use-cases, and is good value for money).
+To access the \`AutoScalingGroup\` that was created on your behalf, you can use \`cluster.defaultCapacity\`.
+You can also independently create an \`AutoScalingGroup\` and connect it to the cluster using the \`cluster.connectAutoScalingGroupCapacity\` method:
+
+\`\`\`ts
+const asg = new ec2.AutoScalingGroup(...)
+cluster.connectAutoScalingGroupCapacity(asg);
+\`\`\`
+
+This will add the necessary user-data to access the apiserver and configure all connections, roles, and tags needed for the instances in the auto-scaling group to properly join the cluster.
+
+#### Spot Instances
+
+When using self-managed nodes, you can configure the capacity to use spot instances, greatly reducing capacity cost.
+To enable spot capacity, use the \`spotPrice\` property:
+
+\`\`\`ts
+cluster.addAutoScalingGroupCapacity('spot', {
+  spotPrice: '0.1094',
+  instanceType: new ec2.InstanceType('t3.large'),
+  maxCapacity: 10
+});
+\`\`\`
+
+> Spot instance nodes will be labeled with \`lifecycle=Ec2Spot\` and tainted with \`PreferNoSchedule\`.
+
+The [AWS Node Termination Handler](https://github.com/aws/aws-node-termination-handler) \`DaemonSet\` will be
+installed from [Amazon EKS Helm chart repository](https://github.com/aws/eks-charts/tree/master/stable/aws-node-termination-handler) on these nodes.
+The termination handler ensures that the Kubernetes control plane responds appropriately to events that
+can cause your EC2 instance to become unavailable, such as [EC2 maintenance events](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-instances-status-check_sched.html)
+and [EC2 Spot interruptions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html) and helps gracefully stop all pods running on spot nodes that are about to be
+terminated.
+
+> Handler Version: [1.7.0](https://github.com/aws/aws-node-termination-handler/releases/tag/v1.7.0)
+>
+> Chart Version: [0.9.5](https://github.com/aws/eks-charts/blob/v0.0.28/stable/aws-node-termination-handler/Chart.yaml)
+
+To disable the installation of the termination handler, set the \`spotInterruptHandler\` property to \`false\`. This applies both to \`addAutoScalingGroupCapacity\` and \`connectAutoScalingGroupCapacity\`.
+
+#### Bottlerocket
+
+[Bottlerocket](https://aws.amazon.com/bottlerocket/) is a Linux-based open-source operating system that is purpose-built by Amazon Web Services for running containers on virtual machines or bare metal hosts.
+At this moment, \`Bottlerocket\` is only supported when using self-managed auto-scaling groups.
+
+> **NOTICE**: Bottlerocket is only available in [some supported AWS regions](https://github.com/bottlerocket-os/bottlerocket/blob/develop/QUICKSTART-EKS.md#finding-an-ami).
+
+The following example will create an auto-scaling group of 2 \`t3.small\` Linux instances running with the \`Bottlerocket\` AMI.
+
+\`\`\`ts
+cluster.addAutoScalingGroupCapacity('BottlerocketNodes', {
+  instanceType: new ec2.InstanceType('t3.small'),
+  minCapacity:  2,
+  machineImageType: eks.MachineImageType.BOTTLEROCKET
+});
+\`\`\`
+
+The specific Bottlerocket AMI variant will be auto selected according to the k8s version for the \`x86_64\` architecture.
+For example, if the Amazon EKS cluster version is \`1.17\`, the Bottlerocket AMI variant will be auto selected as
+\`aws-k8s-1.17\` behind the scene.
+
+> See [Variants](https://github.com/bottlerocket-os/bottlerocket/blob/develop/README.md#variants) for more details.
+
+Please note Bottlerocket does not allow to customize bootstrap options and \`bootstrapOptions\` properties is not supported when you create the \`Bottlerocket\` capacity.
+
+### Endpoint Access
+
+When you create a new cluster, Amazon EKS creates an endpoint for the managed Kubernetes API server that you use to communicate with your cluster (using Kubernetes management tools such as \`kubectl\`)
+
+By default, this API server endpoint is public to the internet, and access to the API server is secured using a combination of
+AWS Identity and Access Management (IAM) and native Kubernetes [Role Based Access Control](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) (RBAC).
+
+You can configure the [cluster endpoint access](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html) by using the \`endpointAccess\` property:
+
+\`\`\`ts
+const cluster = new eks.Cluster(this, 'hello-eks', {
+  version: eks.KubernetesVersion.V1_19,
+  endpointAccess: eks.EndpointAccess.PRIVATE // No access outside of your VPC.
+});
+\`\`\`
+
+The default value is \`eks.EndpointAccess.PUBLIC_AND_PRIVATE\`. Which means the cluster endpoint is accessible from outside of your VPC, but worker node traffic and \`kubectl\` commands issued by this library stay within your VPC.
+
+### VPC Support
+
+You can specify the VPC of the cluster using the \`vpc\` and \`vpcSubnets\` properties:
+
+\`\`\`ts
+const vpc = new ec2.Vpc(this, 'Vpc');
+
+new eks.Cluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+  vpc,
+  vpcSubnets: [{ subnetType: ec2.SubnetType.PRIVATE }]
+});
+\`\`\`
+
+> Note: Isolated VPCs (i.e with no internet access) are not currently supported. See https://github.com/aws/aws-cdk/issues/12171
+
+If you do not specify a VPC, one will be created on your behalf, which you can then access via \`cluster.vpc\`. The cluster VPC will be associated to any EKS managed capacity (i.e Managed Node Groups and Fargate Profiles).
+
+If you allocate self managed capacity, you can specify which subnets should the auto-scaling group use:
+
+\`\`\`ts
+const vpc = new ec2.Vpc(this, 'Vpc');
+cluster.addAutoScalingGroupCapacity('nodes', {
+  vpcSubnets: { subnets: vpc.privateSubnets }
+});
+\`\`\`
+
+There are two additional components you might want to provision within the VPC.
+
+#### Kubectl Handler
+
+The \`KubectlHandler\` is a Lambda function responsible to issuing \`kubectl\` and \`helm\` commands against the cluster when you add resource manifests to the cluster.
+
+The handler association to the VPC is derived from the \`endpointAccess\` configuration. The rule of thumb is: *If the cluster VPC can be associated, it will be*.
+
+Breaking this down, it means that if the endpoint exposes private access (via \`EndpointAccess.PRIVATE\` or \`EndpointAccess.PUBLIC_AND_PRIVATE\`), and the VPC contains **private** subnets, the Lambda function will be provisioned inside the VPC and use the private subnets to interact with the cluster. This is the common use-case.
+
+If the endpoint does not expose private access (via \`EndpointAccess.PUBLIC\`) **or** the VPC does not contain private subnets, the function will not be provisioned within the VPC.
+
+#### Cluster Handler
+
+The \`ClusterHandler\` is a Lambda function responsible to interact with the EKS API in order to control the cluster lifecycle. To provision this function inside the VPC, set the \`placeClusterHandlerInVpc\` property to \`true\`. This will place the function inside the private subnets of the VPC based on the selection strategy specified in the [\`vpcSubnets\`](https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-eks.Cluster.html#vpcsubnetsspan-classapi-icon-api-icon-experimental-titlethis-api-element-is-experimental-it-may-change-without-noticespan) property.
+
+You can configure the environment of this function by specifying it at cluster instantiation. For example, this can be useful in order to configure an http proxy:
+
+\`\`\`ts
+const cluster = new eks.Cluster(this, 'hello-eks', {
+  version: eks.KubernetesVersion.V1_19,
+  clusterHandlerEnvironment: {
+    'http_proxy': 'http://proxy.myproxy.com'
+  }
+});
+\`\`\`
+
+### Kubectl Support
+
+The resources are created in the cluster by running \`kubectl apply\` from a python lambda function.
+
+#### Environment
+
+You can configure the environment of this function by specifying it at cluster instantiation. For example, this can be useful in order to configure an http proxy:
+
+\`\`\`ts
+const cluster = new eks.Cluster(this, 'hello-eks', {
+  version: eks.KubernetesVersion.V1_19,
+  kubectlEnvironment: {
+    'http_proxy': 'http://proxy.myproxy.com'
+  }
+});
+\`\`\`
+
+#### Runtime
+
+The kubectl handler uses \`kubectl\`, \`helm\` and the \`aws\` CLI in order to
+interact with the cluster. These are bundled into AWS Lambda layers included in
+the \`@aws-cdk/lambda-layer-awscli\` and \`@aws-cdk/lambda-layer-kubectl\` modules.
+
+You can specify a custom \`lambda.LayerVersion\` if you wish to use a different
+version of these tools. The handler expects the layer to include the following
+three executables:
+
+\`\`\`text
+helm/helm
+kubectl/kubectl
+awscli/aws
+\`\`\`
+
+See more information in the
+[Dockerfile](https://github.com/aws/aws-cdk/tree/master/packages/%40aws-cdk/lambda-layer-awscli/layer) for @aws-cdk/lambda-layer-awscli
+and the
+[Dockerfile](https://github.com/aws/aws-cdk/tree/master/packages/%40aws-cdk/lambda-layer-kubectl/layer) for @aws-cdk/lambda-layer-kubectl.
+
+\`\`\`ts
+const layer = new lambda.LayerVersion(this, 'KubectlLayer', {
+  code: lambda.Code.fromAsset('layer.zip'),
+});
+\`\`\`
+
+Now specify when the cluster is defined:
+
+\`\`\`ts
+const cluster = new eks.Cluster(this, 'MyCluster', {
+  kubectlLayer: layer,
+});
+
+// or
+const cluster = eks.Cluster.fromClusterAttributes(this, 'MyCluster', {
+  kubectlLayer: layer,
+});
+\`\`\`
+
+#### Memory
+
+By default, the kubectl provider is configured with 1024MiB of memory. You can use the \`kubectlMemory\` option to specify the memory size for the AWS Lambda function:
+
+\`\`\`ts
+import { Size } from 'aws-cdk-lib';
+
+new eks.Cluster(this, 'MyCluster', {
+  kubectlMemory: Size.gibibytes(4)
+});
+
+// or
+eks.Cluster.fromClusterAttributes(this, 'MyCluster', {
+  kubectlMemory: Size.gibibytes(4)
+});
+\`\`\`
+
+### ARM64 Support
+
+Instance types with \`ARM64\` architecture are supported in both managed nodegroup and self-managed capacity. Simply specify an ARM64 \`instanceType\` (such as \`m6g.medium\`), and the latest
+Amazon Linux 2 AMI for ARM64 will be automatically selected.
+
+\`\`\`ts
+// add a managed ARM64 nodegroup
+cluster.addNodegroupCapacity('extra-ng-arm', {
+  instanceTypes: [new ec2.InstanceType('m6g.medium')],
+  minSize: 2,
+});
+
+// add a self-managed ARM64 nodegroup
+cluster.addAutoScalingGroupCapacity('self-ng-arm', {
+  instanceType: new ec2.InstanceType('m6g.medium'),
+  minCapacity: 2,
+})
+\`\`\`
+
+### Masters Role
+
+When you create a cluster, you can specify a \`mastersRole\`. The \`Cluster\` construct will associate this role with the \`system:masters\` [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) group, giving it super-user access to the cluster.
+
+\`\`\`ts
+const role = new iam.Role(...);
+new eks.Cluster(this, 'HelloEKS', {
+  version: eks.KubernetesVersion.V1_19,
+  mastersRole: role,
+});
+\`\`\`
+
+If you do not specify it, a default role will be created on your behalf, that can be assumed by anyone in the account with \`sts:AssumeRole\` permissions for this role.
+
+This is the role you see as part of the stack outputs mentioned in the [Quick Start](#quick-start).
+
+\`\`\`console
+$ aws eks update-kubeconfig --name cluster-xxxxx --role-arn arn:aws:iam::112233445566:role/yyyyy
+Added new context arn:aws:eks:rrrrr:112233445566:cluster/cluster-xxxxx to /home/boom/.kube/config
+\`\`\`
+
+### Encryption
+
+When you create an Amazon EKS cluster, envelope encryption of Kubernetes secrets using the AWS Key Management Service (AWS KMS) can be enabled.
+The documentation on [creating a cluster](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html)
+can provide more details about the customer master key (CMK) that can be used for the encryption.
+
+You can use the \`secretsEncryptionKey\` to configure which key the cluster will use to encrypt Kubernetes secrets. By default, an AWS Managed key will be used.
+
+> This setting can only be specified when the cluster is created and cannot be updated.
+
+\`\`\`ts
+const secretsKey = new kms.Key(this, 'SecretsKey');
+const cluster = new eks.Cluster(this, 'MyCluster', {
+  secretsEncryptionKey: secretsKey,
+  // ...
+});
+\`\`\`
+
+You can also use a similar configuration for running a cluster built using the FargateCluster construct.
+
+\`\`\`ts
+const secretsKey = new kms.Key(this, 'SecretsKey');
+const cluster = new eks.FargateCluster(this, 'MyFargateCluster', {
+  secretsEncryptionKey: secretsKey
+});
+\`\`\`
+
+The Amazon Resource Name (ARN) for that CMK can be retrieved.
+
+\`\`\`ts
+const clusterEncryptionConfigKeyArn = cluster.clusterEncryptionConfigKeyArn;
+\`\`\`
+
+## Permissions and Security
+
+Amazon EKS provides several mechanism of securing the cluster and granting permissions to specific IAM users and roles.
+
+### AWS IAM Mapping
+
+As described in the [Amazon EKS User Guide](https://docs.aws.amazon.com/en_us/eks/latest/userguide/add-user-role.html), you can map AWS IAM users and roles to [Kubernetes Role-based access control (RBAC)](https://kubernetes.io/docs/reference/access-authn-authz/rbac).
+
+The Amazon EKS construct manages the *aws-auth* \`ConfigMap\` Kubernetes resource on your behalf and exposes an API through the \`cluster.awsAuth\` for mapping
+users, roles and accounts.
+
+Furthermore, when auto-scaling group capacity is added to the cluster, the IAM instance role of the auto-scaling group will be automatically mapped to RBAC so nodes can connect to the cluster. No manual mapping is required.
+
+For example, let's say you want to grant an IAM user administrative privileges on your cluster:
+
+\`\`\`ts
+const adminUser = new iam.User(this, 'Admin');
+cluster.awsAuth.addUserMapping(adminUser, { groups: [ 'system:masters' ]});
+\`\`\`
+
+A convenience method for mapping a role to the \`system:masters\` group is also available:
+
+\`\`\`ts
+cluster.awsAuth.addMastersRole(role)
+\`\`\`
+
+### Cluster Security Group
+
+When you create an Amazon EKS cluster, a [cluster security group](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html)
+is automatically created as well. This security group is designed to allow all traffic from the control plane and managed node groups to flow freely
+between each other.
+
+The ID for that security group can be retrieved after creating the cluster.
+
+\`\`\`ts
+const clusterSecurityGroupId = cluster.clusterSecurityGroupId;
+\`\`\`
+
+### Node SSH Access
+
+If you want to be able to SSH into your worker nodes, you must already have an SSH key in the region you're connecting to and pass it when
+you add capacity to the cluster. You must also be able to connect to the hosts (meaning they must have a public IP and you
+should be allowed to connect to them on port 22):
+
+See [SSH into nodes](test/example.ssh-into-nodes.lit.ts) for a code example.
+
+If you want to SSH into nodes in a private subnet, you should set up a bastion host in a public subnet. That setup is recommended, but is
+unfortunately beyond the scope of this documentation.
+
+### Service Accounts
+
+With services account you can provide Kubernetes Pods access to AWS resources.
+
+\`\`\`ts
+// add service account
+const sa = cluster.addServiceAccount('MyServiceAccount');
+
+const bucket = new Bucket(this, 'Bucket');
+bucket.grantReadWrite(serviceAccount);
+
+const mypod = cluster.addManifest('mypod', {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: { name: 'mypod' },
+  spec: {
+    serviceAccountName: sa.serviceAccountName
+    containers: [
+      {
+        name: 'hello',
+        image: 'paulbouwer/hello-kubernetes:1.5',
+        ports: [ { containerPort: 8080 } ],
+
+      }
+    ]
+  }
+});
+
+// create the resource after the service account.
+mypod.node.addDependency(sa);
+
+// print the IAM role arn for this service account
+new cdk.CfnOutput(this, 'ServiceAccountIamRole', { value: sa.role.roleArn })
+\`\`\`
+
+Note that using \`sa.serviceAccountName\` above **does not** translate into a resource dependency.
+This is why an explicit dependency is needed. See <https://github.com/aws/aws-cdk/issues/9910> for more details.
+
+You can also add service accounts to existing clusters.
+To do so, pass the \`openIdConnectProvider\` property when you import the cluster into the application.
+
+\`\`\`ts
+// you can import an existing provider
+const provider = eks.OpenIdConnectProvider.fromOpenIdConnectProviderArn(this, 'Provider', 'arn:aws:iam::123456:oidc-provider/oidc.eks.eu-west-1.amazonaws.com/id/AB123456ABC');
+
+// or create a new one using an existing issuer url
+const provider = new eks.OpenIdConnectProvider(this, 'Provider', issuerUrl);
+
+const cluster = eks.Cluster.fromClusterAttributes({
+  clusterName: 'Cluster',
+  openIdConnectProvider: provider,
+  kubectlRoleArn: 'arn:aws:iam::123456:role/service-role/k8sservicerole',
+});
+
+const sa = cluster.addServiceAccount('MyServiceAccount');
+
+const bucket = new Bucket(this, 'Bucket');
+bucket.grantReadWrite(serviceAccount);
+
+// ...
+\`\`\`
+
+Note that adding service accounts requires running \`kubectl\` commands against the cluster.
+This means you must also pass the \`kubectlRoleArn\` when importing the cluster.
+See [Using existing Clusters](https://github.com/aws/aws-cdk/tree/master/packages/@aws-cdk/aws-eks#using-existing-clusters).
+
+## Applying Kubernetes Resources
+
+The library supports several popular resource deployment mechanisms, among which are:
+
+### Kubernetes Manifests
+
+The \`KubernetesManifest\` construct or \`cluster.addManifest\` method can be used
+to apply Kubernetes resource manifests to this cluster.
+
+> When using \`cluster.addManifest\`, the manifest construct is defined within the cluster's stack scope. If the manifest contains
+> attributes from a different stack which depend on the cluster stack, a circular dependency will be created and you will get a synth time error.
+> To avoid this, directly use \`new KubernetesManifest\` to create the manifest in the scope of the other stack.
+
+The following examples will deploy the [paulbouwer/hello-kubernetes](https://github.com/paulbouwer/hello-kubernetes)
+service on the cluster:
+
+\`\`\`ts
+const appLabel = { app: \\"hello-kubernetes\\" };
+
+const deployment = {
+  apiVersion: \\"apps/v1\\",
+  kind: \\"Deployment\\",
+  metadata: { name: \\"hello-kubernetes\\" },
+  spec: {
+    replicas: 3,
+    selector: { matchLabels: appLabel },
+    template: {
+      metadata: { labels: appLabel },
+      spec: {
+        containers: [
+          {
+            name: \\"hello-kubernetes\\",
+            image: \\"paulbouwer/hello-kubernetes:1.5\\",
+            ports: [ { containerPort: 8080 } ]
+          }
+        ]
+      }
+    }
+  }
+};
+
+const service = {
+  apiVersion: \\"v1\\",
+  kind: \\"Service\\",
+  metadata: { name: \\"hello-kubernetes\\" },
+  spec: {
+    type: \\"LoadBalancer\\",
+    ports: [ { port: 80, targetPort: 8080 } ],
+    selector: appLabel
+  }
+};
+
+// option 1: use a construct
+new KubernetesManifest(this, 'hello-kub', {
+  cluster,
+  manifest: [ deployment, service ]
+});
+
+// or, option2: use \`addManifest\`
+cluster.addManifest('hello-kub', service, deployment);
+\`\`\`
+
+#### Adding resources from a URL
+
+The following example will deploy the resource manifest hosting on remote server:
+
+\`\`\`ts
+import * as yaml from 'js-yaml';
+import * as request from 'sync-request';
+
+const manifestUrl = 'https://url/of/manifest.yaml';
+const manifest = yaml.safeLoadAll(request('GET', manifestUrl).getBody());
+cluster.addManifest('my-resource', ...manifest);
+\`\`\`
+
+#### Dependencies
+
+There are cases where Kubernetes resources must be deployed in a specific order.
+For example, you cannot define a resource in a Kubernetes namespace before the
+namespace was created.
+
+You can represent dependencies between \`KubernetesManifest\`s using
+\`resource.node.addDependency()\`:
+
+\`\`\`ts
+const namespace = cluster.addManifest('my-namespace', {
+  apiVersion: 'v1',
+  kind: 'Namespace',
+  metadata: { name: 'my-app' }
+});
+
+const service = cluster.addManifest('my-service', {
+  metadata: {
+    name: 'myservice',
+    namespace: 'my-app'
+  },
+  spec: // ...
+});
+
+service.node.addDependency(namespace); // will apply \`my-namespace\` before \`my-service\`.
+\`\`\`
+
+**NOTE:** when a \`KubernetesManifest\` includes multiple resources (either directly
+or through \`cluster.addManifest()\`) (e.g. \`cluster.addManifest('foo', r1, r2,
+r3,...)\`), these resources will be applied as a single manifest via \`kubectl\`
+and will be applied sequentially (the standard behavior in \`kubectl\`).
+
+---
+
+Since Kubernetes manifests are implemented as CloudFormation resources in the
+CDK. This means that if the manifest is deleted from your code (or the stack is
+deleted), the next \`cdk deploy\` will issue a \`kubectl delete\` command and the
+Kubernetes resources in that manifest will be deleted.
+
+#### Resource Pruning
+
+When a resource is deleted from a Kubernetes manifest, the EKS module will
+automatically delete these resources by injecting a _prune label_ to all
+manifest resources. This label is then passed to [\`kubectl apply --prune\`].
+
+[\`kubectl apply --prune\`]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#alternative-kubectl-apply-f-directory-prune-l-your-label
+
+Pruning is enabled by default but can be disabled through the \`prune\` option
+when a cluster is defined:
+
+\`\`\`ts
+new Cluster(this, 'MyCluster', {
+  prune: false
+});
+\`\`\`
+
+#### Manifests Validation
+
+The \`kubectl\` CLI supports applying a manifest by skipping the validation.
+This can be accomplished by setting the \`skipValidation\` flag to \`true\` in the \`KubernetesManifest\` props.
+
+\`\`\`ts
+new eks.KubernetesManifest(this, 'HelloAppWithoutValidation', {
+  cluster: this.cluster,
+  manifest: [ deployment, service ],
+  skipValidation: true,
+});
+\`\`\`
+
+### Helm Charts
+
+The \`HelmChart\` construct or \`cluster.addHelmChart\` method can be used
+to add Kubernetes resources to this cluster using Helm.
+
+> When using \`cluster.addHelmChart\`, the manifest construct is defined within the cluster's stack scope. If the manifest contains
+> attributes from a different stack which depend on the cluster stack, a circular dependency will be created and you will get a synth time error.
+> To avoid this, directly use \`new HelmChart\` to create the chart in the scope of the other stack.
+
+The following example will install the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/) to your cluster using Helm.
+
+\`\`\`ts
+// option 1: use a construct
+new HelmChart(this, 'NginxIngress', {
+  cluster,
+  chart: 'nginx-ingress',
+  repository: 'https://helm.nginx.com/stable',
+  namespace: 'kube-system'
+});
+
+// or, option2: use \`addHelmChart\`
+cluster.addHelmChart('NginxIngress', {
+  chart: 'nginx-ingress',
+  repository: 'https://helm.nginx.com/stable',
+  namespace: 'kube-system'
+});
+\`\`\`
+
+Helm charts will be installed and updated using \`helm upgrade --install\`, where a few parameters
+are being passed down (such as \`repo\`, \`values\`, \`version\`, \`namespace\`, \`wait\`, \`timeout\`, etc).
+This means that if the chart is added to CDK with the same release name, it will try to update
+the chart in the cluster.
+
+Helm charts are implemented as CloudFormation resources in CDK.
+This means that if the chart is deleted from your code (or the stack is
+deleted), the next \`cdk deploy\` will issue a \`helm uninstall\` command and the
+Helm chart will be deleted.
+
+When there is no \`release\` defined, a unique ID will be allocated for the release based
+on the construct path.
+
+By default, all Helm charts will be installed concurrently. In some cases, this
+could cause race conditions where two Helm charts attempt to deploy the same
+resource or if Helm charts depend on each other. You can use
+\`chart.node.addDependency()\` in order to declare a dependency order between
+charts:
+
+\`\`\`ts
+const chart1 = cluster.addHelmChart(...);
+const chart2 = cluster.addHelmChart(...);
+
+chart2.node.addDependency(chart1);
+\`\`\`
+
+#### CDK8s Charts
+
+[CDK8s](https://cdk8s.io/) is an open-source library that enables Kubernetes manifest authoring using familiar programming languages. It is founded on the same technologies as the AWS CDK, such as [\`constructs\`](https://github.com/aws/constructs) and [\`jsii\`](https://github.com/aws/jsii).
+
+> To learn more about cdk8s, visit the [Getting Started](https://github.com/awslabs/cdk8s/tree/master/docs/getting-started) tutorials.
+
+The EKS module natively integrates with cdk8s and allows you to apply cdk8s charts on AWS EKS clusters via the \`cluster.addCdk8sChart\` method.
+
+In addition to \`cdk8s\`, you can also use [\`cdk8s+\`](https://github.com/awslabs/cdk8s/tree/master/packages/cdk8s-plus), which provides higher level abstraction for the core kubernetes api objects.
+You can think of it like the \`L2\` constructs for Kubernetes. Any other \`cdk8s\` based libraries are also supported, for example [\`cdk8s-debore\`](https://github.com/toricls/cdk8s-debore).
+
+To get started, add the following dependencies to your \`package.json\` file:
+
+\`\`\`json
+\\"dependencies\\": {
+  \\"cdk8s\\": \\"0.30.0\\",
+  \\"cdk8s-plus\\": \\"0.30.0\\",
+  \\"constructs\\": \\"3.0.4\\"
+}
+\`\`\`
+
+> Note that the version of \`cdk8s\` must be \`>=0.30.0\`.
+
+Similarly to how you would create a stack by extending \`@aws-cdk/core.Stack\`, we recommend you create a chart of your own that extends \`cdk8s.Chart\`,
+and add your kubernetes resources to it. You can use \`aws-cdk\` construct attributes and properties inside your \`cdk8s\` construct freely.
+
+In this example we create a chart that accepts an \`s3.Bucket\` and passes its name to a kubernetes pod as an environment variable.
+
+Notice that the chart must accept a \`constructs.Construct\` type as its scope, not an \`@aws-cdk/core.Construct\` as you would normally use.
+For this reason, to avoid possible confusion, we will create the chart in a separate file:
+
+\`+ my-chart.ts\`
+
+\`\`\`ts
+import { aws_s3 as s3 } from 'aws-cdk-lib';
+import * as constructs from 'constructs';
+import * as cdk8s from 'cdk8s';
+import * as kplus from 'cdk8s-plus';
+
+export interface MyChartProps {
+  readonly bucket: s3.Bucket;
+}
+
+export class MyChart extends cdk8s.Chart {
+  constructor(scope: constructs.Construct, id: string, props: MyChartProps) {
+    super(scope, id);
+
+    new kplus.Pod(this, 'Pod', {
+      spec: {
+        containers: [
+          new kplus.Container({
+            image: 'my-image',
+            env: {
+              BUCKET_NAME: kplus.EnvValue.fromValue(props.bucket.bucketName),
+            },
+          }),
+        ],
+      },
+    });
+  }
+}
+\`\`\`
+
+Then, in your AWS CDK app:
+
+\`\`\`ts
+import { aws_s3 as s3 } from 'aws-cdk-lib';
+import * as cdk8s from 'cdk8s';
+import { MyChart } from './my-chart';
+
+// some bucket..
+const bucket = new s3.Bucket(this, 'Bucket');
+
+// create a cdk8s chart and use \`cdk8s.App\` as the scope.
+const myChart = new MyChart(new cdk8s.App(), 'MyChart', { bucket });
+
+// add the cdk8s chart to the cluster
+cluster.addCdk8sChart('my-chart', myChart);
+\`\`\`
+
+##### Custom CDK8s Constructs
+
+You can also compose a few stock \`cdk8s+\` constructs into your own custom construct. However, since mixing scopes between \`aws-cdk\` and \`cdk8s\` is currently not supported, the \`Construct\` class
+you'll need to use is the one from the [\`constructs\`](https://github.com/aws/constructs) module, and not from \`@aws-cdk/core\` like you normally would.
+This is why we used \`new cdk8s.App()\` as the scope of the chart above.
+
+\`\`\`ts
+import * as constructs from 'constructs';
+import * as cdk8s from 'cdk8s';
+import * as kplus from 'cdk8s-plus';
+
+export interface LoadBalancedWebService {
+  readonly port: number;
+  readonly image: string;
+  readonly replicas: number;
+}
+
+export class LoadBalancedWebService extends constructs.Construct {
+  constructor(scope: constructs.Construct, id: string, props: LoadBalancedWebService) {
+    super(scope, id);
+
+    const deployment = new kplus.Deployment(chart, 'Deployment', {
+      spec: {
+        replicas: props.replicas,
+        podSpecTemplate: {
+          containers: [ new kplus.Container({ image: props.image }) ]
+        }
+      },
+    });
+
+    deployment.expose({port: props.port, serviceType: kplus.ServiceType.LOAD_BALANCER})
+
+  }
+}
+\`\`\`
+
+##### Manually importing k8s specs and CRD's
+
+If you find yourself unable to use \`cdk8s+\`, or just like to directly use the \`k8s\` native objects or CRD's, you can do so by manually importing them using the \`cdk8s-cli\`.
+
+See [Importing kubernetes objects](https://github.com/awslabs/cdk8s/tree/master/packages/cdk8s-cli#import) for detailed instructions.
+
+## Patching Kubernetes Resources
+
+The \`KubernetesPatch\` construct can be used to update existing kubernetes
+resources. The following example can be used to patch the \`hello-kubernetes\`
+deployment from the example above with 5 replicas.
+
+\`\`\`ts
+new KubernetesPatch(this, 'hello-kub-deployment-label', {
+  cluster,
+  resourceName: \\"deployment/hello-kubernetes\\",
+  applyPatch: { spec: { replicas: 5 } },
+  restorePatch: { spec: { replicas: 3 } }
+})
+\`\`\`
+
+## Querying Kubernetes Resources
+
+The \`KubernetesObjectValue\` construct can be used to query for information about kubernetes objects,
+and use that as part of your CDK application.
+
+For example, you can fetch the address of a [\`LoadBalancer\`](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) type service:
+
+\`\`\`ts
+// query the load balancer address
+const myServiceAddress = new KubernetesObjectValue(this, 'LoadBalancerAttribute', {
+  cluster: cluster,
+  objectType: 'service',
+  objectName: 'my-service',
+  jsonPath: '.status.loadBalancer.ingress[0].hostname', // https://kubernetes.io/docs/reference/kubectl/jsonpath/
+});
+
+// pass the address to a lambda function
+const proxyFunction = new lambda.Function(this, 'ProxyFunction', {
+  ...
+  environment: {
+    myServiceAddress: myServiceAddress.value
+  },
+})
+\`\`\`
+
+Specifically, since the above use-case is quite common, there is an easier way to access that information:
+
+\`\`\`ts
+const loadBalancerAddress = cluster.getServiceLoadBalancerAddress('my-service');
+\`\`\`
+
+## Using existing clusters
+
+The Amazon EKS library allows defining Kubernetes resources such as [Kubernetes
+manifests](#kubernetes-resources) and [Helm charts](#helm-charts) on clusters
+that are not defined as part of your CDK app.
+
+First, you'll need to \\"import\\" a cluster to your CDK app. To do that, use the
+\`eks.Cluster.fromClusterAttributes()\` static method:
+
+\`\`\`ts
+const cluster = eks.Cluster.fromClusterAttributes(this, 'MyCluster', {
+  clusterName: 'my-cluster-name',
+  kubectlRoleArn: 'arn:aws:iam::1111111:role/iam-role-that-has-masters-access',
+});
+\`\`\`
+
+Then, you can use \`addManifest\` or \`addHelmChart\` to define resources inside
+your Kubernetes cluster. For example:
+
+\`\`\`ts
+cluster.addManifest('Test', {
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  metadata: {
+    name: 'myconfigmap',
+  },
+  data: {
+    Key: 'value',
+    Another: '123454',
+  },
+});
+\`\`\`
+
+At the minimum, when importing clusters for \`kubectl\` management, you will need
+to specify:
+
+* \`clusterName\` - the name of the cluster.
+* \`kubectlRoleArn\` - the ARN of an IAM role mapped to the \`system:masters\` RBAC
+  role. If the cluster you are importing was created using the AWS CDK, the
+  CloudFormation stack has an output that includes an IAM role that can be used.
+  Otherwise, you can create an IAM role and map it to \`system:masters\` manually.
+  The trust policy of this role should include the the
+  \`arn:aws::iam::\${accountId}:root\` principal in order to allow the execution
+  role of the kubectl resource to assume it.
+
+If the cluster is configured with private-only or private and restricted public
+Kubernetes [endpoint access](#endpoint-access), you must also specify:
+
+* \`kubectlSecurityGroupId\` - the ID of an EC2 security group that is allowed
+  connections to the cluster's control security group. For example, the EKS managed [cluster security group](#cluster-security-group).
+* \`kubectlPrivateSubnetIds\` - a list of private VPC subnets IDs that will be used
+  to access the Kubernetes endpoint.
+
+## Known Issues and Limitations
+
+* [One cluster per stack](https://github.com/aws/aws-cdk/issues/10073)
+* [Service Account dependencies](https://github.com/aws/aws-cdk/issues/9910)
+* [Support isolated VPCs](https://github.com/aws/aws-cdk/issues/12171)
+
+# API Reference <a name=\\"API Reference\\"></a>
+
+## Constructs <a name=\\"Constructs\\"></a>
+
+### AwsAuth <a name=\\"software.amazon.awscdk.services.eks.AwsAuth\\"></a>
+
+Manages mapping between IAM users and roles to Kubernetes RBAC configuration.
+
+> https://docs.aws.amazon.com/en_us/eks/latest/userguide/add-user-role.html
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.AwsAuth;
+
+AwsAuth.Builder.create(Construct scope, java.lang.String id)
+    .cluster(Cluster)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuthProps.parameter.cluster\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.Cluster\`](#software.amazon.awscdk.services.eks.Cluster)
+
+The EKS cluster to apply this configuration to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+#### Methods <a name=\\"Methods\\"></a>
+
+##### \`addAccount\` <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.addAccount\\"></a>
+
+\`\`\`java
+public addAccount(java.lang.String accountId)
+\`\`\`
+
+###### \`accountId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.parameter.accountId\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+account number.
+
+---
+
+##### \`addMastersRole\` <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.addMastersRole\\"></a>
+
+\`\`\`java
+public addMastersRole(IRole role)
+public addMastersRole(IRole role, java.lang.String username)
+\`\`\`
+
+###### \`role\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.parameter.role\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+
+The IAM role to add.
+
+---
+
+###### \`username\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.parameter.username\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+Optional user (defaults to the role ARN).
+
+---
+
+##### \`addRoleMapping\` <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.addRoleMapping\\"></a>
+
+\`\`\`java
+public addRoleMapping(IRole role, AwsAuthMapping mapping)
+\`\`\`
+
+###### \`role\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.parameter.role\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+
+The IAM role to map.
+
+---
+
+###### \`mapping\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.parameter.mapping\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.AwsAuthMapping\`](#software.amazon.awscdk.services.eks.AwsAuthMapping)
+
+Mapping to k8s user name and groups.
+
+---
+
+##### \`addUserMapping\` <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.addUserMapping\\"></a>
+
+\`\`\`java
+public addUserMapping(IUser user, AwsAuthMapping mapping)
+\`\`\`
+
+###### \`user\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.parameter.user\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IUser\`](#software.amazon.awscdk.services.iam.IUser)
+
+The IAM user to map.
+
+---
+
+###### \`mapping\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuth.parameter.mapping\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.AwsAuthMapping\`](#software.amazon.awscdk.services.eks.AwsAuthMapping)
+
+Mapping to k8s user name and groups.
+
+---
+
+
+
+
+### CfnAddon <a name=\\"software.amazon.awscdk.services.eks.CfnAddon\\"></a>
+
+- *Implements:* [\`software.amazon.awscdk.core.IInspectable\`](#software.amazon.awscdk.core.IInspectable)
+
+A CloudFormation \`AWS::EKS::Addon\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html)
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnAddon;
+
+CfnAddon.Builder.create(Construct scope, java.lang.String id)
+    .addonName(java.lang.String)
+    .clusterName(java.lang.String)
+//  .addonVersion(java.lang.String)
+//  .resolveConflicts(java.lang.String)
+//  .serviceAccountRoleArn(java.lang.String)
+//  .tags(java.util.List<CfnTag>)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.parameter.scope\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.Construct\`](#software.amazon.awscdk.core.Construct)
+
+scope in which this resource is defined.
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+scoped id of the resource.
+
+---
+
+##### \`addonName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.parameter.addonName\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.AddonName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonname](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonname)
+
+---
+
+##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.parameter.clusterName\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-clustername)
+
+---
+
+##### \`addonVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.parameter.addonVersion\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.AddonVersion\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonversion](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonversion)
+
+---
+
+##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.parameter.resolveConflicts\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.ResolveConflicts\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-resolveconflicts](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-resolveconflicts)
+
+---
+
+##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.parameter.serviceAccountRoleArn\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.ServiceAccountRoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-serviceaccountrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-serviceaccountrolearn)
+
+---
+
+##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.parameter.tags\\"></a>
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
+
+\`AWS::EKS::Addon.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-tags)
+
+---
+
+#### Methods <a name=\\"Methods\\"></a>
+
+##### \`inspect\` <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.inspect\\"></a>
+
+\`\`\`java
+public inspect(TreeInspector inspector)
+\`\`\`
+
+###### \`inspector\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.parameter.inspector\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.TreeInspector\`](#software.amazon.awscdk.core.TreeInspector)
+
+tree inspector to collect and process attributes.
+
+---
+
+
+#### Properties <a name=\\"Properties\\"></a>
+
+##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.attrArn\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.tags\\"></a>
+
+\`\`\`java
+public TagManager getTags();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.TagManager\`](#software.amazon.awscdk.core.TagManager)
+
+\`AWS::EKS::Addon.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-tags)
+
+---
+
+##### \`addonName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.addonName\\"></a>
+
+\`\`\`java
+public java.lang.String getAddonName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.AddonName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonname](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonname)
+
+---
+
+##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-clustername)
+
+---
+
+##### \`addonVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.addonVersion\\"></a>
+
+\`\`\`java
+public java.lang.String getAddonVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.AddonVersion\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonversion](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonversion)
+
+---
+
+##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.resolveConflicts\\"></a>
+
+\`\`\`java
+public java.lang.String getResolveConflicts();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.ResolveConflicts\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-resolveconflicts](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-resolveconflicts)
+
+---
+
+##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.serviceAccountRoleArn\\"></a>
+
+\`\`\`java
+public java.lang.String getServiceAccountRoleArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.ServiceAccountRoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-serviceaccountrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-serviceaccountrolearn)
+
+---
+
+#### Constants <a name=\\"Constants\\"></a>
+
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.eks.CfnAddon.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The CloudFormation resource type name for this resource class.
+
+---
+
+### CfnCluster <a name=\\"software.amazon.awscdk.services.eks.CfnCluster\\"></a>
+
+- *Implements:* [\`software.amazon.awscdk.core.IInspectable\`](#software.amazon.awscdk.core.IInspectable)
+
+A CloudFormation \`AWS::EKS::Cluster\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html)
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnCluster;
+
+CfnCluster.Builder.create(Construct scope, java.lang.String id)
+    .resourcesVpcConfig(ResourcesVpcConfigProperty)
+    .resourcesVpcConfig(IResolvable)
+    .roleArn(java.lang.String)
+//  .encryptionConfig(IResolvable)
+//  .encryptionConfig(java.util.List<EncryptionConfigProperty)
+//  .encryptionConfig(IResolvable>)
+//  .kubernetesNetworkConfig(KubernetesNetworkConfigProperty)
+//  .kubernetesNetworkConfig(IResolvable)
+//  .name(java.lang.String)
+//  .version(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.parameter.scope\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.Construct\`](#software.amazon.awscdk.core.Construct)
+
+scope in which this resource is defined.
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+scoped id of the resource.
+
+---
+
+##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.parameter.resourcesVpcConfig\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Cluster.ResourcesVpcConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-resourcesvpcconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-resourcesvpcconfig)
+
+---
+
+##### \`roleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.parameter.roleArn\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Cluster.RoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-rolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-rolearn)
+
+---
+
+##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.parameter.encryptionConfig\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)>
+
+\`AWS::EKS::Cluster.EncryptionConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig)
+
+---
+
+##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.parameter.kubernetesNetworkConfig\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Cluster.KubernetesNetworkConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-kubernetesnetworkconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-kubernetesnetworkconfig)
+
+---
+
+##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.parameter.name\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Cluster.Name\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name)
+
+---
+
+##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.parameter.version\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Cluster.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version)
+
+---
+
+#### Methods <a name=\\"Methods\\"></a>
+
+##### \`inspect\` <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.inspect\\"></a>
+
+\`\`\`java
+public inspect(TreeInspector inspector)
+\`\`\`
+
+###### \`inspector\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.parameter.inspector\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.TreeInspector\`](#software.amazon.awscdk.core.TreeInspector)
+
+tree inspector to collect and process attributes.
+
+---
+
+
+#### Properties <a name=\\"Properties\\"></a>
+
+##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrArn\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`attrCertificateAuthorityData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrCertificateAuthorityData\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrCertificateAuthorityData();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`attrClusterSecurityGroupId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrClusterSecurityGroupId\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrClusterSecurityGroupId();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`attrEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrEncryptionConfigKeyArn\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrEncryptionConfigKeyArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`attrEndpoint\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrEndpoint\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrEndpoint();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`attrOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.attrOpenIdConnectIssuerUrl\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrOpenIdConnectIssuerUrl();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.resourcesVpcConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getResourcesVpcConfig();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Cluster.ResourcesVpcConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-resourcesvpcconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-resourcesvpcconfig)
+
+---
+
+##### \`roleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.roleArn\\"></a>
+
+\`\`\`java
+public java.lang.String getRoleArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Cluster.RoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-rolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-rolearn)
+
+---
+
+##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.encryptionConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getEncryptionConfig();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)>
+
+\`AWS::EKS::Cluster.EncryptionConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig)
+
+---
+
+##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.kubernetesNetworkConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getKubernetesNetworkConfig();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Cluster.KubernetesNetworkConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-kubernetesnetworkconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-kubernetesnetworkconfig)
+
+---
+
+##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.name\\"></a>
+
+\`\`\`java
+public java.lang.String getName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Cluster.Name\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name)
+
+---
+
+##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Cluster.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version)
+
+---
+
+#### Constants <a name=\\"Constants\\"></a>
+
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The CloudFormation resource type name for this resource class.
+
+---
+
+### CfnFargateProfile <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile\\"></a>
+
+- *Implements:* [\`software.amazon.awscdk.core.IInspectable\`](#software.amazon.awscdk.core.IInspectable)
+
+A CloudFormation \`AWS::EKS::FargateProfile\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html)
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnFargateProfile;
+
+CfnFargateProfile.Builder.create(Construct scope, java.lang.String id)
+    .clusterName(java.lang.String)
+    .podExecutionRoleArn(java.lang.String)
+    .selectors(IResolvable)
+    .selectors(java.util.List<SelectorProperty)
+    .selectors(IResolvable>)
+//  .fargateProfileName(java.lang.String)
+//  .subnets(java.util.List<java.lang.String>)
+//  .tags(java.util.List<CfnTag>)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.parameter.scope\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.Construct\`](#software.amazon.awscdk.core.Construct)
+
+scope in which this resource is defined.
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+scoped id of the resource.
+
+---
+
+##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.parameter.clusterName\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::FargateProfile.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-clustername)
+
+---
+
+##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.parameter.podExecutionRoleArn\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::FargateProfile.PodExecutionRoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-podexecutionrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-podexecutionrolearn)
+
+---
+
+##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.parameter.selectors\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty\`](#software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)>
+
+\`AWS::EKS::FargateProfile.Selectors\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-selectors](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-selectors)
+
+---
+
+##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.parameter.fargateProfileName\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::FargateProfile.FargateProfileName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-fargateprofilename](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-fargateprofilename)
+
+---
+
+##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.parameter.subnets\\"></a>
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`AWS::EKS::FargateProfile.Subnets\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-subnets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-subnets)
+
+---
+
+##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.parameter.tags\\"></a>
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
+
+\`AWS::EKS::FargateProfile.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-tags)
+
+---
+
+#### Methods <a name=\\"Methods\\"></a>
+
+##### \`inspect\` <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.inspect\\"></a>
+
+\`\`\`java
+public inspect(TreeInspector inspector)
+\`\`\`
+
+###### \`inspector\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.parameter.inspector\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.TreeInspector\`](#software.amazon.awscdk.core.TreeInspector)
+
+tree inspector to collect and process attributes.
+
+---
+
+
+#### Properties <a name=\\"Properties\\"></a>
+
+##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.attrArn\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.tags\\"></a>
+
+\`\`\`java
+public TagManager getTags();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.TagManager\`](#software.amazon.awscdk.core.TagManager)
+
+\`AWS::EKS::FargateProfile.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-tags)
+
+---
+
+##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::FargateProfile.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-clustername)
+
+---
+
+##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.podExecutionRoleArn\\"></a>
+
+\`\`\`java
+public java.lang.String getPodExecutionRoleArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::FargateProfile.PodExecutionRoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-podexecutionrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-podexecutionrolearn)
+
+---
+
+##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.selectors\\"></a>
+
+\`\`\`java
+public java.lang.Object getSelectors();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty\`](#software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)>
+
+\`AWS::EKS::FargateProfile.Selectors\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-selectors](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-selectors)
+
+---
+
+##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.fargateProfileName\\"></a>
+
+\`\`\`java
+public java.lang.String getFargateProfileName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::FargateProfile.FargateProfileName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-fargateprofilename](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-fargateprofilename)
+
+---
+
+##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.subnets\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getSubnets();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`AWS::EKS::FargateProfile.Subnets\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-subnets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-subnets)
+
+---
+
+#### Constants <a name=\\"Constants\\"></a>
+
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The CloudFormation resource type name for this resource class.
+
+---
+
+### CfnNodegroup <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup\\"></a>
+
+- *Implements:* [\`software.amazon.awscdk.core.IInspectable\`](#software.amazon.awscdk.core.IInspectable)
+
+A CloudFormation \`AWS::EKS::Nodegroup\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html)
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnNodegroup;
+
+CfnNodegroup.Builder.create(Construct scope, java.lang.String id)
+    .clusterName(java.lang.String)
+    .nodeRole(java.lang.String)
+    .subnets(java.util.List<java.lang.String>)
+//  .amiType(java.lang.String)
+//  .capacityType(java.lang.String)
+//  .diskSize(java.lang.Number)
+//  .forceUpdateEnabled(java.lang.Boolean)
+//  .forceUpdateEnabled(IResolvable)
+//  .instanceTypes(java.util.List<java.lang.String>)
+//  .labels(java.lang.Object)
+//  .launchTemplate(LaunchTemplateSpecificationProperty)
+//  .launchTemplate(IResolvable)
+//  .nodegroupName(java.lang.String)
+//  .releaseVersion(java.lang.String)
+//  .remoteAccess(RemoteAccessProperty)
+//  .remoteAccess(IResolvable)
+//  .scalingConfig(ScalingConfigProperty)
+//  .scalingConfig(IResolvable)
+//  .tags(java.lang.Object)
+//  .taints(IResolvable)
+//  .taints(java.util.List<TaintProperty)
+//  .taints(IResolvable>)
+//  .version(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.parameter.scope\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.Construct\`](#software.amazon.awscdk.core.Construct)
+
+scope in which this resource is defined.
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+scoped id of the resource.
+
+---
+
+##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.clusterName\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername)
+
+---
+
+##### \`nodeRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.nodeRole\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.NodeRole\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-noderole](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-noderole)
+
+---
+
+##### \`subnets\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.subnets\\"></a>
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`AWS::EKS::Nodegroup.Subnets\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-subnets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-subnets)
+
+---
+
+##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.amiType\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.AmiType\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype)
+
+---
+
+##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.capacityType\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.CapacityType\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype)
+
+---
+
+##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.diskSize\\"></a>
+
+- *Type:* \`java.lang.Number\`
+
+\`AWS::EKS::Nodegroup.DiskSize\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-disksize](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-disksize)
+
+---
+
+##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.forceUpdateEnabled\\"></a>
+
+- *Type:* \`java.lang.Boolean\` OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Nodegroup.ForceUpdateEnabled\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-forceupdateenabled](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-forceupdateenabled)
+
+---
+
+##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.instanceTypes\\"></a>
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`AWS::EKS::Nodegroup.InstanceTypes\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes)
+
+---
+
+##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.labels\\"></a>
+
+- *Type:* \`java.lang.Object\`
+
+\`AWS::EKS::Nodegroup.Labels\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-labels](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-labels)
+
+---
+
+##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.launchTemplate\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Nodegroup.LaunchTemplate\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-launchtemplate](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-launchtemplate)
+
+---
+
+##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.nodegroupName\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.NodegroupName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-nodegroupname](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-nodegroupname)
+
+---
+
+##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.releaseVersion\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.ReleaseVersion\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion)
+
+---
+
+##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.remoteAccess\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Nodegroup.RemoteAccess\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-remoteaccess](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-remoteaccess)
+
+---
+
+##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.scalingConfig\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Nodegroup.ScalingConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-scalingconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-scalingconfig)
+
+---
+
+##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.tags\\"></a>
+
+- *Type:* \`java.lang.Object\`
+
+\`AWS::EKS::Nodegroup.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-tags)
+
+---
+
+##### \`taints\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.taints\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)>
+
+\`AWS::EKS::Nodegroup.Taints\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints)
+
+---
+
+##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.parameter.version\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version)
+
+---
+
+#### Methods <a name=\\"Methods\\"></a>
+
+##### \`inspect\` <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.inspect\\"></a>
+
+\`\`\`java
+public inspect(TreeInspector inspector)
+\`\`\`
+
+###### \`inspector\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.parameter.inspector\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.TreeInspector\`](#software.amazon.awscdk.core.TreeInspector)
+
+tree inspector to collect and process attributes.
+
+---
+
+
+#### Properties <a name=\\"Properties\\"></a>
+
+##### \`attrArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.attrArn\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`attrClusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.attrClusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`attrNodegroupName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.attrNodegroupName\\"></a>
+
+\`\`\`java
+public java.lang.String getAttrNodegroupName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.tags\\"></a>
+
+\`\`\`java
+public TagManager getTags();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.TagManager\`](#software.amazon.awscdk.core.TagManager)
+
+\`AWS::EKS::Nodegroup.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-tags)
+
+---
+
+##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername)
+
+---
+
+##### \`labels\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.labels\\"></a>
+
+\`\`\`java
+public java.lang.Object getLabels();
+\`\`\`
+
+- *Type:* \`java.lang.Object\`
+
+\`AWS::EKS::Nodegroup.Labels\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-labels](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-labels)
+
+---
+
+##### \`nodeRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.nodeRole\\"></a>
+
+\`\`\`java
+public java.lang.String getNodeRole();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.NodeRole\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-noderole](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-noderole)
+
+---
+
+##### \`subnets\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.subnets\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getSubnets();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`AWS::EKS::Nodegroup.Subnets\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-subnets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-subnets)
+
+---
+
+##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.amiType\\"></a>
+
+\`\`\`java
+public java.lang.String getAmiType();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.AmiType\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype)
+
+---
+
+##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.capacityType\\"></a>
+
+\`\`\`java
+public java.lang.String getCapacityType();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.CapacityType\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype)
+
+---
+
+##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.diskSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getDiskSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+
+\`AWS::EKS::Nodegroup.DiskSize\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-disksize](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-disksize)
+
+---
+
+##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.forceUpdateEnabled\\"></a>
+
+\`\`\`java
+public java.lang.Object getForceUpdateEnabled();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\` OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Nodegroup.ForceUpdateEnabled\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-forceupdateenabled](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-forceupdateenabled)
+
+---
+
+##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.instanceTypes\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getInstanceTypes();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`AWS::EKS::Nodegroup.InstanceTypes\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes)
+
+---
+
+##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.launchTemplate\\"></a>
+
+\`\`\`java
+public java.lang.Object getLaunchTemplate();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Nodegroup.LaunchTemplate\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-launchtemplate](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-launchtemplate)
+
+---
+
+##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.nodegroupName\\"></a>
+
+\`\`\`java
+public java.lang.String getNodegroupName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.NodegroupName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-nodegroupname](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-nodegroupname)
+
+---
+
+##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.releaseVersion\\"></a>
+
+\`\`\`java
+public java.lang.String getReleaseVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.ReleaseVersion\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion)
+
+---
+
+##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.remoteAccess\\"></a>
+
+\`\`\`java
+public java.lang.Object getRemoteAccess();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Nodegroup.RemoteAccess\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-remoteaccess](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-remoteaccess)
+
+---
+
+##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.scalingConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getScalingConfig();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Nodegroup.ScalingConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-scalingconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-scalingconfig)
+
+---
+
+##### \`taints\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.taints\\"></a>
+
+\`\`\`java
+public java.lang.Object getTaints();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)>
+
+\`AWS::EKS::Nodegroup.Taints\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints)
+
+---
+
+##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version)
+
+---
+
+#### Constants <a name=\\"Constants\\"></a>
+
+##### \`CFN_RESOURCE_TYPE_NAME\` <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.property.CFN_RESOURCE_TYPE_NAME\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The CloudFormation resource type name for this resource class.
+
+---
+
+### Cluster <a name=\\"software.amazon.awscdk.services.eks.Cluster\\"></a>
+
+- *Implements:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+A Cluster represents a managed Kubernetes Service (EKS).
+
+This is a fully managed cluster of API Servers (control-plane)
+The user is still required to create the worker nodes.
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.Cluster.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.Cluster;
+
+Cluster.Builder.create(Construct scope, java.lang.String id)
+    .version(KubernetesVersion)
+//  .clusterName(java.lang.String)
+//  .outputClusterName(java.lang.Boolean)
+//  .outputConfigCommand(java.lang.Boolean)
+//  .role(IRole)
+//  .securityGroup(ISecurityGroup)
+//  .vpc(IVpc)
+//  .vpcSubnets(java.util.List<SubnetSelection>)
+//  .clusterHandlerEnvironment(java.util.Map<java.lang.String, java.lang.String>)
+//  .coreDnsComputeType(CoreDnsComputeType)
+//  .endpointAccess(EndpointAccess)
+//  .kubectlEnvironment(java.util.Map<java.lang.String, java.lang.String>)
+//  .kubectlLayer(ILayerVersion)
+//  .kubectlMemory(Size)
+//  .mastersRole(IRole)
+//  .outputMastersRoleArn(java.lang.Boolean)
+//  .placeClusterHandlerInVpc(java.lang.Boolean)
+//  .prune(java.lang.Boolean)
+//  .secretsEncryptionKey(IKey)
+//  .defaultCapacity(java.lang.Number)
+//  .defaultCapacityInstance(InstanceType)
+//  .defaultCapacityType(DefaultCapacityType)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+a Construct, most likely a cdk.Stack created.
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+the id of the Construct to create.
+
+---
+
+##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.version\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
+
+The Kubernetes version to run in the cluster.
+
+---
+
+##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.clusterName\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* Automatically generated name
+
+Name for the cluster.
+
+---
+
+##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.outputClusterName\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the name of the cluster will be synthesized.
+
+---
+
+##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.outputConfigCommand\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Determines whether a CloudFormation output with the \`aws eks update-kubeconfig\` command will be synthesized.
+
+This command will include
+the cluster name and, if applicable, the ARN of the masters IAM role.
+
+---
+
+##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.role\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* A role is automatically created for you
+
+Role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
+
+---
+
+##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.securityGroup\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
+- *Default:* A security group is automatically created
+
+Security Group to use for Control Plane ENIs.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.vpc\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
+- *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
+
+The VPC in which to create the Cluster.
+
+---
+
+##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.vpcSubnets\\"></a>
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
+- *Default:* All public and private subnets
+
+Where to place EKS Control Plane ENIs.
+
+If you want to create public load balancers, this must include public subnets.
+
+For example, to only select private subnets, supply the following:
+
+\`\`\`ts
+vpcSubnets: [
+   { subnetType: ec2.SubnetType.Private }
+]
+\`\`\`
+
+---
+
+##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.clusterHandlerEnvironment\\"></a>
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* No environment variables.
+
+Custom environment variables when interacting with the EKS endpoint to manage the cluster lifecycle.
+
+---
+
+##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.coreDnsComputeType\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CoreDnsComputeType\`](#software.amazon.awscdk.services.eks.CoreDnsComputeType)
+- *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
+
+Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS configuration on your cluster to determine which compute type to use for CoreDNS.
+
+---
+
+##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.endpointAccess\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
+- *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
+
+Configure access to the Kubernetes API server endpoint..
+
+> https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+
+---
+
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.kubectlEnvironment\\"></a>
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* No environment variables.
+
+Environment variables for the kubectl execution.
+
+Only relevant for kubectl enabled clusters.
+
+---
+
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.kubectlLayer\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
+- *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+By default, the provider will use the layer included in the
+\\"aws-lambda-layer-kubectl\\" SAR application which is available in all
+commercial regions.
+
+To deploy the layer locally, visit
+https://github.com/aws-samples/aws-lambda-layer-kubectl/blob/master/cdk/README.md
+for instructions on how to prepare the .zip file and then define it in your
+app as follows:
+
+\`\`\`ts
+const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
+   code: lambda.Code.fromAsset(\`\${__dirname}/layer.zip\`)),
+   compatibleRuntimes: [lambda.Runtime.PROVIDED]
+})
+\`\`\`
+
+> https://github.com/aws-samples/aws-lambda-layer-kubectl
+
+---
+
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.kubectlMemory\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.Size\`](#software.amazon.awscdk.core.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`mastersRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.mastersRole\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* a role that assumable by anyone with permissions in the same
+account will automatically be defined
+
+An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.outputMastersRoleArn\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM role will be synthesized (if \`mastersRole\` is specified).
+
+---
+
+##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.placeClusterHandlerInVpc\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+If set to true, the cluster handler functions will be placed in the private subnets of the cluster vpc, subject to the \`vpcSubnets\` selection strategy.
+
+---
+
+##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.prune\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.secretsEncryptionKey\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.kms.IKey\`](#software.amazon.awscdk.services.kms.IKey)
+- *Default:* By default, Kubernetes stores all secret object data within etcd and
+  all etcd volumes used by Amazon EKS are encrypted at the disk-level
+  using AWS-Managed encryption keys.
+
+KMS secret for envelope encryption for Kubernetes secrets.
+
+---
+
+##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.defaultCapacity\\"></a>
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 2
+
+Number of instances to allocate as an initial capacity for this cluster.
+
+Instance type can be configured through \`defaultCapacityInstanceType\`,
+which defaults to \`m5.large\`.
+
+Use \`cluster.addAutoScalingGroupCapacity\` to add additional customized capacity. Set this
+to \`0\` is you wish to avoid the initial capacity allocation.
+
+---
+
+##### \`defaultCapacityInstance\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.defaultCapacityInstance\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)
+- *Default:* m5.large
+
+The instance type to use for the default capacity.
+
+This will only be taken
+into account if \`defaultCapacity\` is > 0.
+
+---
+
+##### \`defaultCapacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.parameter.defaultCapacityType\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.DefaultCapacityType\`](#software.amazon.awscdk.services.eks.DefaultCapacityType)
+- *Default:* NODEGROUP
+
+The default capacity type for the cluster.
+
+---
+
+#### Methods <a name=\\"Methods\\"></a>
+
+##### \`addAutoScalingGroupCapacity\` <a name=\\"software.amazon.awscdk.services.eks.Cluster.addAutoScalingGroupCapacity\\"></a>
+
+\`\`\`java
+public addAutoScalingGroupCapacity(java.lang.String id, AutoScalingGroupCapacityOptions options)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+###### \`options\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.options\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions\`](#software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions)
+
+---
+
+##### \`addCdk8sChart\` <a name=\\"software.amazon.awscdk.services.eks.Cluster.addCdk8sChart\\"></a>
+
+\`\`\`java
+public addCdk8sChart(java.lang.String id, Construct chart)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+logical id of this chart.
+
+---
+
+###### \`chart\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.chart\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+the cdk8s chart.
+
+---
+
+##### \`addFargateProfile\` <a name=\\"software.amazon.awscdk.services.eks.Cluster.addFargateProfile\\"></a>
+
+\`\`\`java
+public addFargateProfile(java.lang.String id, FargateProfileOptions options)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+the id of this profile.
+
+---
+
+###### \`options\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.options\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.FargateProfileOptions\`](#software.amazon.awscdk.services.eks.FargateProfileOptions)
+
+profile options.
+
+---
+
+##### \`addHelmChart\` <a name=\\"software.amazon.awscdk.services.eks.Cluster.addHelmChart\\"></a>
+
+\`\`\`java
+public addHelmChart(java.lang.String id, HelmChartOptions options)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+logical id of this chart.
+
+---
+
+###### \`options\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.options\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.HelmChartOptions\`](#software.amazon.awscdk.services.eks.HelmChartOptions)
+
+options of this chart.
+
+---
+
+##### \`addManifest\` <a name=\\"software.amazon.awscdk.services.eks.Cluster.addManifest\\"></a>
+
+\`\`\`java
+public addManifest(java.lang.String id, java.util.Map<java.lang.String, java.lang.Object> manifest)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+logical id of this manifest.
+
+---
+
+###### \`manifest\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.manifest\\"></a>
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
+
+a list of Kubernetes resource specifications.
+
+---
+
+##### \`addNodegroupCapacity\` <a name=\\"software.amazon.awscdk.services.eks.Cluster.addNodegroupCapacity\\"></a>
+
+\`\`\`java
+public addNodegroupCapacity(java.lang.String id)
+public addNodegroupCapacity(java.lang.String id, NodegroupOptions options)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The ID of the nodegroup.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.options\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.NodegroupOptions\`](#software.amazon.awscdk.services.eks.NodegroupOptions)
+
+options for creating a new nodegroup.
+
+---
+
+##### \`addServiceAccount\` <a name=\\"software.amazon.awscdk.services.eks.Cluster.addServiceAccount\\"></a>
+
+\`\`\`java
+public addServiceAccount(java.lang.String id)
+public addServiceAccount(java.lang.String id, ServiceAccountOptions options)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.options\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ServiceAccountOptions\`](#software.amazon.awscdk.services.eks.ServiceAccountOptions)
+
+---
+
+##### \`connectAutoScalingGroupCapacity\` <a name=\\"software.amazon.awscdk.services.eks.Cluster.connectAutoScalingGroupCapacity\\"></a>
+
+\`\`\`java
+public connectAutoScalingGroupCapacity(AutoScalingGroup autoScalingGroup, AutoScalingGroupOptions options)
+\`\`\`
+
+###### \`autoScalingGroup\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.autoScalingGroup\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.autoscaling.AutoScalingGroup\`](#software.amazon.awscdk.services.autoscaling.AutoScalingGroup)
+
+[disable-awslint:ref-via-interface].
+
+---
+
+###### \`options\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.options\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.AutoScalingGroupOptions\`](#software.amazon.awscdk.services.eks.AutoScalingGroupOptions)
+
+options for adding auto scaling groups, like customizing the bootstrap script.
+
+---
+
+##### \`getServiceLoadBalancerAddress\` <a name=\\"software.amazon.awscdk.services.eks.Cluster.getServiceLoadBalancerAddress\\"></a>
+
+\`\`\`java
+public getServiceLoadBalancerAddress(java.lang.String serviceName)
+public getServiceLoadBalancerAddress(java.lang.String serviceName, ServiceLoadBalancerAddressOptions options)
+\`\`\`
+
+###### \`serviceName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.serviceName\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The name of the service.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.options\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ServiceLoadBalancerAddressOptions\`](#software.amazon.awscdk.services.eks.ServiceLoadBalancerAddressOptions)
+
+Additional operation options.
+
+---
+
+#### Static Functions <a name=\\"Static Functions\\"></a>
+
+##### \`fromClusterAttributes\` <a name=\\"software.amazon.awscdk.services.eks.Cluster.fromClusterAttributes\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.Cluster;
+
+Cluster.fromClusterAttributes(Construct scope, java.lang.String id, ClusterAttributes attrs)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+the construct scope, in most cases 'this'.
+
+---
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+the id or name to import as.
+
+---
+
+###### \`attrs\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.parameter.attrs\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ClusterAttributes\`](#software.amazon.awscdk.services.eks.ClusterAttributes)
+
+the cluster properties to use for importing information.
+
+---
+
+#### Properties <a name=\\"Properties\\"></a>
+
+##### \`adminRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.adminRole\\"></a>
+
+\`\`\`java
+public Role getAdminRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.Role\`](#software.amazon.awscdk.services.iam.Role)
+
+An IAM role with administrative permissions to create or update the cluster.
+
+This role also has \`systems:master\` permissions.
+
+---
+
+##### \`awsAuth\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.awsAuth\\"></a>
+
+\`\`\`java
+public AwsAuth getAwsAuth();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.AwsAuth\`](#software.amazon.awscdk.services.eks.AwsAuth)
+
+Lazily creates the AwsAuth resource, which manages AWS authentication mapping.
+
+---
+
+##### \`clusterArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterArn\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The AWS generated ARN for the Cluster resource.
+
+---
+
+##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterCertificateAuthorityData\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterCertificateAuthorityData();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The certificate-authority-data for your cluster.
+
+---
+
+##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterEncryptionConfigKeyArn\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterEncryptionConfigKeyArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+Amazon Resource Name (ARN) or alias of the customer master key (CMK).
+
+---
+
+##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterEndpoint\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterEndpoint();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The endpoint URL for the Cluster.
+
+This is the URL inside the kubeconfig file to use with kubectl
+
+---
+
+##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The Name of the created EKS Cluster.
+
+---
+
+##### \`clusterOpenIdConnectIssuer\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterOpenIdConnectIssuer\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterOpenIdConnectIssuer();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+If this cluster is kubectl-enabled, returns the OpenID Connect issuer.
+
+This is because the values is only be retrieved by the API and not exposed
+by CloudFormation. If this cluster is not kubectl-enabled (i.e. uses the
+stock \`CfnCluster\`), this is \`undefined\`.
+
+---
+
+##### \`clusterOpenIdConnectIssuerUrl\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterOpenIdConnectIssuerUrl\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterOpenIdConnectIssuerUrl();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+If this cluster is kubectl-enabled, returns the OpenID Connect issuer url.
+
+This is because the values is only be retrieved by the API and not exposed
+by CloudFormation. If this cluster is not kubectl-enabled (i.e. uses the
+stock \`CfnCluster\`), this is \`undefined\`.
+
+---
+
+##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterSecurityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getClusterSecurityGroup();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
+
+The cluster security group that was created by Amazon EKS for the cluster.
+
+---
+
+##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.clusterSecurityGroupId\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterSecurityGroupId();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The id of the cluster security group that was created by Amazon EKS for the cluster.
+
+---
+
+##### \`connections\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.connections\\"></a>
+
+\`\`\`java
+public Connections getConnections();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.Connections\`](#software.amazon.awscdk.services.ec2.Connections)
+
+Manages connection rules (Security Group Rules) for the cluster.
+
+---
+
+##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.openIdConnectProvider\\"></a>
+
+\`\`\`java
+public IOpenIdConnectProvider getOpenIdConnectProvider();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IOpenIdConnectProvider\`](#software.amazon.awscdk.services.iam.IOpenIdConnectProvider)
+
+An \`OpenIdConnectProvider\` resource associated with this cluster, and which can be used to link this cluster to AWS IAM.
+
+A provider will only be defined if this property is accessed (lazy initialization).
+
+---
+
+##### \`prune\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+
+Determines if Kubernetes resources can be pruned automatically.
+
+---
+
+##### \`role\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.role\\"></a>
+
+\`\`\`java
+public IRole getRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+
+IAM role assumed by the EKS Control Plane.
+
+---
+
+##### \`vpc\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.vpc\\"></a>
+
+\`\`\`java
+public IVpc getVpc();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
+
+The VPC in which this Cluster was created.
+
+---
+
+##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.defaultCapacity\\"></a>
+
+\`\`\`java
+public AutoScalingGroup getDefaultCapacity();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.autoscaling.AutoScalingGroup\`](#software.amazon.awscdk.services.autoscaling.AutoScalingGroup)
+
+The auto scaling group that hosts the default capacity for this cluster.
+
+This will be \`undefined\` if the \`defaultCapacityType\` is not \`EC2\` or
+\`defaultCapacityType\` is \`EC2\` but default capacity is set to 0.
+
+---
+
+##### \`defaultNodegroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.defaultNodegroup\\"></a>
+
+\`\`\`java
+public Nodegroup getDefaultNodegroup();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.Nodegroup\`](#software.amazon.awscdk.services.eks.Nodegroup)
+
+The node group that hosts the default capacity for this cluster.
+
+This will be \`undefined\` if the \`defaultCapacityType\` is \`EC2\` or
+\`defaultCapacityType\` is \`NODEGROUP\` but default capacity is set to 0.
+
+---
+
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlEnvironment\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+
+Custom environment variables when running \`kubectl\` against this cluster.
+
+---
+
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlLayer\\"></a>
+
+\`\`\`java
+public ILayerVersion getKubectlLayer();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
+
+The AWS Lambda layer that contains \`kubectl\`, \`helm\` and the AWS CLI.
+
+If
+undefined, a SAR app that contains this layer will be used.
+
+---
+
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlMemory\\"></a>
+
+\`\`\`java
+public Size getKubectlMemory();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Size\`](#software.amazon.awscdk.core.Size)
+
+The amount of memory allocated to the kubectl provider's lambda function.
+
+---
+
+##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlPrivateSubnets\\"></a>
+
+\`\`\`java
+public java.util.List<ISubnet> getKubectlPrivateSubnets();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.ISubnet\`](#software.amazon.awscdk.services.ec2.ISubnet)>
+- *Default:* If not specified, the k8s endpoint is expected to be accessible
+publicly.
+
+Subnets to host the \`kubectl\` compute resources.
+
+---
+
+##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlRole\\"></a>
+
+\`\`\`java
+public IRole getKubectlRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+
+An IAM role that can perform kubectl operations against this cluster.
+
+The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
+
+---
+
+##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Cluster.property.kubectlSecurityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getKubectlSecurityGroup();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
+- *Default:* If not specified, the k8s endpoint is expected to be accessible
+publicly.
+
+A security group to use for \`kubectl\` execution.
+
+---
+
+
+### FargateCluster <a name=\\"software.amazon.awscdk.services.eks.FargateCluster\\"></a>
+
+Defines an EKS cluster that runs entirely on AWS Fargate.
+
+The cluster is created with a default Fargate Profile that matches the
+\\"default\\" and \\"kube-system\\" namespaces. You can add additional profiles using
+\`addFargateProfile\`.
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.FargateCluster.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.FargateCluster;
+
+FargateCluster.Builder.create(Construct scope, java.lang.String id)
+    .version(KubernetesVersion)
+//  .clusterName(java.lang.String)
+//  .outputClusterName(java.lang.Boolean)
+//  .outputConfigCommand(java.lang.Boolean)
+//  .role(IRole)
+//  .securityGroup(ISecurityGroup)
+//  .vpc(IVpc)
+//  .vpcSubnets(java.util.List<SubnetSelection>)
+//  .clusterHandlerEnvironment(java.util.Map<java.lang.String, java.lang.String>)
+//  .coreDnsComputeType(CoreDnsComputeType)
+//  .endpointAccess(EndpointAccess)
+//  .kubectlEnvironment(java.util.Map<java.lang.String, java.lang.String>)
+//  .kubectlLayer(ILayerVersion)
+//  .kubectlMemory(Size)
+//  .mastersRole(IRole)
+//  .outputMastersRoleArn(java.lang.Boolean)
+//  .placeClusterHandlerInVpc(java.lang.Boolean)
+//  .prune(java.lang.Boolean)
+//  .secretsEncryptionKey(IKey)
+//  .defaultProfile(FargateProfileOptions)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateCluster.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateCluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.version\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
+
+The Kubernetes version to run in the cluster.
+
+---
+
+##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.clusterName\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* Automatically generated name
+
+Name for the cluster.
+
+---
+
+##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.outputClusterName\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the name of the cluster will be synthesized.
+
+---
+
+##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.outputConfigCommand\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Determines whether a CloudFormation output with the \`aws eks update-kubeconfig\` command will be synthesized.
+
+This command will include
+the cluster name and, if applicable, the ARN of the masters IAM role.
+
+---
+
+##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.role\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* A role is automatically created for you
+
+Role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
+
+---
+
+##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.securityGroup\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
+- *Default:* A security group is automatically created
+
+Security Group to use for Control Plane ENIs.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.vpc\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
+- *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
+
+The VPC in which to create the Cluster.
+
+---
+
+##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.vpcSubnets\\"></a>
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
+- *Default:* All public and private subnets
+
+Where to place EKS Control Plane ENIs.
+
+If you want to create public load balancers, this must include public subnets.
+
+For example, to only select private subnets, supply the following:
+
+\`\`\`ts
+vpcSubnets: [
+   { subnetType: ec2.SubnetType.Private }
+]
+\`\`\`
+
+---
+
+##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.clusterHandlerEnvironment\\"></a>
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* No environment variables.
+
+Custom environment variables when interacting with the EKS endpoint to manage the cluster lifecycle.
+
+---
+
+##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.coreDnsComputeType\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CoreDnsComputeType\`](#software.amazon.awscdk.services.eks.CoreDnsComputeType)
+- *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
+
+Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS configuration on your cluster to determine which compute type to use for CoreDNS.
+
+---
+
+##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.endpointAccess\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
+- *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
+
+Configure access to the Kubernetes API server endpoint..
+
+> https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+
+---
+
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.kubectlEnvironment\\"></a>
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* No environment variables.
+
+Environment variables for the kubectl execution.
+
+Only relevant for kubectl enabled clusters.
+
+---
+
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.kubectlLayer\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
+- *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+By default, the provider will use the layer included in the
+\\"aws-lambda-layer-kubectl\\" SAR application which is available in all
+commercial regions.
+
+To deploy the layer locally, visit
+https://github.com/aws-samples/aws-lambda-layer-kubectl/blob/master/cdk/README.md
+for instructions on how to prepare the .zip file and then define it in your
+app as follows:
+
+\`\`\`ts
+const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
+   code: lambda.Code.fromAsset(\`\${__dirname}/layer.zip\`)),
+   compatibleRuntimes: [lambda.Runtime.PROVIDED]
+})
+\`\`\`
+
+> https://github.com/aws-samples/aws-lambda-layer-kubectl
+
+---
+
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.kubectlMemory\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.Size\`](#software.amazon.awscdk.core.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`mastersRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.mastersRole\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* a role that assumable by anyone with permissions in the same
+account will automatically be defined
+
+An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.outputMastersRoleArn\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM role will be synthesized (if \`mastersRole\` is specified).
+
+---
+
+##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.placeClusterHandlerInVpc\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+If set to true, the cluster handler functions will be placed in the private subnets of the cluster vpc, subject to the \`vpcSubnets\` selection strategy.
+
+---
+
+##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.prune\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.secretsEncryptionKey\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.kms.IKey\`](#software.amazon.awscdk.services.kms.IKey)
+- *Default:* By default, Kubernetes stores all secret object data within etcd and
+  all etcd volumes used by Amazon EKS are encrypted at the disk-level
+  using AWS-Managed encryption keys.
+
+KMS secret for envelope encryption for Kubernetes secrets.
+
+---
+
+##### \`defaultProfile\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.parameter.defaultProfile\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.FargateProfileOptions\`](#software.amazon.awscdk.services.eks.FargateProfileOptions)
+- *Default:* A profile called \\"default\\" with 'default' and 'kube-system'
+  selectors will be created if this is left undefined.
+
+Fargate Profile to create along with the cluster.
+
+---
+
+
+
+
+
+### FargateProfile <a name=\\"software.amazon.awscdk.services.eks.FargateProfile\\"></a>
+
+- *Implements:* [\`software.amazon.awscdk.core.ITaggable\`](#software.amazon.awscdk.core.ITaggable)
+
+Fargate profiles allows an administrator to declare which pods run on Fargate.
+
+This declaration is done through the profile’s selectors. Each
+profile can have up to five selectors that contain a namespace and optional
+labels. You must define a namespace for every selector. The label field
+consists of multiple optional key-value pairs. Pods that match a selector (by
+matching a namespace for the selector and all of the labels specified in the
+selector) are scheduled on Fargate. If a namespace selector is defined
+without any labels, Amazon EKS will attempt to schedule all pods that run in
+that namespace onto Fargate using the profile. If a to-be-scheduled pod
+matches any of the selectors in the Fargate profile, then that pod is
+scheduled on Fargate.
+
+If a pod matches multiple Fargate profiles, Amazon EKS picks one of the
+matches at random. In this case, you can specify which profile a pod should
+use by adding the following Kubernetes label to the pod specification:
+eks.amazonaws.com/fargate-profile: profile_name. However, the pod must still
+match a selector in that profile in order to be scheduled onto Fargate.
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.FargateProfile;
+
+FargateProfile.Builder.create(Construct scope, java.lang.String id)
+    .selectors(java.util.List<Selector>)
+//  .fargateProfileName(java.lang.String)
+//  .podExecutionRole(IRole)
+//  .subnetSelection(SubnetSelection)
+//  .vpc(IVpc)
+    .cluster(Cluster)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.parameter.selectors\\"></a>
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.eks.Selector\`](#software.amazon.awscdk.services.eks.Selector)>
+
+The selectors to match for pods to use this Fargate profile.
+
+Each selector
+must have an associated namespace. Optionally, you can also specify labels
+for a namespace.
+
+At least one selector is required and you may specify up to five selectors.
+
+---
+
+##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.parameter.fargateProfileName\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* generated
+
+The name of the Fargate profile.
+
+---
+
+##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.parameter.podExecutionRole\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* a role will be automatically created
+
+The pod execution role to use for pods that match the selectors in the Fargate profile.
+
+The pod execution role allows Fargate infrastructure to
+register with your cluster as a node, and it provides read access to Amazon
+ECR image repositories.
+
+> https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html
+
+---
+
+##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.parameter.subnetSelection\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
+- *Default:* all private subnets of the VPC are selected.
+
+Select which subnets to launch your pods into.
+
+At this time, pods running
+on Fargate are not assigned public IP addresses, so only private subnets
+(with no direct route to an Internet Gateway) are allowed.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.parameter.vpc\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
+- *Default:* all private subnets used by theEKS cluster
+
+The VPC from which to select subnets to launch your pods into.
+
+By default, all private subnets are selected. You can customize this using
+\`subnetSelection\`.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.parameter.cluster\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.Cluster\`](#software.amazon.awscdk.services.eks.Cluster)
+
+The EKS cluster to apply the Fargate profile to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+
+
+#### Properties <a name=\\"Properties\\"></a>
+
+##### \`fargateProfileArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.property.fargateProfileArn\\"></a>
+
+\`\`\`java
+public java.lang.String getFargateProfileArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The full Amazon Resource Name (ARN) of the Fargate profile.
+
+---
+
+##### \`fargateProfileName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.property.fargateProfileName\\"></a>
+
+\`\`\`java
+public java.lang.String getFargateProfileName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The name of the Fargate profile.
+
+---
+
+##### \`podExecutionRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.property.podExecutionRole\\"></a>
+
+\`\`\`java
+public IRole getPodExecutionRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+
+The pod execution role to use for pods that match the selectors in the Fargate profile.
+
+The pod execution role allows Fargate infrastructure to
+register with your cluster as a node, and it provides read access to Amazon
+ECR image repositories.
+
+---
+
+##### \`tags\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfile.property.tags\\"></a>
+
+\`\`\`java
+public TagManager getTags();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.TagManager\`](#software.amazon.awscdk.core.TagManager)
+
+Resource tags.
+
+---
+
+
+### HelmChart <a name=\\"software.amazon.awscdk.services.eks.HelmChart\\"></a>
+
+Represents a helm chart within the Kubernetes system.
+
+Applies/deletes the resources using \`kubectl\` in sync with the resource.
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.HelmChart.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.HelmChart;
+
+HelmChart.Builder.create(Construct scope, java.lang.String id)
+    .chart(java.lang.String)
+//  .createNamespace(java.lang.Boolean)
+//  .namespace(java.lang.String)
+//  .release(java.lang.String)
+//  .repository(java.lang.String)
+//  .timeout(Duration)
+//  .values(java.util.Map<java.lang.String, java.lang.Object>)
+//  .version(java.lang.String)
+//  .wait(java.lang.Boolean)
+    .cluster(ICluster)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChart.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChart.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`chart\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.parameter.chart\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The name of the chart.
+
+---
+
+##### \`createNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.parameter.createNamespace\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+create namespace if not exist.
+
+---
+
+##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.parameter.namespace\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* default
+
+The Kubernetes namespace scope of the requests.
+
+---
+
+##### \`release\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.parameter.release\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
+
+The name of the release.
+
+---
+
+##### \`repository\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.parameter.repository\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
+
+The repository which contains the chart.
+
+For example: https://kubernetes-charts.storage.googleapis.com/
+
+---
+
+##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.parameter.timeout\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
+- *Default:* Duration.minutes(5)
+
+Amount of time to wait for any individual Kubernetes operation.
+
+Maximum 15 minutes.
+
+---
+
+##### \`values\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.parameter.values\\"></a>
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
+- *Default:* No values are provided to the chart.
+
+The values to be used by the chart.
+
+---
+
+##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.parameter.version\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* If this is not specified, the latest version is installed
+
+The chart version to install.
+
+---
+
+##### \`wait\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.parameter.wait\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* Helm will not wait before marking release as successful
+
+Whether or not Helm should wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.parameter.cluster\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+The EKS cluster to apply this configuration to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+
+
+
+#### Constants <a name=\\"Constants\\"></a>
+
+##### \`RESOURCE_TYPE\` <a name=\\"software.amazon.awscdk.services.eks.HelmChart.property.RESOURCE_TYPE\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The CloudFormation resource type.
+
+---
+
+### KubernetesManifest <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifest\\"></a>
+
+Represents a manifest within the Kubernetes system.
+
+Alternatively, you can use \`cluster.addManifest(resource[, resource, ...])\`
+to define resources on this cluster.
+
+Applies/deletes the manifest using \`kubectl\`.
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifest.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.KubernetesManifest;
+
+KubernetesManifest.Builder.create(Construct scope, java.lang.String id)
+//  .prune(java.lang.Boolean)
+//  .skipValidation(java.lang.Boolean)
+    .cluster(ICluster)
+    .manifest(java.util.List<java.util.Map<java.lang.String, java.lang.Object>>)
+//  .overwrite(java.lang.Boolean)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifest.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifest.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.parameter.prune\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* based on the prune option of the cluster, which is \`true\` unless
+otherwise specified.
+
+When a resource is removed from a Kubernetes manifest, it no longer appears in the manifest, and there is no way to know that this resource needs to be deleted.
+
+To address this, \`kubectl apply\` has a \`--prune\` option which will
+query the cluster for all resources with a specific label and will remove
+all the labeld resources that are not part of the applied manifest. If this
+option is disabled and a resource is removed, it will become \\"orphaned\\" and
+will not be deleted from the cluster.
+
+When this option is enabled (default), the construct will inject a label to
+all Kubernetes resources included in this manifest which will be used to
+prune resources when the manifest changes via \`kubectl apply --prune\`.
+
+The label name will be \`aws.cdk.eks/prune-<ADDR>\` where \`<ADDR>\` is the
+42-char unique address of this construct in the construct tree. Value is
+empty.
+
+> https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#alternative-kubectl-apply-f-directory-prune-l-your-label
+
+---
+
+##### \`skipValidation\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.parameter.skipValidation\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+A flag to signify if the manifest validation should be skipped.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.parameter.cluster\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+The EKS cluster to apply this manifest to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+##### \`manifest\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.parameter.manifest\\"></a>
+
+- *Type:* java.util.List<java.util.Map<java.lang.String, \`java.lang.Object\`>>
+
+The manifest to apply.
+
+Consists of any number of child resources.
+
+When the resources are created/updated, this manifest will be applied to the
+cluster through \`kubectl apply\` and when the resources or the stack is
+deleted, the resources in the manifest will be deleted through \`kubectl delete\`.
+
+---
+
+##### \`overwrite\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.parameter.overwrite\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Overwrite any existing resources.
+
+If this is set, we will use \`kubectl apply\` instead of \`kubectl create\`
+when the resource is created. Otherwise, if there is already a resource
+in the cluster with the same name, the operation will fail.
+
+---
+
+
+
+
+#### Constants <a name=\\"Constants\\"></a>
+
+##### \`RESOURCE_TYPE\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifest.property.RESOURCE_TYPE\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The CloudFormation reosurce type.
+
+---
+
+### KubernetesObjectValue <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValue\\"></a>
+
+Represents a value of a specific object deployed in the cluster.
+
+Use this to fetch any information available by the \`kubectl get\` command.
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValue.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.KubernetesObjectValue;
+
+KubernetesObjectValue.Builder.create(Construct scope, java.lang.String id)
+    .cluster(ICluster)
+    .jsonPath(java.lang.String)
+    .objectName(java.lang.String)
+    .objectType(java.lang.String)
+//  .objectNamespace(java.lang.String)
+//  .timeout(Duration)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValue.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValue.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.parameter.cluster\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+The EKS cluster to fetch attributes from.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+##### \`jsonPath\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.parameter.jsonPath\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+JSONPath to the specific value.
+
+> https://kubernetes.io/docs/reference/kubectl/jsonpath/
+
+---
+
+##### \`objectName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.parameter.objectName\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The name of the object to query.
+
+---
+
+##### \`objectType\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.parameter.objectType\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The object type to query.
+
+(e.g 'service', 'pod'...)
+
+---
+
+##### \`objectNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.parameter.objectNamespace\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* 'default'
+
+The namespace the object belongs to.
+
+---
+
+##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.parameter.timeout\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
+- *Default:* Duration.minutes(5)
+
+Timeout for waiting on a value.
+
+---
+
+
+
+#### Properties <a name=\\"Properties\\"></a>
+
+##### \`value\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValue.property.value\\"></a>
+
+\`\`\`java
+public java.lang.String getValue();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The value as a string token.
+
+---
+
+#### Constants <a name=\\"Constants\\"></a>
+
+##### \`RESOURCE_TYPE\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValue.property.RESOURCE_TYPE\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The CloudFormation reosurce type.
+
+---
+
+### KubernetesPatch <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatch\\"></a>
+
+A CloudFormation resource which applies/restores a JSON patch into a Kubernetes resource.
+
+> https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatch.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.KubernetesPatch;
+
+KubernetesPatch.Builder.create(Construct scope, java.lang.String id)
+    .applyPatch(java.util.Map<java.lang.String, java.lang.Object>)
+    .cluster(ICluster)
+    .resourceName(java.lang.String)
+    .restorePatch(java.util.Map<java.lang.String, java.lang.Object>)
+//  .patchType(PatchType)
+//  .resourceNamespace(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatch.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatch.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`applyPatch\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.parameter.applyPatch\\"></a>
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
+
+The JSON object to pass to \`kubectl patch\` when the resource is created/updated.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.parameter.cluster\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+The cluster to apply the patch to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+##### \`resourceName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.parameter.resourceName\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The full name of the resource to patch (e.g. \`deployment/coredns\`).
+
+---
+
+##### \`restorePatch\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.parameter.restorePatch\\"></a>
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
+
+The JSON object to pass to \`kubectl patch\` when the resource is removed.
+
+---
+
+##### \`patchType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.parameter.patchType\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.PatchType\`](#software.amazon.awscdk.services.eks.PatchType)
+- *Default:* PatchType.STRATEGIC
+
+The patch type to pass to \`kubectl patch\`.
+
+The default type used by \`kubectl patch\` is \\"strategic\\".
+
+---
+
+##### \`resourceNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.parameter.resourceNamespace\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* \\"default\\"
+
+The kubernetes API namespace.
+
+---
+
+
+
+
+
+### Nodegroup <a name=\\"software.amazon.awscdk.services.eks.Nodegroup\\"></a>
+
+- *Implements:* [\`software.amazon.awscdk.services.eks.INodegroup\`](#software.amazon.awscdk.services.eks.INodegroup)
+
+The Nodegroup resource class.
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.Nodegroup;
+
+Nodegroup.Builder.create(Construct scope, java.lang.String id)
+//  .amiType(NodegroupAmiType)
+//  .capacityType(CapacityType)
+//  .desiredSize(java.lang.Number)
+//  .diskSize(java.lang.Number)
+//  .forceUpdate(java.lang.Boolean)
+//  .instanceType(InstanceType)
+//  .instanceTypes(java.util.List<InstanceType>)
+//  .labels(java.util.Map<java.lang.String, java.lang.String>)
+//  .launchTemplateSpec(LaunchTemplateSpec)
+//  .maxSize(java.lang.Number)
+//  .minSize(java.lang.Number)
+//  .nodegroupName(java.lang.String)
+//  .nodeRole(IRole)
+//  .releaseVersion(java.lang.String)
+//  .remoteAccess(NodegroupRemoteAccess)
+//  .subnets(SubnetSelection)
+//  .tags(java.util.Map<java.lang.String, java.lang.String>)
+    .cluster(ICluster)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.amiType\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.NodegroupAmiType\`](#software.amazon.awscdk.services.eks.NodegroupAmiType)
+- *Default:* auto-determined from the instanceTypes property.
+
+The AMI type for your node group.
+
+---
+
+##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.capacityType\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CapacityType\`](#software.amazon.awscdk.services.eks.CapacityType)
+- *Default:* ON_DEMAND
+
+The capacity type of the nodegroup.
+
+---
+
+##### \`desiredSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.desiredSize\\"></a>
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 2
+
+The current number of worker nodes that the managed node group should maintain.
+
+If not specified,
+the nodewgroup will initially create \`minSize\` instances.
+
+---
+
+##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.diskSize\\"></a>
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 20
+
+The root device disk size (in GiB) for your node group instances.
+
+---
+
+##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.forceUpdate\\"></a>
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Force the update if the existing node group's pods are unable to be drained due to a pod disruption budget issue.
+
+If an update fails because pods could not be drained, you can force the update after it fails to terminate the old
+node whether or not any pods are
+running on the node.
+
+---
+
+##### ~~\`instanceType\`~~<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.instanceType\\"></a>
+
+- *Deprecated:* Use \`instanceTypes\` instead.
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)
+- *Default:* t3.medium
+
+The instance type to use for your node group.
+
+Currently, you can specify a single instance type for a node group.
+The default value for this parameter is \`t3.medium\`. If you choose a GPU instance type, be sure to specify the
+\`AL2_x86_64_GPU\` with the amiType parameter.
+
+---
+
+##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.instanceTypes\\"></a>
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)>
+- *Default:* t3.medium will be used according to the cloudformation document.
+
+The instance types to use for your node group.
+
+> - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes
+
+---
+
+##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.labels\\"></a>
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* None
+
+The Kubernetes labels to be applied to the nodes in the node group when they are created.
+
+---
+
+##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.launchTemplateSpec\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.LaunchTemplateSpec\`](#software.amazon.awscdk.services.eks.LaunchTemplateSpec)
+- *Default:* no launch template
+
+Launch template specification used for the nodegroup.
+
+> - https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html
+
+---
+
+##### \`maxSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.maxSize\\"></a>
+
+- *Type:* \`java.lang.Number\`
+- *Default:* desiredSize
+
+The maximum number of worker nodes that the managed node group can scale out to.
+
+Managed node groups can support up to 100 nodes by default.
+
+---
+
+##### \`minSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.minSize\\"></a>
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 1
+
+The minimum number of worker nodes that the managed node group can scale in to.
+
+This number must be greater than zero.
+
+---
+
+##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.nodegroupName\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* resource ID
+
+Name of the Nodegroup.
+
+---
+
+##### \`nodeRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.nodeRole\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* None. Auto-generated if not specified.
+
+The IAM role to associate with your node group.
+
+The Amazon EKS worker node kubelet daemon
+makes calls to AWS APIs on your behalf. Worker nodes receive permissions for these API calls through
+an IAM instance profile and associated policies. Before you can launch worker nodes and register them
+into a cluster, you must create an IAM role for those worker nodes to use when they are launched.
+
+---
+
+##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.releaseVersion\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
+
+The AMI version of the Amazon EKS-optimized AMI to use with your node group (for example, \`1.14.7-YYYYMMDD\`).
+
+---
+
+##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.remoteAccess\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.NodegroupRemoteAccess\`](#software.amazon.awscdk.services.eks.NodegroupRemoteAccess)
+- *Default:* disabled
+
+The remote access (SSH) configuration to use with your node group.
+
+Disabled by default, however, if you
+specify an Amazon EC2 SSH key but do not specify a source security group when you create a managed node group,
+then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
+
+---
+
+##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.subnets\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
+- *Default:* private subnets
+
+The subnets to use for the Auto Scaling group that is created for your node group.
+
+By specifying the
+SubnetSelection, the selected subnets will automatically apply required tags i.e.
+\`kubernetes.io/cluster/CLUSTER_NAME\` with a value of \`shared\`, where \`CLUSTER_NAME\` is replaced with
+the name of your cluster.
+
+---
+
+##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.tags\\"></a>
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* None
+
+The metadata to apply to the node group to assist with categorization and organization.
+
+Each tag consists of
+a key and an optional value, both of which you define. Node group tags do not propagate to any other resources
+associated with the node group, such as the Amazon EC2 instances or subnets.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.parameter.cluster\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+Cluster resource.
+
+---
+
+
+#### Static Functions <a name=\\"Static Functions\\"></a>
+
+##### \`fromNodegroupName\` <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.fromNodegroupName\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.Nodegroup;
+
+Nodegroup.fromNodegroupName(Construct scope, java.lang.String id, java.lang.String nodegroupName)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+---
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+###### \`nodegroupName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.parameter.nodegroupName\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+#### Properties <a name=\\"Properties\\"></a>
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.property.cluster\\"></a>
+
+\`\`\`java
+public ICluster getCluster();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+the Amazon EKS cluster resource.
+
+---
+
+##### \`nodegroupArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.property.nodegroupArn\\"></a>
+
+\`\`\`java
+public java.lang.String getNodegroupArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+ARN of the nodegroup.
+
+---
+
+##### \`nodegroupName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.property.nodegroupName\\"></a>
+
+\`\`\`java
+public java.lang.String getNodegroupName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+Nodegroup name.
+
+---
+
+##### \`role\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Nodegroup.property.role\\"></a>
+
+\`\`\`java
+public IRole getRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+
+IAM role of the instance profile for the nodegroup.
+
+---
+
+
+### OpenIdConnectProvider <a name=\\"software.amazon.awscdk.services.eks.OpenIdConnectProvider\\"></a>
+
+IAM OIDC identity providers are entities in IAM that describe an external identity provider (IdP) service that supports the OpenID Connect (OIDC) standard, such as Google or Salesforce.
+
+You use an IAM OIDC identity provider
+when you want to establish trust between an OIDC-compatible IdP and your AWS
+account.
+
+This implementation has default values for thumbprints and clientIds props
+that will be compatible with the eks cluster
+
+> https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.OpenIdConnectProvider.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.OpenIdConnectProvider;
+
+OpenIdConnectProvider.Builder.create(Construct scope, java.lang.String id)
+    .url(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.OpenIdConnectProvider.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+The definition scope.
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.OpenIdConnectProvider.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+Construct ID.
+
+---
+
+##### \`url\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.OpenIdConnectProviderProps.parameter.url\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+The URL of the identity provider.
+
+The URL must begin with https:// and
+should correspond to the iss claim in the provider's OpenID Connect ID
+tokens. Per the OIDC standard, path components are allowed but query
+parameters are not. Typically the URL consists of only a hostname, like
+https://server.example.org or https://example.com.
+
+You can find your OIDC Issuer URL by:
+aws eks describe-cluster --name %cluster_name% --query \\"cluster.identity.oidc.issuer\\" --output text
+
+---
+
+
+
+
+
+### ServiceAccount <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount\\"></a>
+
+- *Implements:* [\`software.amazon.awscdk.services.iam.IPrincipal\`](#software.amazon.awscdk.services.iam.IPrincipal)
+
+Service Account.
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.ServiceAccount;
+
+ServiceAccount.Builder.create(Construct scope, java.lang.String id)
+//  .name(java.lang.String)
+//  .namespace(java.lang.String)
+    .cluster(ICluster)
+    .build();
+\`\`\`
+
+##### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.parameter.scope\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+---
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+---
+
+##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps.parameter.name\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* If no name is given, it will use the id of the resource.
+
+The name of the service account.
+
+---
+
+##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps.parameter.namespace\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* \\"default\\"
+
+The namespace of the service account.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps.parameter.cluster\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+The cluster to apply the patch to.
+
+---
+
+#### Methods <a name=\\"Methods\\"></a>
+
+##### ~~\`addToPolicy\`~~ <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.addToPolicy\\"></a>
+
+\`\`\`java
+public addToPolicy(PolicyStatement statement)
+\`\`\`
+
+###### \`statement\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.parameter.statement\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.iam.PolicyStatement\`](#software.amazon.awscdk.services.iam.PolicyStatement)
+
+---
+
+##### \`addToPrincipalPolicy\` <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.addToPrincipalPolicy\\"></a>
+
+\`\`\`java
+public addToPrincipalPolicy(PolicyStatement statement)
+\`\`\`
+
+###### \`statement\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.parameter.statement\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.iam.PolicyStatement\`](#software.amazon.awscdk.services.iam.PolicyStatement)
+
+---
+
+
+#### Properties <a name=\\"Properties\\"></a>
+
+##### \`assumeRoleAction\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.assumeRoleAction\\"></a>
+
+\`\`\`java
+public java.lang.String getAssumeRoleAction();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+When this Principal is used in an AssumeRole policy, the action to use.
+
+---
+
+##### \`grantPrincipal\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.grantPrincipal\\"></a>
+
+\`\`\`java
+public IPrincipal getGrantPrincipal();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IPrincipal\`](#software.amazon.awscdk.services.iam.IPrincipal)
+
+The principal to grant permissions to.
+
+---
+
+##### \`policyFragment\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.policyFragment\\"></a>
+
+\`\`\`java
+public PrincipalPolicyFragment getPolicyFragment();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.PrincipalPolicyFragment\`](#software.amazon.awscdk.services.iam.PrincipalPolicyFragment)
+
+Return the policy fragment that identifies this principal in a Policy.
+
+---
+
+##### \`role\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.role\\"></a>
+
+\`\`\`java
+public IRole getRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+
+The role which is linked to the service account.
+
+---
+
+##### \`serviceAccountName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.serviceAccountName\\"></a>
+
+\`\`\`java
+public java.lang.String getServiceAccountName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The name of the service account.
+
+---
+
+##### \`serviceAccountNamespace\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccount.property.serviceAccountNamespace\\"></a>
+
+\`\`\`java
+public java.lang.String getServiceAccountNamespace();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The namespace where the service account is located in.
+
+---
+
+
+## Structs <a name=\\"Structs\\"></a>
+
+### AutoScalingGroupCapacityOptions <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions\\"></a>
+
+Options for adding worker nodes.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions;
+
+AutoScalingGroupCapacityOptions.builder()
+//  .allowAllOutbound(java.lang.Boolean)
+//  .associatePublicIpAddress(java.lang.Boolean)
+//  .autoScalingGroupName(java.lang.String)
+//  .blockDevices(java.util.List<BlockDevice>)
+//  .cooldown(Duration)
+//  .desiredCapacity(java.lang.Number)
+//  .groupMetrics(java.util.List<GroupMetrics>)
+//  .healthCheck(HealthCheck)
+//  .ignoreUnmodifiedSizeProperties(java.lang.Boolean)
+//  .instanceMonitoring(Monitoring)
+//  .keyName(java.lang.String)
+//  .maxCapacity(java.lang.Number)
+//  .maxInstanceLifetime(Duration)
+//  .minCapacity(java.lang.Number)
+//  .newInstancesProtectedFromScaleIn(java.lang.Boolean)
+//  .notifications(java.util.List<NotificationConfiguration>)
+//  .notificationsTopic(ITopic)
+//  .replacingUpdateMinSuccessfulInstancesPercent(java.lang.Number)
+//  .resourceSignalCount(java.lang.Number)
+//  .resourceSignalTimeout(Duration)
+//  .rollingUpdateConfiguration(RollingUpdateConfiguration)
+//  .signals(Signals)
+//  .spotPrice(java.lang.String)
+//  .updatePolicy(UpdatePolicy)
+//  .updateType(UpdateType)
+//  .vpcSubnets(SubnetSelection)
+    .instanceType(InstanceType)
+//  .bootstrapEnabled(java.lang.Boolean)
+//  .bootstrapOptions(BootstrapOptions)
+//  .machineImageType(MachineImageType)
+//  .mapRole(java.lang.Boolean)
+//  .spotInterruptHandler(java.lang.Boolean)
+    .build();
+\`\`\`
+
+##### \`allowAllOutbound\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.allowAllOutbound\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getAllowAllOutbound();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Whether the instances can initiate connections to anywhere by default.
+
+---
+
+##### \`associatePublicIpAddress\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.associatePublicIpAddress\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getAssociatePublicIpAddress();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* Use subnet setting.
+
+Whether instances in the Auto Scaling Group should have public IP addresses associated with them.
+
+---
+
+##### \`autoScalingGroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.autoScalingGroupName\\"></a>
+
+\`\`\`java
+public java.lang.String getAutoScalingGroupName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* Auto generated by CloudFormation
+
+The name of the Auto Scaling group.
+
+This name must be unique per Region per account.
+
+---
+
+##### \`blockDevices\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.blockDevices\\"></a>
+
+\`\`\`java
+public java.util.List<BlockDevice> getBlockDevices();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.autoscaling.BlockDevice\`](#software.amazon.awscdk.services.autoscaling.BlockDevice)>
+- *Default:* Uses the block device mapping of the AMI
+
+Specifies how block devices are exposed to the instance. You can specify virtual devices and EBS volumes.
+
+Each instance that is launched has an associated root device volume,
+either an Amazon EBS volume or an instance store volume.
+You can use block device mappings to specify additional EBS volumes or
+instance store volumes to attach to an instance when it is launched.
+
+> https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
+
+---
+
+##### \`cooldown\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.cooldown\\"></a>
+
+\`\`\`java
+public Duration getCooldown();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
+- *Default:* Duration.minutes(5)
+
+Default scaling cooldown for this AutoScalingGroup.
+
+---
+
+##### \`desiredCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.desiredCapacity\\"></a>
+
+\`\`\`java
+public java.lang.Number getDesiredCapacity();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* minCapacity, and leave unchanged during deployment
+
+Initial amount of instances in the fleet.
+
+If this is set to a number, every deployment will reset the amount of
+instances to this number. It is recommended to leave this value blank.
+
+> https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-desiredcapacity
+
+---
+
+##### \`groupMetrics\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.groupMetrics\\"></a>
+
+\`\`\`java
+public java.util.List<GroupMetrics> getGroupMetrics();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.autoscaling.GroupMetrics\`](#software.amazon.awscdk.services.autoscaling.GroupMetrics)>
+- *Default:* no group metrics will be reported
+
+Enable monitoring for group metrics, these metrics describe the group rather than any of its instances.
+
+To report all group metrics use \`GroupMetrics.all()\`
+Group metrics are reported in a granularity of 1 minute at no additional charge.
+
+---
+
+##### \`healthCheck\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.healthCheck\\"></a>
+
+\`\`\`java
+public HealthCheck getHealthCheck();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.autoscaling.HealthCheck\`](#software.amazon.awscdk.services.autoscaling.HealthCheck)
+- *Default:* HealthCheck.ec2 with no grace period
+
+Configuration for health checks.
+
+---
+
+##### \`ignoreUnmodifiedSizeProperties\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.ignoreUnmodifiedSizeProperties\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getIgnoreUnmodifiedSizeProperties();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+If the ASG has scheduled actions, don't reset unchanged group sizes.
+
+Only used if the ASG has scheduled actions (which may scale your ASG up
+or down regardless of cdk deployments). If true, the size of the group
+will only be reset if it has been changed in the CDK app. If false, the
+sizes will always be changed back to what they were in the CDK app
+on deployment.
+
+---
+
+##### \`instanceMonitoring\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.instanceMonitoring\\"></a>
+
+\`\`\`java
+public Monitoring getInstanceMonitoring();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.autoscaling.Monitoring\`](#software.amazon.awscdk.services.autoscaling.Monitoring)
+- *Default:* Monitoring.DETAILED
+
+Controls whether instances in this group are launched with detailed or basic monitoring.
+
+When detailed monitoring is enabled, Amazon CloudWatch generates metrics every minute and your account
+is charged a fee. When you disable detailed monitoring, CloudWatch generates metrics every 5 minutes.
+
+> https://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-monitoring.html#enable-as-instance-metrics
+
+---
+
+##### \`keyName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.keyName\\"></a>
+
+\`\`\`java
+public java.lang.String getKeyName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* No SSH access will be possible.
+
+Name of SSH keypair to grant access to instances.
+
+---
+
+##### \`maxCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.maxCapacity\\"></a>
+
+\`\`\`java
+public java.lang.Number getMaxCapacity();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* desiredCapacity
+
+Maximum number of instances in the fleet.
+
+---
+
+##### \`maxInstanceLifetime\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.maxInstanceLifetime\\"></a>
+
+\`\`\`java
+public Duration getMaxInstanceLifetime();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
+- *Default:* none
+
+The maximum amount of time that an instance can be in service.
+
+The maximum duration applies
+to all current and future instances in the group. As an instance approaches its maximum duration,
+it is terminated and replaced, and cannot be used again.
+
+You must specify a value of at least 604,800 seconds (7 days). To clear a previously set value,
+leave this property undefined.
+
+> https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-max-instance-lifetime.html
+
+---
+
+##### \`minCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.minCapacity\\"></a>
+
+\`\`\`java
+public java.lang.Number getMinCapacity();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 1
+
+Minimum number of instances in the fleet.
+
+---
+
+##### \`newInstancesProtectedFromScaleIn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.newInstancesProtectedFromScaleIn\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getNewInstancesProtectedFromScaleIn();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Whether newly-launched instances are protected from termination by Amazon EC2 Auto Scaling when scaling in.
+
+By default, Auto Scaling can terminate an instance at any time after launch
+when scaling in an Auto Scaling Group, subject to the group's termination
+policy. However, you may wish to protect newly-launched instances from
+being scaled in if they are going to run critical applications that should
+not be prematurely terminated.
+
+This flag must be enabled if the Auto Scaling Group will be associated with
+an ECS Capacity Provider with managed termination protection.
+
+---
+
+##### \`notifications\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.notifications\\"></a>
+
+\`\`\`java
+public java.util.List<NotificationConfiguration> getNotifications();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.autoscaling.NotificationConfiguration\`](#software.amazon.awscdk.services.autoscaling.NotificationConfiguration)>
+- *Default:* No fleet change notifications will be sent.
+
+Configure autoscaling group to send notifications about fleet changes to an SNS topic(s).
+
+> https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html#cfn-as-group-notificationconfigurations
+
+---
+
+##### ~~\`notificationsTopic\`~~<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.notificationsTopic\\"></a>
+
+- *Deprecated:* use \`notifications\`
+
+\`\`\`java
+public ITopic getNotificationsTopic();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.sns.ITopic\`](#software.amazon.awscdk.services.sns.ITopic)
+- *Default:* No fleet change notifications will be sent.
+
+SNS topic to send notifications about fleet changes.
+
+---
+
+##### ~~\`replacingUpdateMinSuccessfulInstancesPercent\`~~<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.replacingUpdateMinSuccessfulInstancesPercent\\"></a>
+
+- *Deprecated:* Use \`signals\` instead
+
+\`\`\`java
+public java.lang.Number getReplacingUpdateMinSuccessfulInstancesPercent();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* minSuccessfulInstancesPercent
+
+Configuration for replacing updates.
+
+Only used if updateType == UpdateType.ReplacingUpdate. Specifies how
+many instances must signal success for the update to succeed.
+
+---
+
+##### ~~\`resourceSignalCount\`~~<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.resourceSignalCount\\"></a>
+
+- *Deprecated:* Use \`signals\` instead.
+
+\`\`\`java
+public java.lang.Number getResourceSignalCount();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 1 if resourceSignalTimeout is set, 0 otherwise
+
+How many ResourceSignal calls CloudFormation expects before the resource is considered created.
+
+---
+
+##### ~~\`resourceSignalTimeout\`~~<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.resourceSignalTimeout\\"></a>
+
+- *Deprecated:* Use \`signals\` instead.
+
+\`\`\`java
+public Duration getResourceSignalTimeout();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
+- *Default:* Duration.minutes(5) if resourceSignalCount is set, N/A otherwise
+
+The length of time to wait for the resourceSignalCount.
+
+The maximum value is 43200 (12 hours).
+
+---
+
+##### ~~\`rollingUpdateConfiguration\`~~<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.rollingUpdateConfiguration\\"></a>
+
+- *Deprecated:* Use \`updatePolicy\` instead
+
+\`\`\`java
+public RollingUpdateConfiguration getRollingUpdateConfiguration();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.autoscaling.RollingUpdateConfiguration\`](#software.amazon.awscdk.services.autoscaling.RollingUpdateConfiguration)
+- *Default:* RollingUpdateConfiguration with defaults.
+
+Configuration for rolling updates.
+
+Only used if updateType == UpdateType.RollingUpdate.
+
+---
+
+##### \`signals\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.signals\\"></a>
+
+\`\`\`java
+public Signals getSignals();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.autoscaling.Signals\`](#software.amazon.awscdk.services.autoscaling.Signals)
+- *Default:* Do not wait for signals
+
+Configure waiting for signals during deployment.
+
+Use this to pause the CloudFormation deployment to wait for the instances
+in the AutoScalingGroup to report successful startup during
+creation and updates. The UserData script needs to invoke \`cfn-signal\`
+with a success or failure code after it is done setting up the instance.
+
+Without waiting for signals, the CloudFormation deployment will proceed as
+soon as the AutoScalingGroup has been created or updated but before the
+instances in the group have been started.
+
+For example, to have instances wait for an Elastic Load Balancing health check before
+they signal success, add a health-check verification by using the
+cfn-init helper script. For an example, see the verify_instance_health
+command in the Auto Scaling rolling updates sample template:
+
+https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/services/AutoScaling/AutoScalingRollingUpdates.yaml
+
+---
+
+##### \`spotPrice\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.spotPrice\\"></a>
+
+\`\`\`java
+public java.lang.String getSpotPrice();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* none
+
+The maximum hourly price (in USD) to be paid for any Spot Instance launched to fulfill the request.
+
+Spot Instances are
+launched when the price you specify exceeds the current Spot market price.
+
+---
+
+##### \`updatePolicy\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.updatePolicy\\"></a>
+
+\`\`\`java
+public UpdatePolicy getUpdatePolicy();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.autoscaling.UpdatePolicy\`](#software.amazon.awscdk.services.autoscaling.UpdatePolicy)
+- *Default:* \`UpdatePolicy.rollingUpdate()\` if using \`init\`, \`UpdatePolicy.none()\` otherwise
+
+What to do when an AutoScalingGroup's instance configuration is changed.
+
+This is applied when any of the settings on the ASG are changed that
+affect how the instances should be created (VPC, instance type, startup
+scripts, etc.). It indicates how the existing instances should be
+replaced with new instances matching the new config. By default, nothing
+is done and only new instances are launched with the new config.
+
+---
+
+##### ~~\`updateType\`~~<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.updateType\\"></a>
+
+- *Deprecated:* Use \`updatePolicy\` instead
+
+\`\`\`java
+public UpdateType getUpdateType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.autoscaling.UpdateType\`](#software.amazon.awscdk.services.autoscaling.UpdateType)
+- *Default:* UpdateType.None
+
+What to do when an AutoScalingGroup's instance configuration is changed.
+
+This is applied when any of the settings on the ASG are changed that
+affect how the instances should be created (VPC, instance type, startup
+scripts, etc.). It indicates how the existing instances should be
+replaced with new instances matching the new config. By default, nothing
+is done and only new instances are launched with the new config.
+
+---
+
+##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.vpcSubnets\\"></a>
+
+\`\`\`java
+public SubnetSelection getVpcSubnets();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
+- *Default:* All Private subnets.
+
+Where to place instances within the VPC.
+
+---
+
+##### \`instanceType\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.instanceType\\"></a>
+
+\`\`\`java
+public InstanceType getInstanceType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)
+
+Instance type of the instances to start.
+
+---
+
+##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.bootstrapEnabled\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getBootstrapEnabled();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Configures the EC2 user-data script for instances in this autoscaling group to bootstrap the node (invoke \`/etc/eks/bootstrap.sh\`) and associate it with the EKS cluster.
+
+If you wish to provide a custom user data script, set this to \`false\` and
+manually invoke \`autoscalingGroup.addUserData()\`.
+
+---
+
+##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.bootstrapOptions\\"></a>
+
+\`\`\`java
+public BootstrapOptions getBootstrapOptions();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.BootstrapOptions\`](#software.amazon.awscdk.services.eks.BootstrapOptions)
+- *Default:* none
+
+EKS node bootstrapping options.
+
+---
+
+##### \`machineImageType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.machineImageType\\"></a>
+
+\`\`\`java
+public MachineImageType getMachineImageType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.MachineImageType\`](#software.amazon.awscdk.services.eks.MachineImageType)
+- *Default:* MachineImageType.AMAZON_LINUX_2
+
+Machine image type.
+
+---
+
+##### \`mapRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.mapRole\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getMapRole();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true if the cluster has kubectl enabled (which is the default).
+
+Will automatically update the aws-auth ConfigMap to map the IAM instance role to RBAC.
+
+This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
+
+---
+
+##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupCapacityOptions.property.spotInterruptHandler\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getSpotInterruptHandler();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Installs the AWS spot instance interrupt handler on the cluster if it's not already added.
+
+Only relevant if \`spotPrice\` is used.
+
+---
+
+### AutoScalingGroupOptions <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions\\"></a>
+
+Options for adding an AutoScalingGroup as capacity.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.AutoScalingGroupOptions;
+
+AutoScalingGroupOptions.builder()
+//  .bootstrapEnabled(java.lang.Boolean)
+//  .bootstrapOptions(BootstrapOptions)
+//  .machineImageType(MachineImageType)
+//  .mapRole(java.lang.Boolean)
+//  .spotInterruptHandler(java.lang.Boolean)
+    .build();
+\`\`\`
+
+##### \`bootstrapEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.bootstrapEnabled\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getBootstrapEnabled();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Configures the EC2 user-data script for instances in this autoscaling group to bootstrap the node (invoke \`/etc/eks/bootstrap.sh\`) and associate it with the EKS cluster.
+
+If you wish to provide a custom user data script, set this to \`false\` and
+manually invoke \`autoscalingGroup.addUserData()\`.
+
+---
+
+##### \`bootstrapOptions\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.bootstrapOptions\\"></a>
+
+\`\`\`java
+public BootstrapOptions getBootstrapOptions();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.BootstrapOptions\`](#software.amazon.awscdk.services.eks.BootstrapOptions)
+- *Default:* default options
+
+Allows options for node bootstrapping through EC2 user data.
+
+---
+
+##### \`machineImageType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.machineImageType\\"></a>
+
+\`\`\`java
+public MachineImageType getMachineImageType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.MachineImageType\`](#software.amazon.awscdk.services.eks.MachineImageType)
+- *Default:* MachineImageType.AMAZON_LINUX_2
+
+Allow options to specify different machine image type.
+
+---
+
+##### \`mapRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.mapRole\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getMapRole();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true if the cluster has kubectl enabled (which is the default).
+
+Will automatically update the aws-auth ConfigMap to map the IAM instance role to RBAC.
+
+This cannot be explicitly set to \`true\` if the cluster has kubectl disabled.
+
+---
+
+##### \`spotInterruptHandler\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AutoScalingGroupOptions.property.spotInterruptHandler\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getSpotInterruptHandler();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Installs the AWS spot instance interrupt handler on the cluster if it's not already added.
+
+Only relevant if \`spotPrice\` is configured on the auto-scaling group.
+
+---
+
+### AwsAuthMapping <a name=\\"software.amazon.awscdk.services.eks.AwsAuthMapping\\"></a>
+
+AwsAuth mapping.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.AwsAuthMapping;
+
+AwsAuthMapping.builder()
+    .groups(java.util.List<java.lang.String>)
+//  .username(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`groups\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuthMapping.property.groups\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getGroups();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+A list of groups within Kubernetes to which the role is mapped.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+##### \`username\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuthMapping.property.username\\"></a>
+
+\`\`\`java
+public java.lang.String getUsername();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* By default, the user name is the ARN of the IAM role.
+
+The user name within Kubernetes to map to the IAM role.
+
+---
+
+### AwsAuthProps <a name=\\"software.amazon.awscdk.services.eks.AwsAuthProps\\"></a>
+
+Configuration props for the AwsAuth construct.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.AwsAuthProps;
+
+AwsAuthProps.builder()
+    .cluster(Cluster)
+    .build();
+\`\`\`
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.AwsAuthProps.property.cluster\\"></a>
+
+\`\`\`java
+public Cluster getCluster();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.Cluster\`](#software.amazon.awscdk.services.eks.Cluster)
+
+The EKS cluster to apply this configuration to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+### BootstrapOptions <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions\\"></a>
+
+EKS node bootstrapping options.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.BootstrapOptions;
+
+BootstrapOptions.builder()
+//  .additionalArgs(java.lang.String)
+//  .awsApiRetryAttempts(java.lang.Number)
+//  .dnsClusterIp(java.lang.String)
+//  .dockerConfigJson(java.lang.String)
+//  .enableDockerBridge(java.lang.Boolean)
+//  .kubeletExtraArgs(java.lang.String)
+//  .useMaxPods(java.lang.Boolean)
+    .build();
+\`\`\`
+
+##### \`additionalArgs\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.additionalArgs\\"></a>
+
+\`\`\`java
+public java.lang.String getAdditionalArgs();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* none
+
+Additional command line arguments to pass to the \`/etc/eks/bootstrap.sh\` command.
+
+> https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh
+
+---
+
+##### \`awsApiRetryAttempts\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.awsApiRetryAttempts\\"></a>
+
+\`\`\`java
+public java.lang.Number getAwsApiRetryAttempts();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 3
+
+Number of retry attempts for AWS API call (DescribeCluster).
+
+---
+
+##### \`dnsClusterIp\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.dnsClusterIp\\"></a>
+
+\`\`\`java
+public java.lang.String getDnsClusterIp();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* 10.100.0.10 or 172.20.0.10 based on the IP
+address of the primary interface.
+
+Overrides the IP address to use for DNS queries within the cluster.
+
+---
+
+##### \`dockerConfigJson\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.dockerConfigJson\\"></a>
+
+\`\`\`java
+public java.lang.String getDockerConfigJson();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* none
+
+The contents of the \`/etc/docker/daemon.json\` file. Useful if you want a custom config differing from the default one in the EKS AMI.
+
+---
+
+##### \`enableDockerBridge\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.enableDockerBridge\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getEnableDockerBridge();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Restores the docker default bridge network.
+
+---
+
+##### \`kubeletExtraArgs\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.kubeletExtraArgs\\"></a>
+
+\`\`\`java
+public java.lang.String getKubeletExtraArgs();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* none
+
+Extra arguments to add to the kubelet.
+
+Useful for adding labels or taints.
+
+---
+
+##### \`useMaxPods\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.BootstrapOptions.property.useMaxPods\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getUseMaxPods();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Sets \`--max-pods\` for the kubelet based on the capacity of the EC2 instance.
+
+---
+
+### CfnAddonProps <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps\\"></a>
+
+Properties for defining a \`AWS::EKS::Addon\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnAddonProps;
+
+CfnAddonProps.builder()
+    .addonName(java.lang.String)
+    .clusterName(java.lang.String)
+//  .addonVersion(java.lang.String)
+//  .resolveConflicts(java.lang.String)
+//  .serviceAccountRoleArn(java.lang.String)
+//  .tags(java.util.List<CfnTag>)
+    .build();
+\`\`\`
+
+##### \`addonName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.addonName\\"></a>
+
+\`\`\`java
+public java.lang.String getAddonName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.AddonName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonname](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonname)
+
+---
+
+##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-clustername)
+
+---
+
+##### \`addonVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.addonVersion\\"></a>
+
+\`\`\`java
+public java.lang.String getAddonVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.AddonVersion\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonversion](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-addonversion)
+
+---
+
+##### \`resolveConflicts\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.resolveConflicts\\"></a>
+
+\`\`\`java
+public java.lang.String getResolveConflicts();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.ResolveConflicts\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-resolveconflicts](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-resolveconflicts)
+
+---
+
+##### \`serviceAccountRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.serviceAccountRoleArn\\"></a>
+
+\`\`\`java
+public java.lang.String getServiceAccountRoleArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Addon.ServiceAccountRoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-serviceaccountrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-serviceaccountrolearn)
+
+---
+
+##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnAddonProps.property.tags\\"></a>
+
+\`\`\`java
+public java.util.List<CfnTag> getTags();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
+
+\`AWS::EKS::Addon.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-addon.html#cfn-eks-addon-tags)
+
+---
+
+### CfnClusterProps <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps\\"></a>
+
+Properties for defining a \`AWS::EKS::Cluster\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnClusterProps;
+
+CfnClusterProps.builder()
+    .resourcesVpcConfig(ResourcesVpcConfigProperty)
+    .resourcesVpcConfig(IResolvable)
+    .roleArn(java.lang.String)
+//  .encryptionConfig(IResolvable)
+//  .encryptionConfig(java.util.List<EncryptionConfigProperty)
+//  .encryptionConfig(IResolvable>)
+//  .kubernetesNetworkConfig(KubernetesNetworkConfigProperty)
+//  .kubernetesNetworkConfig(IResolvable)
+//  .name(java.lang.String)
+//  .version(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`resourcesVpcConfig\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.resourcesVpcConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getResourcesVpcConfig();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Cluster.ResourcesVpcConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-resourcesvpcconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-resourcesvpcconfig)
+
+---
+
+##### \`roleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.roleArn\\"></a>
+
+\`\`\`java
+public java.lang.String getRoleArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Cluster.RoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-rolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-rolearn)
+
+---
+
+##### \`encryptionConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.encryptionConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getEncryptionConfig();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)>
+
+\`AWS::EKS::Cluster.EncryptionConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-encryptionconfig)
+
+---
+
+##### \`kubernetesNetworkConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.kubernetesNetworkConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getKubernetesNetworkConfig();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Cluster.KubernetesNetworkConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-kubernetesnetworkconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-kubernetesnetworkconfig)
+
+---
+
+##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.name\\"></a>
+
+\`\`\`java
+public java.lang.String getName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Cluster.Name\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-name)
+
+---
+
+##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnClusterProps.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Cluster.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version)
+
+---
+
+### CfnFargateProfileProps <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps\\"></a>
+
+Properties for defining a \`AWS::EKS::FargateProfile\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnFargateProfileProps;
+
+CfnFargateProfileProps.builder()
+    .clusterName(java.lang.String)
+    .podExecutionRoleArn(java.lang.String)
+    .selectors(IResolvable)
+    .selectors(java.util.List<SelectorProperty)
+    .selectors(IResolvable>)
+//  .fargateProfileName(java.lang.String)
+//  .subnets(java.util.List<java.lang.String>)
+//  .tags(java.util.List<CfnTag>)
+    .build();
+\`\`\`
+
+##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::FargateProfile.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-clustername)
+
+---
+
+##### \`podExecutionRoleArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.podExecutionRoleArn\\"></a>
+
+\`\`\`java
+public java.lang.String getPodExecutionRoleArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::FargateProfile.PodExecutionRoleArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-podexecutionrolearn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-podexecutionrolearn)
+
+---
+
+##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.selectors\\"></a>
+
+\`\`\`java
+public java.lang.Object getSelectors();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty\`](#software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)>
+
+\`AWS::EKS::FargateProfile.Selectors\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-selectors](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-selectors)
+
+---
+
+##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.fargateProfileName\\"></a>
+
+\`\`\`java
+public java.lang.String getFargateProfileName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::FargateProfile.FargateProfileName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-fargateprofilename](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-fargateprofilename)
+
+---
+
+##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.subnets\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getSubnets();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`AWS::EKS::FargateProfile.Subnets\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-subnets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-subnets)
+
+---
+
+##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfileProps.property.tags\\"></a>
+
+\`\`\`java
+public java.util.List<CfnTag> getTags();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.core.CfnTag\`](#software.amazon.awscdk.core.CfnTag)>
+
+\`AWS::EKS::FargateProfile.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-fargateprofile.html#cfn-eks-fargateprofile-tags)
+
+---
+
+### CfnNodegroupProps <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps\\"></a>
+
+Properties for defining a \`AWS::EKS::Nodegroup\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnNodegroupProps;
+
+CfnNodegroupProps.builder()
+    .clusterName(java.lang.String)
+    .nodeRole(java.lang.String)
+    .subnets(java.util.List<java.lang.String>)
+//  .amiType(java.lang.String)
+//  .capacityType(java.lang.String)
+//  .diskSize(java.lang.Number)
+//  .forceUpdateEnabled(java.lang.Boolean)
+//  .forceUpdateEnabled(IResolvable)
+//  .instanceTypes(java.util.List<java.lang.String>)
+//  .labels(java.lang.Object)
+//  .launchTemplate(LaunchTemplateSpecificationProperty)
+//  .launchTemplate(IResolvable)
+//  .nodegroupName(java.lang.String)
+//  .releaseVersion(java.lang.String)
+//  .remoteAccess(RemoteAccessProperty)
+//  .remoteAccess(IResolvable)
+//  .scalingConfig(ScalingConfigProperty)
+//  .scalingConfig(IResolvable)
+//  .tags(java.lang.Object)
+//  .taints(IResolvable)
+//  .taints(java.util.List<TaintProperty)
+//  .taints(IResolvable>)
+//  .version(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.ClusterName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-clustername)
+
+---
+
+##### \`nodeRole\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.nodeRole\\"></a>
+
+\`\`\`java
+public java.lang.String getNodeRole();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.NodeRole\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-noderole](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-noderole)
+
+---
+
+##### \`subnets\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.subnets\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getSubnets();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`AWS::EKS::Nodegroup.Subnets\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-subnets](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-subnets)
+
+---
+
+##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.amiType\\"></a>
+
+\`\`\`java
+public java.lang.String getAmiType();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.AmiType\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-amitype)
+
+---
+
+##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.capacityType\\"></a>
+
+\`\`\`java
+public java.lang.String getCapacityType();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.CapacityType\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-capacitytype)
+
+---
+
+##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.diskSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getDiskSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+
+\`AWS::EKS::Nodegroup.DiskSize\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-disksize](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-disksize)
+
+---
+
+##### \`forceUpdateEnabled\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.forceUpdateEnabled\\"></a>
+
+\`\`\`java
+public java.lang.Object getForceUpdateEnabled();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\` OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Nodegroup.ForceUpdateEnabled\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-forceupdateenabled](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-forceupdateenabled)
+
+---
+
+##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.instanceTypes\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getInstanceTypes();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`AWS::EKS::Nodegroup.InstanceTypes\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes)
+
+---
+
+##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.labels\\"></a>
+
+\`\`\`java
+public java.lang.Object getLabels();
+\`\`\`
+
+- *Type:* \`java.lang.Object\`
+
+\`AWS::EKS::Nodegroup.Labels\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-labels](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-labels)
+
+---
+
+##### \`launchTemplate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.launchTemplate\\"></a>
+
+\`\`\`java
+public java.lang.Object getLaunchTemplate();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Nodegroup.LaunchTemplate\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-launchtemplate](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-launchtemplate)
+
+---
+
+##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.nodegroupName\\"></a>
+
+\`\`\`java
+public java.lang.String getNodegroupName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.NodegroupName\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-nodegroupname](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-nodegroupname)
+
+---
+
+##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.releaseVersion\\"></a>
+
+\`\`\`java
+public java.lang.String getReleaseVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.ReleaseVersion\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-releaseversion)
+
+---
+
+##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.remoteAccess\\"></a>
+
+\`\`\`java
+public java.lang.Object getRemoteAccess();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Nodegroup.RemoteAccess\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-remoteaccess](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-remoteaccess)
+
+---
+
+##### \`scalingConfig\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.scalingConfig\\"></a>
+
+\`\`\`java
+public java.lang.Object getScalingConfig();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`AWS::EKS::Nodegroup.ScalingConfig\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-scalingconfig](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-scalingconfig)
+
+---
+
+##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.tags\\"></a>
+
+\`\`\`java
+public java.lang.Object getTags();
+\`\`\`
+
+- *Type:* \`java.lang.Object\`
+
+\`AWS::EKS::Nodegroup.Tags\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-tags](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-tags)
+
+---
+
+##### \`taints\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.taints\\"></a>
+
+\`\`\`java
+public java.lang.Object getTaints();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty\`](#software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)>
+
+\`AWS::EKS::Nodegroup.Taints\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints)
+
+---
+
+##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroupProps.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`AWS::EKS::Nodegroup.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version)
+
+---
+
+### ClusterAttributes <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes\\"></a>
+
+Attributes for EKS clusters.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.ClusterAttributes;
+
+ClusterAttributes.builder()
+    .clusterName(java.lang.String)
+//  .clusterCertificateAuthorityData(java.lang.String)
+//  .clusterEncryptionConfigKeyArn(java.lang.String)
+//  .clusterEndpoint(java.lang.String)
+//  .clusterSecurityGroupId(java.lang.String)
+//  .kubectlEnvironment(java.util.Map<java.lang.String, java.lang.String>)
+//  .kubectlLayer(ILayerVersion)
+//  .kubectlMemory(Size)
+//  .kubectlPrivateSubnetIds(java.util.List<java.lang.String>)
+//  .kubectlRoleArn(java.lang.String)
+//  .kubectlSecurityGroupId(java.lang.String)
+//  .openIdConnectProvider(IOpenIdConnectProvider)
+//  .prune(java.lang.Boolean)
+//  .securityGroupIds(java.util.List<java.lang.String>)
+//  .vpc(IVpc)
+    .build();
+\`\`\`
+
+##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The physical name of the Cluster.
+
+---
+
+##### \`clusterCertificateAuthorityData\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterCertificateAuthorityData\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterCertificateAuthorityData();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* if not specified \`cluster.clusterCertificateAuthorityData\` will
+throw an error
+
+The certificate-authority-data for your cluster.
+
+---
+
+##### \`clusterEncryptionConfigKeyArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterEncryptionConfigKeyArn\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterEncryptionConfigKeyArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* if not specified \`cluster.clusterEncryptionConfigKeyArn\` will
+throw an error
+
+Amazon Resource Name (ARN) or alias of the customer master key (CMK).
+
+---
+
+##### \`clusterEndpoint\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterEndpoint\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterEndpoint();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* if not specified \`cluster.clusterEndpoint\` will throw an error.
+
+The API Server endpoint URL.
+
+---
+
+##### \`clusterSecurityGroupId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.clusterSecurityGroupId\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterSecurityGroupId();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* if not specified \`cluster.clusterSecurityGroupId\` will throw an
+error
+
+The cluster security group that was created by Amazon EKS for the cluster.
+
+---
+
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlEnvironment\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* no additional variables
+
+Environment variables to use when running \`kubectl\` against this cluster.
+
+---
+
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlLayer\\"></a>
+
+\`\`\`java
+public ILayerVersion getKubectlLayer();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
+- *Default:* a layer bundled with this module.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+This layer
+is used by the kubectl handler to apply manifests and install helm charts.
+
+The handler expects the layer to include the following executables:
+
+    helm/helm
+    kubectl/kubectl
+    awscli/aws
+
+---
+
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlMemory\\"></a>
+
+\`\`\`java
+public Size getKubectlMemory();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Size\`](#software.amazon.awscdk.core.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`kubectlPrivateSubnetIds\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlPrivateSubnetIds\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getKubectlPrivateSubnetIds();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+- *Default:* k8s endpoint is expected to be accessible publicly
+
+Subnets to host the \`kubectl\` compute resources.
+
+If not specified, the k8s
+endpoint is expected to be accessible publicly.
+
+---
+
+##### \`kubectlRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlRoleArn\\"></a>
+
+\`\`\`java
+public java.lang.String getKubectlRoleArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* if not specified, it not be possible to issue \`kubectl\` commands
+against an imported cluster.
+
+An IAM role with cluster administrator and \\"system:masters\\" permissions.
+
+---
+
+##### \`kubectlSecurityGroupId\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.kubectlSecurityGroupId\\"></a>
+
+\`\`\`java
+public java.lang.String getKubectlSecurityGroupId();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* k8s endpoint is expected to be accessible publicly
+
+A security group to use for \`kubectl\` execution.
+
+If not specified, the k8s
+endpoint is expected to be accessible publicly.
+
+---
+
+##### \`openIdConnectProvider\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.openIdConnectProvider\\"></a>
+
+\`\`\`java
+public IOpenIdConnectProvider getOpenIdConnectProvider();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IOpenIdConnectProvider\`](#software.amazon.awscdk.services.iam.IOpenIdConnectProvider)
+- *Default:* if not specified \`cluster.openIdConnectProvider\` and \`cluster.addServiceAccount\` will throw an error.
+
+An Open ID Connect provider for this cluster that can be used to configure service accounts.
+
+You can either import an existing provider using \`iam.OpenIdConnectProvider.fromProviderArn\`,
+or create a new provider using \`new eks.OpenIdConnectProvider\`
+
+---
+
+##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.securityGroupIds\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getSecurityGroupIds();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+- *Default:* if not specified, no additional security groups will be
+considered in \`cluster.connections\`.
+
+Additional security groups associated with this cluster.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterAttributes.property.vpc\\"></a>
+
+\`\`\`java
+public IVpc getVpc();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
+- *Default:* if not specified \`cluster.vpc\` will throw an error
+
+The VPC in which this Cluster was created.
+
+---
+
+### ClusterOptions <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions\\"></a>
+
+Options for EKS clusters.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.ClusterOptions;
+
+ClusterOptions.builder()
+    .version(KubernetesVersion)
+//  .clusterName(java.lang.String)
+//  .outputClusterName(java.lang.Boolean)
+//  .outputConfigCommand(java.lang.Boolean)
+//  .role(IRole)
+//  .securityGroup(ISecurityGroup)
+//  .vpc(IVpc)
+//  .vpcSubnets(java.util.List<SubnetSelection>)
+//  .clusterHandlerEnvironment(java.util.Map<java.lang.String, java.lang.String>)
+//  .coreDnsComputeType(CoreDnsComputeType)
+//  .endpointAccess(EndpointAccess)
+//  .kubectlEnvironment(java.util.Map<java.lang.String, java.lang.String>)
+//  .kubectlLayer(ILayerVersion)
+//  .kubectlMemory(Size)
+//  .mastersRole(IRole)
+//  .outputMastersRoleArn(java.lang.Boolean)
+//  .placeClusterHandlerInVpc(java.lang.Boolean)
+//  .prune(java.lang.Boolean)
+//  .secretsEncryptionKey(IKey)
+    .build();
+\`\`\`
+
+##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.version\\"></a>
+
+\`\`\`java
+public KubernetesVersion getVersion();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
+
+The Kubernetes version to run in the cluster.
+
+---
+
+##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* Automatically generated name
+
+Name for the cluster.
+
+---
+
+##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.outputClusterName\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the name of the cluster will be synthesized.
+
+---
+
+##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.outputConfigCommand\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputConfigCommand();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Determines whether a CloudFormation output with the \`aws eks update-kubeconfig\` command will be synthesized.
+
+This command will include
+the cluster name and, if applicable, the ARN of the masters IAM role.
+
+---
+
+##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.role\\"></a>
+
+\`\`\`java
+public IRole getRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* A role is automatically created for you
+
+Role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
+
+---
+
+##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.securityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getSecurityGroup();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
+- *Default:* A security group is automatically created
+
+Security Group to use for Control Plane ENIs.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.vpc\\"></a>
+
+\`\`\`java
+public IVpc getVpc();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
+- *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
+
+The VPC in which to create the Cluster.
+
+---
+
+##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.vpcSubnets\\"></a>
+
+\`\`\`java
+public java.util.List<SubnetSelection> getVpcSubnets();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
+- *Default:* All public and private subnets
+
+Where to place EKS Control Plane ENIs.
+
+If you want to create public load balancers, this must include public subnets.
+
+For example, to only select private subnets, supply the following:
+
+\`\`\`ts
+vpcSubnets: [
+   { subnetType: ec2.SubnetType.Private }
+]
+\`\`\`
+
+---
+
+##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.clusterHandlerEnvironment\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getClusterHandlerEnvironment();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* No environment variables.
+
+Custom environment variables when interacting with the EKS endpoint to manage the cluster lifecycle.
+
+---
+
+##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.coreDnsComputeType\\"></a>
+
+\`\`\`java
+public CoreDnsComputeType getCoreDnsComputeType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CoreDnsComputeType\`](#software.amazon.awscdk.services.eks.CoreDnsComputeType)
+- *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
+
+Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS configuration on your cluster to determine which compute type to use for CoreDNS.
+
+---
+
+##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.endpointAccess\\"></a>
+
+\`\`\`java
+public EndpointAccess getEndpointAccess();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
+- *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
+
+Configure access to the Kubernetes API server endpoint..
+
+> https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+
+---
+
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.kubectlEnvironment\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* No environment variables.
+
+Environment variables for the kubectl execution.
+
+Only relevant for kubectl enabled clusters.
+
+---
+
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.kubectlLayer\\"></a>
+
+\`\`\`java
+public ILayerVersion getKubectlLayer();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
+- *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+By default, the provider will use the layer included in the
+\\"aws-lambda-layer-kubectl\\" SAR application which is available in all
+commercial regions.
+
+To deploy the layer locally, visit
+https://github.com/aws-samples/aws-lambda-layer-kubectl/blob/master/cdk/README.md
+for instructions on how to prepare the .zip file and then define it in your
+app as follows:
+
+\`\`\`ts
+const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
+   code: lambda.Code.fromAsset(\`\${__dirname}/layer.zip\`)),
+   compatibleRuntimes: [lambda.Runtime.PROVIDED]
+})
+\`\`\`
+
+> https://github.com/aws-samples/aws-lambda-layer-kubectl
+
+---
+
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.kubectlMemory\\"></a>
+
+\`\`\`java
+public Size getKubectlMemory();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Size\`](#software.amazon.awscdk.core.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`mastersRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.mastersRole\\"></a>
+
+\`\`\`java
+public IRole getMastersRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* a role that assumable by anyone with permissions in the same
+account will automatically be defined
+
+An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.outputMastersRoleArn\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputMastersRoleArn();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM role will be synthesized (if \`mastersRole\` is specified).
+
+---
+
+##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.placeClusterHandlerInVpc\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPlaceClusterHandlerInVpc();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+If set to true, the cluster handler functions will be placed in the private subnets of the cluster vpc, subject to the \`vpcSubnets\` selection strategy.
+
+---
+
+##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterOptions.property.secretsEncryptionKey\\"></a>
+
+\`\`\`java
+public IKey getSecretsEncryptionKey();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.kms.IKey\`](#software.amazon.awscdk.services.kms.IKey)
+- *Default:* By default, Kubernetes stores all secret object data within etcd and
+  all etcd volumes used by Amazon EKS are encrypted at the disk-level
+  using AWS-Managed encryption keys.
+
+KMS secret for envelope encryption for Kubernetes secrets.
+
+---
+
+### ClusterProps <a name=\\"software.amazon.awscdk.services.eks.ClusterProps\\"></a>
+
+Common configuration props for EKS clusters.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.ClusterProps;
+
+ClusterProps.builder()
+    .version(KubernetesVersion)
+//  .clusterName(java.lang.String)
+//  .outputClusterName(java.lang.Boolean)
+//  .outputConfigCommand(java.lang.Boolean)
+//  .role(IRole)
+//  .securityGroup(ISecurityGroup)
+//  .vpc(IVpc)
+//  .vpcSubnets(java.util.List<SubnetSelection>)
+//  .clusterHandlerEnvironment(java.util.Map<java.lang.String, java.lang.String>)
+//  .coreDnsComputeType(CoreDnsComputeType)
+//  .endpointAccess(EndpointAccess)
+//  .kubectlEnvironment(java.util.Map<java.lang.String, java.lang.String>)
+//  .kubectlLayer(ILayerVersion)
+//  .kubectlMemory(Size)
+//  .mastersRole(IRole)
+//  .outputMastersRoleArn(java.lang.Boolean)
+//  .placeClusterHandlerInVpc(java.lang.Boolean)
+//  .prune(java.lang.Boolean)
+//  .secretsEncryptionKey(IKey)
+//  .defaultCapacity(java.lang.Number)
+//  .defaultCapacityInstance(InstanceType)
+//  .defaultCapacityType(DefaultCapacityType)
+    .build();
+\`\`\`
+
+##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.version\\"></a>
+
+\`\`\`java
+public KubernetesVersion getVersion();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
+
+The Kubernetes version to run in the cluster.
+
+---
+
+##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* Automatically generated name
+
+Name for the cluster.
+
+---
+
+##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.outputClusterName\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the name of the cluster will be synthesized.
+
+---
+
+##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.outputConfigCommand\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputConfigCommand();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Determines whether a CloudFormation output with the \`aws eks update-kubeconfig\` command will be synthesized.
+
+This command will include
+the cluster name and, if applicable, the ARN of the masters IAM role.
+
+---
+
+##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.role\\"></a>
+
+\`\`\`java
+public IRole getRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* A role is automatically created for you
+
+Role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
+
+---
+
+##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.securityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getSecurityGroup();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
+- *Default:* A security group is automatically created
+
+Security Group to use for Control Plane ENIs.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.vpc\\"></a>
+
+\`\`\`java
+public IVpc getVpc();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
+- *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
+
+The VPC in which to create the Cluster.
+
+---
+
+##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.vpcSubnets\\"></a>
+
+\`\`\`java
+public java.util.List<SubnetSelection> getVpcSubnets();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
+- *Default:* All public and private subnets
+
+Where to place EKS Control Plane ENIs.
+
+If you want to create public load balancers, this must include public subnets.
+
+For example, to only select private subnets, supply the following:
+
+\`\`\`ts
+vpcSubnets: [
+   { subnetType: ec2.SubnetType.Private }
+]
+\`\`\`
+
+---
+
+##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.clusterHandlerEnvironment\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getClusterHandlerEnvironment();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* No environment variables.
+
+Custom environment variables when interacting with the EKS endpoint to manage the cluster lifecycle.
+
+---
+
+##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.coreDnsComputeType\\"></a>
+
+\`\`\`java
+public CoreDnsComputeType getCoreDnsComputeType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CoreDnsComputeType\`](#software.amazon.awscdk.services.eks.CoreDnsComputeType)
+- *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
+
+Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS configuration on your cluster to determine which compute type to use for CoreDNS.
+
+---
+
+##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.endpointAccess\\"></a>
+
+\`\`\`java
+public EndpointAccess getEndpointAccess();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
+- *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
+
+Configure access to the Kubernetes API server endpoint..
+
+> https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+
+---
+
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.kubectlEnvironment\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* No environment variables.
+
+Environment variables for the kubectl execution.
+
+Only relevant for kubectl enabled clusters.
+
+---
+
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.kubectlLayer\\"></a>
+
+\`\`\`java
+public ILayerVersion getKubectlLayer();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
+- *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+By default, the provider will use the layer included in the
+\\"aws-lambda-layer-kubectl\\" SAR application which is available in all
+commercial regions.
+
+To deploy the layer locally, visit
+https://github.com/aws-samples/aws-lambda-layer-kubectl/blob/master/cdk/README.md
+for instructions on how to prepare the .zip file and then define it in your
+app as follows:
+
+\`\`\`ts
+const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
+   code: lambda.Code.fromAsset(\`\${__dirname}/layer.zip\`)),
+   compatibleRuntimes: [lambda.Runtime.PROVIDED]
+})
+\`\`\`
+
+> https://github.com/aws-samples/aws-lambda-layer-kubectl
+
+---
+
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.kubectlMemory\\"></a>
+
+\`\`\`java
+public Size getKubectlMemory();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Size\`](#software.amazon.awscdk.core.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`mastersRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.mastersRole\\"></a>
+
+\`\`\`java
+public IRole getMastersRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* a role that assumable by anyone with permissions in the same
+account will automatically be defined
+
+An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.outputMastersRoleArn\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputMastersRoleArn();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM role will be synthesized (if \`mastersRole\` is specified).
+
+---
+
+##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.placeClusterHandlerInVpc\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPlaceClusterHandlerInVpc();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+If set to true, the cluster handler functions will be placed in the private subnets of the cluster vpc, subject to the \`vpcSubnets\` selection strategy.
+
+---
+
+##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.secretsEncryptionKey\\"></a>
+
+\`\`\`java
+public IKey getSecretsEncryptionKey();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.kms.IKey\`](#software.amazon.awscdk.services.kms.IKey)
+- *Default:* By default, Kubernetes stores all secret object data within etcd and
+  all etcd volumes used by Amazon EKS are encrypted at the disk-level
+  using AWS-Managed encryption keys.
+
+KMS secret for envelope encryption for Kubernetes secrets.
+
+---
+
+##### \`defaultCapacity\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.defaultCapacity\\"></a>
+
+\`\`\`java
+public java.lang.Number getDefaultCapacity();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 2
+
+Number of instances to allocate as an initial capacity for this cluster.
+
+Instance type can be configured through \`defaultCapacityInstanceType\`,
+which defaults to \`m5.large\`.
+
+Use \`cluster.addAutoScalingGroupCapacity\` to add additional customized capacity. Set this
+to \`0\` is you wish to avoid the initial capacity allocation.
+
+---
+
+##### \`defaultCapacityInstance\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.defaultCapacityInstance\\"></a>
+
+\`\`\`java
+public InstanceType getDefaultCapacityInstance();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)
+- *Default:* m5.large
+
+The instance type to use for the default capacity.
+
+This will only be taken
+into account if \`defaultCapacity\` is > 0.
+
+---
+
+##### \`defaultCapacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ClusterProps.property.defaultCapacityType\\"></a>
+
+\`\`\`java
+public DefaultCapacityType getDefaultCapacityType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.DefaultCapacityType\`](#software.amazon.awscdk.services.eks.DefaultCapacityType)
+- *Default:* NODEGROUP
+
+The default capacity type for the cluster.
+
+---
+
+### CommonClusterOptions <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions\\"></a>
+
+Options for configuring an EKS cluster.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CommonClusterOptions;
+
+CommonClusterOptions.builder()
+    .version(KubernetesVersion)
+//  .clusterName(java.lang.String)
+//  .outputClusterName(java.lang.Boolean)
+//  .outputConfigCommand(java.lang.Boolean)
+//  .role(IRole)
+//  .securityGroup(ISecurityGroup)
+//  .vpc(IVpc)
+//  .vpcSubnets(java.util.List<SubnetSelection>)
+    .build();
+\`\`\`
+
+##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.version\\"></a>
+
+\`\`\`java
+public KubernetesVersion getVersion();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
+
+The Kubernetes version to run in the cluster.
+
+---
+
+##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* Automatically generated name
+
+Name for the cluster.
+
+---
+
+##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.outputClusterName\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the name of the cluster will be synthesized.
+
+---
+
+##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.outputConfigCommand\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputConfigCommand();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Determines whether a CloudFormation output with the \`aws eks update-kubeconfig\` command will be synthesized.
+
+This command will include
+the cluster name and, if applicable, the ARN of the masters IAM role.
+
+---
+
+##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.role\\"></a>
+
+\`\`\`java
+public IRole getRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* A role is automatically created for you
+
+Role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
+
+---
+
+##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.securityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getSecurityGroup();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
+- *Default:* A security group is automatically created
+
+Security Group to use for Control Plane ENIs.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.vpc\\"></a>
+
+\`\`\`java
+public IVpc getVpc();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
+- *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
+
+The VPC in which to create the Cluster.
+
+---
+
+##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CommonClusterOptions.property.vpcSubnets\\"></a>
+
+\`\`\`java
+public java.util.List<SubnetSelection> getVpcSubnets();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
+- *Default:* All public and private subnets
+
+Where to place EKS Control Plane ENIs.
+
+If you want to create public load balancers, this must include public subnets.
+
+For example, to only select private subnets, supply the following:
+
+\`\`\`ts
+vpcSubnets: [
+   { subnetType: ec2.SubnetType.Private }
+]
+\`\`\`
+
+---
+
+### EksOptimizedImageProps <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps\\"></a>
+
+Properties for EksOptimizedImage.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.EksOptimizedImageProps;
+
+EksOptimizedImageProps.builder()
+//  .cpuArch(CpuArch)
+//  .kubernetesVersion(java.lang.String)
+//  .nodeType(NodeType)
+    .build();
+\`\`\`
+
+##### \`cpuArch\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps.property.cpuArch\\"></a>
+
+\`\`\`java
+public CpuArch getCpuArch();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CpuArch\`](#software.amazon.awscdk.services.eks.CpuArch)
+- *Default:* CpuArch.X86_64
+
+What cpu architecture to retrieve the image for (arm64 or x86_64).
+
+---
+
+##### \`kubernetesVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps.property.kubernetesVersion\\"></a>
+
+\`\`\`java
+public java.lang.String getKubernetesVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* The latest version
+
+The Kubernetes version to use.
+
+---
+
+##### \`nodeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps.property.nodeType\\"></a>
+
+\`\`\`java
+public NodeType getNodeType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.NodeType\`](#software.amazon.awscdk.services.eks.NodeType)
+- *Default:* NodeType.STANDARD
+
+What instance type to retrieve the image for (standard or GPU-optimized).
+
+---
+
+### EncryptionConfigProperty <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty\\"></a>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-encryptionconfig.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-encryptionconfig.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty;
+
+EncryptionConfigProperty.builder()
+//  .provider(ProviderProperty)
+//  .provider(IResolvable)
+//  .resources(java.util.List<java.lang.String>)
+    .build();
+\`\`\`
+
+##### \`provider\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty.property.provider\\"></a>
+
+\`\`\`java
+public java.lang.Object getProvider();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CfnCluster.ProviderProperty\`](#software.amazon.awscdk.services.eks.CfnCluster.ProviderProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)
+
+\`CfnCluster.EncryptionConfigProperty.Provider\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-encryptionconfig.html#cfn-eks-cluster-encryptionconfig-provider](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-encryptionconfig.html#cfn-eks-cluster-encryptionconfig-provider)
+
+---
+
+##### \`resources\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.EncryptionConfigProperty.property.resources\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getResources();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`CfnCluster.EncryptionConfigProperty.Resources\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-encryptionconfig.html#cfn-eks-cluster-encryptionconfig-resources](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-encryptionconfig.html#cfn-eks-cluster-encryptionconfig-resources)
+
+---
+
+### FargateClusterProps <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps\\"></a>
+
+Configuration props for EKS Fargate.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.FargateClusterProps;
+
+FargateClusterProps.builder()
+    .version(KubernetesVersion)
+//  .clusterName(java.lang.String)
+//  .outputClusterName(java.lang.Boolean)
+//  .outputConfigCommand(java.lang.Boolean)
+//  .role(IRole)
+//  .securityGroup(ISecurityGroup)
+//  .vpc(IVpc)
+//  .vpcSubnets(java.util.List<SubnetSelection>)
+//  .clusterHandlerEnvironment(java.util.Map<java.lang.String, java.lang.String>)
+//  .coreDnsComputeType(CoreDnsComputeType)
+//  .endpointAccess(EndpointAccess)
+//  .kubectlEnvironment(java.util.Map<java.lang.String, java.lang.String>)
+//  .kubectlLayer(ILayerVersion)
+//  .kubectlMemory(Size)
+//  .mastersRole(IRole)
+//  .outputMastersRoleArn(java.lang.Boolean)
+//  .placeClusterHandlerInVpc(java.lang.Boolean)
+//  .prune(java.lang.Boolean)
+//  .secretsEncryptionKey(IKey)
+//  .defaultProfile(FargateProfileOptions)
+    .build();
+\`\`\`
+
+##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.version\\"></a>
+
+\`\`\`java
+public KubernetesVersion getVersion();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
+
+The Kubernetes version to run in the cluster.
+
+---
+
+##### \`clusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* Automatically generated name
+
+Name for the cluster.
+
+---
+
+##### \`outputClusterName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.outputClusterName\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the name of the cluster will be synthesized.
+
+---
+
+##### \`outputConfigCommand\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.outputConfigCommand\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputConfigCommand();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Determines whether a CloudFormation output with the \`aws eks update-kubeconfig\` command will be synthesized.
+
+This command will include
+the cluster name and, if applicable, the ARN of the masters IAM role.
+
+---
+
+##### \`role\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.role\\"></a>
+
+\`\`\`java
+public IRole getRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* A role is automatically created for you
+
+Role that provides permissions for the Kubernetes control plane to make calls to AWS API operations on your behalf.
+
+---
+
+##### \`securityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.securityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getSecurityGroup();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
+- *Default:* A security group is automatically created
+
+Security Group to use for Control Plane ENIs.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.vpc\\"></a>
+
+\`\`\`java
+public IVpc getVpc();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
+- *Default:* a VPC with default configuration will be created and can be accessed through \`cluster.vpc\`.
+
+The VPC in which to create the Cluster.
+
+---
+
+##### \`vpcSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.vpcSubnets\\"></a>
+
+\`\`\`java
+public java.util.List<SubnetSelection> getVpcSubnets();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)>
+- *Default:* All public and private subnets
+
+Where to place EKS Control Plane ENIs.
+
+If you want to create public load balancers, this must include public subnets.
+
+For example, to only select private subnets, supply the following:
+
+\`\`\`ts
+vpcSubnets: [
+   { subnetType: ec2.SubnetType.Private }
+]
+\`\`\`
+
+---
+
+##### \`clusterHandlerEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.clusterHandlerEnvironment\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getClusterHandlerEnvironment();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* No environment variables.
+
+Custom environment variables when interacting with the EKS endpoint to manage the cluster lifecycle.
+
+---
+
+##### \`coreDnsComputeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.coreDnsComputeType\\"></a>
+
+\`\`\`java
+public CoreDnsComputeType getCoreDnsComputeType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CoreDnsComputeType\`](#software.amazon.awscdk.services.eks.CoreDnsComputeType)
+- *Default:* CoreDnsComputeType.EC2 (for \`FargateCluster\` the default is FARGATE)
+
+Controls the \\"eks.amazonaws.com/compute-type\\" annotation in the CoreDNS configuration on your cluster to determine which compute type to use for CoreDNS.
+
+---
+
+##### \`endpointAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.endpointAccess\\"></a>
+
+\`\`\`java
+public EndpointAccess getEndpointAccess();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
+- *Default:* EndpointAccess.PUBLIC_AND_PRIVATE
+
+Configure access to the Kubernetes API server endpoint..
+
+> https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html
+
+---
+
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.kubectlEnvironment\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* No environment variables.
+
+Environment variables for the kubectl execution.
+
+Only relevant for kubectl enabled clusters.
+
+---
+
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.kubectlLayer\\"></a>
+
+\`\`\`java
+public ILayerVersion getKubectlLayer();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
+- *Default:* the layer provided by the \`aws-lambda-layer-kubectl\` SAR app.
+
+An AWS Lambda Layer which includes \`kubectl\`, Helm and the AWS CLI.
+
+By default, the provider will use the layer included in the
+\\"aws-lambda-layer-kubectl\\" SAR application which is available in all
+commercial regions.
+
+To deploy the layer locally, visit
+https://github.com/aws-samples/aws-lambda-layer-kubectl/blob/master/cdk/README.md
+for instructions on how to prepare the .zip file and then define it in your
+app as follows:
+
+\`\`\`ts
+const layer = new lambda.LayerVersion(this, 'kubectl-layer', {
+   code: lambda.Code.fromAsset(\`\${__dirname}/layer.zip\`)),
+   compatibleRuntimes: [lambda.Runtime.PROVIDED]
+})
+\`\`\`
+
+> https://github.com/aws-samples/aws-lambda-layer-kubectl
+
+---
+
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.kubectlMemory\\"></a>
+
+\`\`\`java
+public Size getKubectlMemory();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Size\`](#software.amazon.awscdk.core.Size)
+- *Default:* Size.gibibytes(1)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`mastersRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.mastersRole\\"></a>
+
+\`\`\`java
+public IRole getMastersRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* a role that assumable by anyone with permissions in the same
+account will automatically be defined
+
+An IAM role that will be added to the \`system:masters\` Kubernetes RBAC group.
+
+> https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+
+---
+
+##### \`outputMastersRoleArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.outputMastersRoleArn\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOutputMastersRoleArn();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Determines whether a CloudFormation output with the ARN of the \\"masters\\" IAM role will be synthesized (if \`mastersRole\` is specified).
+
+---
+
+##### \`placeClusterHandlerInVpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.placeClusterHandlerInVpc\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPlaceClusterHandlerInVpc();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+If set to true, the cluster handler functions will be placed in the private subnets of the cluster vpc, subject to the \`vpcSubnets\` selection strategy.
+
+---
+
+##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Indicates whether Kubernetes resources added through \`addManifest()\` can be automatically pruned.
+
+When this is enabled (default), prune labels will be
+allocated and injected to each resource. These labels will then be used
+when issuing the \`kubectl apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`secretsEncryptionKey\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.secretsEncryptionKey\\"></a>
+
+\`\`\`java
+public IKey getSecretsEncryptionKey();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.kms.IKey\`](#software.amazon.awscdk.services.kms.IKey)
+- *Default:* By default, Kubernetes stores all secret object data within etcd and
+  all etcd volumes used by Amazon EKS are encrypted at the disk-level
+  using AWS-Managed encryption keys.
+
+KMS secret for envelope encryption for Kubernetes secrets.
+
+---
+
+##### \`defaultProfile\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateClusterProps.property.defaultProfile\\"></a>
+
+\`\`\`java
+public FargateProfileOptions getDefaultProfile();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.FargateProfileOptions\`](#software.amazon.awscdk.services.eks.FargateProfileOptions)
+- *Default:* A profile called \\"default\\" with 'default' and 'kube-system'
+  selectors will be created if this is left undefined.
+
+Fargate Profile to create along with the cluster.
+
+---
+
+### FargateProfileOptions <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions\\"></a>
+
+Options for defining EKS Fargate Profiles.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.FargateProfileOptions;
+
+FargateProfileOptions.builder()
+    .selectors(java.util.List<Selector>)
+//  .fargateProfileName(java.lang.String)
+//  .podExecutionRole(IRole)
+//  .subnetSelection(SubnetSelection)
+//  .vpc(IVpc)
+    .build();
+\`\`\`
+
+##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.selectors\\"></a>
+
+\`\`\`java
+public java.util.List<Selector> getSelectors();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.eks.Selector\`](#software.amazon.awscdk.services.eks.Selector)>
+
+The selectors to match for pods to use this Fargate profile.
+
+Each selector
+must have an associated namespace. Optionally, you can also specify labels
+for a namespace.
+
+At least one selector is required and you may specify up to five selectors.
+
+---
+
+##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.fargateProfileName\\"></a>
+
+\`\`\`java
+public java.lang.String getFargateProfileName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* generated
+
+The name of the Fargate profile.
+
+---
+
+##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.podExecutionRole\\"></a>
+
+\`\`\`java
+public IRole getPodExecutionRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* a role will be automatically created
+
+The pod execution role to use for pods that match the selectors in the Fargate profile.
+
+The pod execution role allows Fargate infrastructure to
+register with your cluster as a node, and it provides read access to Amazon
+ECR image repositories.
+
+> https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html
+
+---
+
+##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.subnetSelection\\"></a>
+
+\`\`\`java
+public SubnetSelection getSubnetSelection();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
+- *Default:* all private subnets of the VPC are selected.
+
+Select which subnets to launch your pods into.
+
+At this time, pods running
+on Fargate are not assigned public IP addresses, so only private subnets
+(with no direct route to an Internet Gateway) are allowed.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileOptions.property.vpc\\"></a>
+
+\`\`\`java
+public IVpc getVpc();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
+- *Default:* all private subnets used by theEKS cluster
+
+The VPC from which to select subnets to launch your pods into.
+
+By default, all private subnets are selected. You can customize this using
+\`subnetSelection\`.
+
+---
+
+### FargateProfileProps <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps\\"></a>
+
+Configuration props for EKS Fargate Profiles.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.FargateProfileProps;
+
+FargateProfileProps.builder()
+    .selectors(java.util.List<Selector>)
+//  .fargateProfileName(java.lang.String)
+//  .podExecutionRole(IRole)
+//  .subnetSelection(SubnetSelection)
+//  .vpc(IVpc)
+    .cluster(Cluster)
+    .build();
+\`\`\`
+
+##### \`selectors\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.selectors\\"></a>
+
+\`\`\`java
+public java.util.List<Selector> getSelectors();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.eks.Selector\`](#software.amazon.awscdk.services.eks.Selector)>
+
+The selectors to match for pods to use this Fargate profile.
+
+Each selector
+must have an associated namespace. Optionally, you can also specify labels
+for a namespace.
+
+At least one selector is required and you may specify up to five selectors.
+
+---
+
+##### \`fargateProfileName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.fargateProfileName\\"></a>
+
+\`\`\`java
+public java.lang.String getFargateProfileName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* generated
+
+The name of the Fargate profile.
+
+---
+
+##### \`podExecutionRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.podExecutionRole\\"></a>
+
+\`\`\`java
+public IRole getPodExecutionRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* a role will be automatically created
+
+The pod execution role to use for pods that match the selectors in the Fargate profile.
+
+The pod execution role allows Fargate infrastructure to
+register with your cluster as a node, and it provides read access to Amazon
+ECR image repositories.
+
+> https://docs.aws.amazon.com/eks/latest/userguide/pod-execution-role.html
+
+---
+
+##### \`subnetSelection\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.subnetSelection\\"></a>
+
+\`\`\`java
+public SubnetSelection getSubnetSelection();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
+- *Default:* all private subnets of the VPC are selected.
+
+Select which subnets to launch your pods into.
+
+At this time, pods running
+on Fargate are not assigned public IP addresses, so only private subnets
+(with no direct route to an Internet Gateway) are allowed.
+
+---
+
+##### \`vpc\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.vpc\\"></a>
+
+\`\`\`java
+public IVpc getVpc();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
+- *Default:* all private subnets used by theEKS cluster
+
+The VPC from which to select subnets to launch your pods into.
+
+By default, all private subnets are selected. You can customize this using
+\`subnetSelection\`.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.FargateProfileProps.property.cluster\\"></a>
+
+\`\`\`java
+public Cluster getCluster();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.Cluster\`](#software.amazon.awscdk.services.eks.Cluster)
+
+The EKS cluster to apply the Fargate profile to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+### HelmChartOptions <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions\\"></a>
+
+Helm Chart options.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.HelmChartOptions;
+
+HelmChartOptions.builder()
+    .chart(java.lang.String)
+//  .createNamespace(java.lang.Boolean)
+//  .namespace(java.lang.String)
+//  .release(java.lang.String)
+//  .repository(java.lang.String)
+//  .timeout(Duration)
+//  .values(java.util.Map<java.lang.String, java.lang.Object>)
+//  .version(java.lang.String)
+//  .wait(java.lang.Boolean)
+    .build();
+\`\`\`
+
+##### \`chart\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.chart\\"></a>
+
+\`\`\`java
+public java.lang.String getChart();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The name of the chart.
+
+---
+
+##### \`createNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.createNamespace\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getCreateNamespace();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+create namespace if not exist.
+
+---
+
+##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.namespace\\"></a>
+
+\`\`\`java
+public java.lang.String getNamespace();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* default
+
+The Kubernetes namespace scope of the requests.
+
+---
+
+##### \`release\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.release\\"></a>
+
+\`\`\`java
+public java.lang.String getRelease();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
+
+The name of the release.
+
+---
+
+##### \`repository\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.repository\\"></a>
+
+\`\`\`java
+public java.lang.String getRepository();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
+
+The repository which contains the chart.
+
+For example: https://kubernetes-charts.storage.googleapis.com/
+
+---
+
+##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.timeout\\"></a>
+
+\`\`\`java
+public Duration getTimeout();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
+- *Default:* Duration.minutes(5)
+
+Amount of time to wait for any individual Kubernetes operation.
+
+Maximum 15 minutes.
+
+---
+
+##### \`values\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.values\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.Object> getValues();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
+- *Default:* No values are provided to the chart.
+
+The values to be used by the chart.
+
+---
+
+##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* If this is not specified, the latest version is installed
+
+The chart version to install.
+
+---
+
+##### \`wait\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartOptions.property.wait\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getWait();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* Helm will not wait before marking release as successful
+
+Whether or not Helm should wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful.
+
+---
+
+### HelmChartProps <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps\\"></a>
+
+Helm Chart properties.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.HelmChartProps;
+
+HelmChartProps.builder()
+    .chart(java.lang.String)
+//  .createNamespace(java.lang.Boolean)
+//  .namespace(java.lang.String)
+//  .release(java.lang.String)
+//  .repository(java.lang.String)
+//  .timeout(Duration)
+//  .values(java.util.Map<java.lang.String, java.lang.Object>)
+//  .version(java.lang.String)
+//  .wait(java.lang.Boolean)
+    .cluster(ICluster)
+    .build();
+\`\`\`
+
+##### \`chart\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.chart\\"></a>
+
+\`\`\`java
+public java.lang.String getChart();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The name of the chart.
+
+---
+
+##### \`createNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.createNamespace\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getCreateNamespace();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+create namespace if not exist.
+
+---
+
+##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.namespace\\"></a>
+
+\`\`\`java
+public java.lang.String getNamespace();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* default
+
+The Kubernetes namespace scope of the requests.
+
+---
+
+##### \`release\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.release\\"></a>
+
+\`\`\`java
+public java.lang.String getRelease();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* If no release name is given, it will use the last 53 characters of the node's unique id.
+
+The name of the release.
+
+---
+
+##### \`repository\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.repository\\"></a>
+
+\`\`\`java
+public java.lang.String getRepository();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* No repository will be used, which means that the chart needs to be an absolute URL.
+
+The repository which contains the chart.
+
+For example: https://kubernetes-charts.storage.googleapis.com/
+
+---
+
+##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.timeout\\"></a>
+
+\`\`\`java
+public Duration getTimeout();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
+- *Default:* Duration.minutes(5)
+
+Amount of time to wait for any individual Kubernetes operation.
+
+Maximum 15 minutes.
+
+---
+
+##### \`values\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.values\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.Object> getValues();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
+- *Default:* No values are provided to the chart.
+
+The values to be used by the chart.
+
+---
+
+##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* If this is not specified, the latest version is installed
+
+The chart version to install.
+
+---
+
+##### \`wait\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.wait\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getWait();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* Helm will not wait before marking release as successful
+
+Whether or not Helm should wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.HelmChartProps.property.cluster\\"></a>
+
+\`\`\`java
+public ICluster getCluster();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+The EKS cluster to apply this configuration to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+### KubernetesManifestOptions <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestOptions\\"></a>
+
+Options for \`KubernetesManifest\`.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.KubernetesManifestOptions;
+
+KubernetesManifestOptions.builder()
+//  .prune(java.lang.Boolean)
+//  .skipValidation(java.lang.Boolean)
+    .build();
+\`\`\`
+
+##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestOptions.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* based on the prune option of the cluster, which is \`true\` unless
+otherwise specified.
+
+When a resource is removed from a Kubernetes manifest, it no longer appears in the manifest, and there is no way to know that this resource needs to be deleted.
+
+To address this, \`kubectl apply\` has a \`--prune\` option which will
+query the cluster for all resources with a specific label and will remove
+all the labeld resources that are not part of the applied manifest. If this
+option is disabled and a resource is removed, it will become \\"orphaned\\" and
+will not be deleted from the cluster.
+
+When this option is enabled (default), the construct will inject a label to
+all Kubernetes resources included in this manifest which will be used to
+prune resources when the manifest changes via \`kubectl apply --prune\`.
+
+The label name will be \`aws.cdk.eks/prune-<ADDR>\` where \`<ADDR>\` is the
+42-char unique address of this construct in the construct tree. Value is
+empty.
+
+> https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#alternative-kubectl-apply-f-directory-prune-l-your-label
+
+---
+
+##### \`skipValidation\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestOptions.property.skipValidation\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getSkipValidation();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+A flag to signify if the manifest validation should be skipped.
+
+---
+
+### KubernetesManifestProps <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps\\"></a>
+
+Properties for KubernetesManifest.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.KubernetesManifestProps;
+
+KubernetesManifestProps.builder()
+//  .prune(java.lang.Boolean)
+//  .skipValidation(java.lang.Boolean)
+    .cluster(ICluster)
+    .manifest(java.util.List<java.util.Map<java.lang.String, java.lang.Object>>)
+//  .overwrite(java.lang.Boolean)
+    .build();
+\`\`\`
+
+##### \`prune\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* based on the prune option of the cluster, which is \`true\` unless
+otherwise specified.
+
+When a resource is removed from a Kubernetes manifest, it no longer appears in the manifest, and there is no way to know that this resource needs to be deleted.
+
+To address this, \`kubectl apply\` has a \`--prune\` option which will
+query the cluster for all resources with a specific label and will remove
+all the labeld resources that are not part of the applied manifest. If this
+option is disabled and a resource is removed, it will become \\"orphaned\\" and
+will not be deleted from the cluster.
+
+When this option is enabled (default), the construct will inject a label to
+all Kubernetes resources included in this manifest which will be used to
+prune resources when the manifest changes via \`kubectl apply --prune\`.
+
+The label name will be \`aws.cdk.eks/prune-<ADDR>\` where \`<ADDR>\` is the
+42-char unique address of this construct in the construct tree. Value is
+empty.
+
+> https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#alternative-kubectl-apply-f-directory-prune-l-your-label
+
+---
+
+##### \`skipValidation\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.skipValidation\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getSkipValidation();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+A flag to signify if the manifest validation should be skipped.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.cluster\\"></a>
+
+\`\`\`java
+public ICluster getCluster();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+The EKS cluster to apply this manifest to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+##### \`manifest\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.manifest\\"></a>
+
+\`\`\`java
+public java.util.List<java.util.Map<java.lang.String, java.lang.Object>> getManifest();
+\`\`\`
+
+- *Type:* java.util.List<java.util.Map<java.lang.String, \`java.lang.Object\`>>
+
+The manifest to apply.
+
+Consists of any number of child resources.
+
+When the resources are created/updated, this manifest will be applied to the
+cluster through \`kubectl apply\` and when the resources or the stack is
+deleted, the resources in the manifest will be deleted through \`kubectl delete\`.
+
+---
+
+##### \`overwrite\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesManifestProps.property.overwrite\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getOverwrite();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* false
+
+Overwrite any existing resources.
+
+If this is set, we will use \`kubectl apply\` instead of \`kubectl create\`
+when the resource is created. Otherwise, if there is already a resource
+in the cluster with the same name, the operation will fail.
+
+---
+
+### KubernetesNetworkConfigProperty <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty\\"></a>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-kubernetesnetworkconfig.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-kubernetesnetworkconfig.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty;
+
+KubernetesNetworkConfigProperty.builder()
+//  .serviceIpv4Cidr(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`serviceIpv4Cidr\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.KubernetesNetworkConfigProperty.property.serviceIpv4Cidr\\"></a>
+
+\`\`\`java
+public java.lang.String getServiceIpv4Cidr();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`CfnCluster.KubernetesNetworkConfigProperty.ServiceIpv4Cidr\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-kubernetesnetworkconfig.html#cfn-eks-cluster-kubernetesnetworkconfig-serviceipv4cidr](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-kubernetesnetworkconfig.html#cfn-eks-cluster-kubernetesnetworkconfig-serviceipv4cidr)
+
+---
+
+### KubernetesObjectValueProps <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps\\"></a>
+
+Properties for KubernetesObjectValue.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.KubernetesObjectValueProps;
+
+KubernetesObjectValueProps.builder()
+    .cluster(ICluster)
+    .jsonPath(java.lang.String)
+    .objectName(java.lang.String)
+    .objectType(java.lang.String)
+//  .objectNamespace(java.lang.String)
+//  .timeout(Duration)
+    .build();
+\`\`\`
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.cluster\\"></a>
+
+\`\`\`java
+public ICluster getCluster();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+The EKS cluster to fetch attributes from.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+##### \`jsonPath\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.jsonPath\\"></a>
+
+\`\`\`java
+public java.lang.String getJsonPath();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+JSONPath to the specific value.
+
+> https://kubernetes.io/docs/reference/kubectl/jsonpath/
+
+---
+
+##### \`objectName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.objectName\\"></a>
+
+\`\`\`java
+public java.lang.String getObjectName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The name of the object to query.
+
+---
+
+##### \`objectType\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.objectType\\"></a>
+
+\`\`\`java
+public java.lang.String getObjectType();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The object type to query.
+
+(e.g 'service', 'pod'...)
+
+---
+
+##### \`objectNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.objectNamespace\\"></a>
+
+\`\`\`java
+public java.lang.String getObjectNamespace();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* 'default'
+
+The namespace the object belongs to.
+
+---
+
+##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesObjectValueProps.property.timeout\\"></a>
+
+\`\`\`java
+public Duration getTimeout();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
+- *Default:* Duration.minutes(5)
+
+Timeout for waiting on a value.
+
+---
+
+### KubernetesPatchProps <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps\\"></a>
+
+Properties for KubernetesPatch.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.KubernetesPatchProps;
+
+KubernetesPatchProps.builder()
+    .applyPatch(java.util.Map<java.lang.String, java.lang.Object>)
+    .cluster(ICluster)
+    .resourceName(java.lang.String)
+    .restorePatch(java.util.Map<java.lang.String, java.lang.Object>)
+//  .patchType(PatchType)
+//  .resourceNamespace(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`applyPatch\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.applyPatch\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.Object> getApplyPatch();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
+
+The JSON object to pass to \`kubectl patch\` when the resource is created/updated.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.cluster\\"></a>
+
+\`\`\`java
+public ICluster getCluster();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+The cluster to apply the patch to.
+
+[disable-awslint:ref-via-interface]
+
+---
+
+##### \`resourceName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.resourceName\\"></a>
+
+\`\`\`java
+public java.lang.String getResourceName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The full name of the resource to patch (e.g. \`deployment/coredns\`).
+
+---
+
+##### \`restorePatch\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.restorePatch\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.Object> getRestorePatch();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
+
+The JSON object to pass to \`kubectl patch\` when the resource is removed.
+
+---
+
+##### \`patchType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.patchType\\"></a>
+
+\`\`\`java
+public PatchType getPatchType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.PatchType\`](#software.amazon.awscdk.services.eks.PatchType)
+- *Default:* PatchType.STRATEGIC
+
+The patch type to pass to \`kubectl patch\`.
+
+The default type used by \`kubectl patch\` is \\"strategic\\".
+
+---
+
+##### \`resourceNamespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesPatchProps.property.resourceNamespace\\"></a>
+
+\`\`\`java
+public java.lang.String getResourceNamespace();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* \\"default\\"
+
+The kubernetes API namespace.
+
+---
+
+### LabelProperty <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty\\"></a>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-label.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-label.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty;
+
+LabelProperty.builder()
+    .key(java.lang.String)
+    .value(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`key\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty.property.key\\"></a>
+
+\`\`\`java
+public java.lang.String getKey();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`CfnFargateProfile.LabelProperty.Key\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-label.html#cfn-eks-fargateprofile-label-key](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-label.html#cfn-eks-fargateprofile-label-key)
+
+---
+
+##### \`value\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty.property.value\\"></a>
+
+\`\`\`java
+public java.lang.String getValue();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`CfnFargateProfile.LabelProperty.Value\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-label.html#cfn-eks-fargateprofile-label-value](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-label.html#cfn-eks-fargateprofile-label-value)
+
+---
+
+### LaunchTemplateSpec <a name=\\"software.amazon.awscdk.services.eks.LaunchTemplateSpec\\"></a>
+
+Launch template property specification.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.LaunchTemplateSpec;
+
+LaunchTemplateSpec.builder()
+    .id(java.lang.String)
+//  .version(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.LaunchTemplateSpec.property.id\\"></a>
+
+\`\`\`java
+public java.lang.String getId();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The Launch template ID.
+
+---
+
+##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.LaunchTemplateSpec.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* the default version of the launch template
+
+The launch template version to be used (optional).
+
+---
+
+### LaunchTemplateSpecificationProperty <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty\\"></a>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty;
+
+LaunchTemplateSpecificationProperty.builder()
+//  .id(java.lang.String)
+//  .name(java.lang.String)
+//  .version(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`id\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.id\\"></a>
+
+\`\`\`java
+public java.lang.String getId();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`CfnNodegroup.LaunchTemplateSpecificationProperty.Id\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html#cfn-eks-nodegroup-launchtemplatespecification-id](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html#cfn-eks-nodegroup-launchtemplatespecification-id)
+
+---
+
+##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.name\\"></a>
+
+\`\`\`java
+public java.lang.String getName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`CfnNodegroup.LaunchTemplateSpecificationProperty.Name\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html#cfn-eks-nodegroup-launchtemplatespecification-name](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html#cfn-eks-nodegroup-launchtemplatespecification-name)
+
+---
+
+##### \`version\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.LaunchTemplateSpecificationProperty.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`CfnNodegroup.LaunchTemplateSpecificationProperty.Version\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html#cfn-eks-nodegroup-launchtemplatespecification-version](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-launchtemplatespecification.html#cfn-eks-nodegroup-launchtemplatespecification-version)
+
+---
+
+### NodegroupOptions <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions\\"></a>
+
+The Nodegroup Options for addNodeGroup() method.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.NodegroupOptions;
+
+NodegroupOptions.builder()
+//  .amiType(NodegroupAmiType)
+//  .capacityType(CapacityType)
+//  .desiredSize(java.lang.Number)
+//  .diskSize(java.lang.Number)
+//  .forceUpdate(java.lang.Boolean)
+//  .instanceType(InstanceType)
+//  .instanceTypes(java.util.List<InstanceType>)
+//  .labels(java.util.Map<java.lang.String, java.lang.String>)
+//  .launchTemplateSpec(LaunchTemplateSpec)
+//  .maxSize(java.lang.Number)
+//  .minSize(java.lang.Number)
+//  .nodegroupName(java.lang.String)
+//  .nodeRole(IRole)
+//  .releaseVersion(java.lang.String)
+//  .remoteAccess(NodegroupRemoteAccess)
+//  .subnets(SubnetSelection)
+//  .tags(java.util.Map<java.lang.String, java.lang.String>)
+    .build();
+\`\`\`
+
+##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.amiType\\"></a>
+
+\`\`\`java
+public NodegroupAmiType getAmiType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.NodegroupAmiType\`](#software.amazon.awscdk.services.eks.NodegroupAmiType)
+- *Default:* auto-determined from the instanceTypes property.
+
+The AMI type for your node group.
+
+---
+
+##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.capacityType\\"></a>
+
+\`\`\`java
+public CapacityType getCapacityType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CapacityType\`](#software.amazon.awscdk.services.eks.CapacityType)
+- *Default:* ON_DEMAND
+
+The capacity type of the nodegroup.
+
+---
+
+##### \`desiredSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.desiredSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getDesiredSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 2
+
+The current number of worker nodes that the managed node group should maintain.
+
+If not specified,
+the nodewgroup will initially create \`minSize\` instances.
+
+---
+
+##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.diskSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getDiskSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 20
+
+The root device disk size (in GiB) for your node group instances.
+
+---
+
+##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.forceUpdate\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getForceUpdate();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Force the update if the existing node group's pods are unable to be drained due to a pod disruption budget issue.
+
+If an update fails because pods could not be drained, you can force the update after it fails to terminate the old
+node whether or not any pods are
+running on the node.
+
+---
+
+##### ~~\`instanceType\`~~<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.instanceType\\"></a>
+
+- *Deprecated:* Use \`instanceTypes\` instead.
+
+\`\`\`java
+public InstanceType getInstanceType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)
+- *Default:* t3.medium
+
+The instance type to use for your node group.
+
+Currently, you can specify a single instance type for a node group.
+The default value for this parameter is \`t3.medium\`. If you choose a GPU instance type, be sure to specify the
+\`AL2_x86_64_GPU\` with the amiType parameter.
+
+---
+
+##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.instanceTypes\\"></a>
+
+\`\`\`java
+public java.util.List<InstanceType> getInstanceTypes();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)>
+- *Default:* t3.medium will be used according to the cloudformation document.
+
+The instance types to use for your node group.
+
+> - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes
+
+---
+
+##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.labels\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getLabels();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* None
+
+The Kubernetes labels to be applied to the nodes in the node group when they are created.
+
+---
+
+##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.launchTemplateSpec\\"></a>
+
+\`\`\`java
+public LaunchTemplateSpec getLaunchTemplateSpec();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.LaunchTemplateSpec\`](#software.amazon.awscdk.services.eks.LaunchTemplateSpec)
+- *Default:* no launch template
+
+Launch template specification used for the nodegroup.
+
+> - https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html
+
+---
+
+##### \`maxSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.maxSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getMaxSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* desiredSize
+
+The maximum number of worker nodes that the managed node group can scale out to.
+
+Managed node groups can support up to 100 nodes by default.
+
+---
+
+##### \`minSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.minSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getMinSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 1
+
+The minimum number of worker nodes that the managed node group can scale in to.
+
+This number must be greater than zero.
+
+---
+
+##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.nodegroupName\\"></a>
+
+\`\`\`java
+public java.lang.String getNodegroupName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* resource ID
+
+Name of the Nodegroup.
+
+---
+
+##### \`nodeRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.nodeRole\\"></a>
+
+\`\`\`java
+public IRole getNodeRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* None. Auto-generated if not specified.
+
+The IAM role to associate with your node group.
+
+The Amazon EKS worker node kubelet daemon
+makes calls to AWS APIs on your behalf. Worker nodes receive permissions for these API calls through
+an IAM instance profile and associated policies. Before you can launch worker nodes and register them
+into a cluster, you must create an IAM role for those worker nodes to use when they are launched.
+
+---
+
+##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.releaseVersion\\"></a>
+
+\`\`\`java
+public java.lang.String getReleaseVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
+
+The AMI version of the Amazon EKS-optimized AMI to use with your node group (for example, \`1.14.7-YYYYMMDD\`).
+
+---
+
+##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.remoteAccess\\"></a>
+
+\`\`\`java
+public NodegroupRemoteAccess getRemoteAccess();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.NodegroupRemoteAccess\`](#software.amazon.awscdk.services.eks.NodegroupRemoteAccess)
+- *Default:* disabled
+
+The remote access (SSH) configuration to use with your node group.
+
+Disabled by default, however, if you
+specify an Amazon EC2 SSH key but do not specify a source security group when you create a managed node group,
+then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
+
+---
+
+##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.subnets\\"></a>
+
+\`\`\`java
+public SubnetSelection getSubnets();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
+- *Default:* private subnets
+
+The subnets to use for the Auto Scaling group that is created for your node group.
+
+By specifying the
+SubnetSelection, the selected subnets will automatically apply required tags i.e.
+\`kubernetes.io/cluster/CLUSTER_NAME\` with a value of \`shared\`, where \`CLUSTER_NAME\` is replaced with
+the name of your cluster.
+
+---
+
+##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupOptions.property.tags\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getTags();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* None
+
+The metadata to apply to the node group to assist with categorization and organization.
+
+Each tag consists of
+a key and an optional value, both of which you define. Node group tags do not propagate to any other resources
+associated with the node group, such as the Amazon EC2 instances or subnets.
+
+---
+
+### NodegroupProps <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps\\"></a>
+
+NodeGroup properties interface.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.NodegroupProps;
+
+NodegroupProps.builder()
+//  .amiType(NodegroupAmiType)
+//  .capacityType(CapacityType)
+//  .desiredSize(java.lang.Number)
+//  .diskSize(java.lang.Number)
+//  .forceUpdate(java.lang.Boolean)
+//  .instanceType(InstanceType)
+//  .instanceTypes(java.util.List<InstanceType>)
+//  .labels(java.util.Map<java.lang.String, java.lang.String>)
+//  .launchTemplateSpec(LaunchTemplateSpec)
+//  .maxSize(java.lang.Number)
+//  .minSize(java.lang.Number)
+//  .nodegroupName(java.lang.String)
+//  .nodeRole(IRole)
+//  .releaseVersion(java.lang.String)
+//  .remoteAccess(NodegroupRemoteAccess)
+//  .subnets(SubnetSelection)
+//  .tags(java.util.Map<java.lang.String, java.lang.String>)
+    .cluster(ICluster)
+    .build();
+\`\`\`
+
+##### \`amiType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.amiType\\"></a>
+
+\`\`\`java
+public NodegroupAmiType getAmiType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.NodegroupAmiType\`](#software.amazon.awscdk.services.eks.NodegroupAmiType)
+- *Default:* auto-determined from the instanceTypes property.
+
+The AMI type for your node group.
+
+---
+
+##### \`capacityType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.capacityType\\"></a>
+
+\`\`\`java
+public CapacityType getCapacityType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CapacityType\`](#software.amazon.awscdk.services.eks.CapacityType)
+- *Default:* ON_DEMAND
+
+The capacity type of the nodegroup.
+
+---
+
+##### \`desiredSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.desiredSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getDesiredSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 2
+
+The current number of worker nodes that the managed node group should maintain.
+
+If not specified,
+the nodewgroup will initially create \`minSize\` instances.
+
+---
+
+##### \`diskSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.diskSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getDiskSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 20
+
+The root device disk size (in GiB) for your node group instances.
+
+---
+
+##### \`forceUpdate\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.forceUpdate\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getForceUpdate();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+- *Default:* true
+
+Force the update if the existing node group's pods are unable to be drained due to a pod disruption budget issue.
+
+If an update fails because pods could not be drained, you can force the update after it fails to terminate the old
+node whether or not any pods are
+running on the node.
+
+---
+
+##### ~~\`instanceType\`~~<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.instanceType\\"></a>
+
+- *Deprecated:* Use \`instanceTypes\` instead.
+
+\`\`\`java
+public InstanceType getInstanceType();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)
+- *Default:* t3.medium
+
+The instance type to use for your node group.
+
+Currently, you can specify a single instance type for a node group.
+The default value for this parameter is \`t3.medium\`. If you choose a GPU instance type, be sure to specify the
+\`AL2_x86_64_GPU\` with the amiType parameter.
+
+---
+
+##### \`instanceTypes\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.instanceTypes\\"></a>
+
+\`\`\`java
+public java.util.List<InstanceType> getInstanceTypes();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.InstanceType\`](#software.amazon.awscdk.services.ec2.InstanceType)>
+- *Default:* t3.medium will be used according to the cloudformation document.
+
+The instance types to use for your node group.
+
+> - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-instancetypes
+
+---
+
+##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.labels\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getLabels();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* None
+
+The Kubernetes labels to be applied to the nodes in the node group when they are created.
+
+---
+
+##### \`launchTemplateSpec\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.launchTemplateSpec\\"></a>
+
+\`\`\`java
+public LaunchTemplateSpec getLaunchTemplateSpec();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.LaunchTemplateSpec\`](#software.amazon.awscdk.services.eks.LaunchTemplateSpec)
+- *Default:* no launch template
+
+Launch template specification used for the nodegroup.
+
+> - https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html
+
+---
+
+##### \`maxSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.maxSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getMaxSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* desiredSize
+
+The maximum number of worker nodes that the managed node group can scale out to.
+
+Managed node groups can support up to 100 nodes by default.
+
+---
+
+##### \`minSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.minSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getMinSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+- *Default:* 1
+
+The minimum number of worker nodes that the managed node group can scale in to.
+
+This number must be greater than zero.
+
+---
+
+##### \`nodegroupName\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.nodegroupName\\"></a>
+
+\`\`\`java
+public java.lang.String getNodegroupName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* resource ID
+
+Name of the Nodegroup.
+
+---
+
+##### \`nodeRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.nodeRole\\"></a>
+
+\`\`\`java
+public IRole getNodeRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+- *Default:* None. Auto-generated if not specified.
+
+The IAM role to associate with your node group.
+
+The Amazon EKS worker node kubelet daemon
+makes calls to AWS APIs on your behalf. Worker nodes receive permissions for these API calls through
+an IAM instance profile and associated policies. Before you can launch worker nodes and register them
+into a cluster, you must create an IAM role for those worker nodes to use when they are launched.
+
+---
+
+##### \`releaseVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.releaseVersion\\"></a>
+
+\`\`\`java
+public java.lang.String getReleaseVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* The latest available AMI version for the node group's current Kubernetes version is used.
+
+The AMI version of the Amazon EKS-optimized AMI to use with your node group (for example, \`1.14.7-YYYYMMDD\`).
+
+---
+
+##### \`remoteAccess\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.remoteAccess\\"></a>
+
+\`\`\`java
+public NodegroupRemoteAccess getRemoteAccess();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.NodegroupRemoteAccess\`](#software.amazon.awscdk.services.eks.NodegroupRemoteAccess)
+- *Default:* disabled
+
+The remote access (SSH) configuration to use with your node group.
+
+Disabled by default, however, if you
+specify an Amazon EC2 SSH key but do not specify a source security group when you create a managed node group,
+then port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
+
+---
+
+##### \`subnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.subnets\\"></a>
+
+\`\`\`java
+public SubnetSelection getSubnets();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.SubnetSelection\`](#software.amazon.awscdk.services.ec2.SubnetSelection)
+- *Default:* private subnets
+
+The subnets to use for the Auto Scaling group that is created for your node group.
+
+By specifying the
+SubnetSelection, the selected subnets will automatically apply required tags i.e.
+\`kubernetes.io/cluster/CLUSTER_NAME\` with a value of \`shared\`, where \`CLUSTER_NAME\` is replaced with
+the name of your cluster.
+
+---
+
+##### \`tags\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.tags\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getTags();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* None
+
+The metadata to apply to the node group to assist with categorization and organization.
+
+Each tag consists of
+a key and an optional value, both of which you define. Node group tags do not propagate to any other resources
+associated with the node group, such as the Amazon EC2 instances or subnets.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupProps.property.cluster\\"></a>
+
+\`\`\`java
+public ICluster getCluster();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+Cluster resource.
+
+---
+
+### NodegroupRemoteAccess <a name=\\"software.amazon.awscdk.services.eks.NodegroupRemoteAccess\\"></a>
+
+The remote access (SSH) configuration to use with your node group.
+
+> https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.NodegroupRemoteAccess;
+
+NodegroupRemoteAccess.builder()
+    .sshKeyName(java.lang.String)
+//  .sourceSecurityGroups(java.util.List<ISecurityGroup>)
+    .build();
+\`\`\`
+
+##### \`sshKeyName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupRemoteAccess.property.sshKeyName\\"></a>
+
+\`\`\`java
+public java.lang.String getSshKeyName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The Amazon EC2 SSH key that provides access for SSH communication with the worker nodes in the managed node group.
+
+---
+
+##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.NodegroupRemoteAccess.property.sourceSecurityGroups\\"></a>
+
+\`\`\`java
+public java.util.List<ISecurityGroup> getSourceSecurityGroups();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)>
+- *Default:* port 22 on the worker nodes is opened to the internet (0.0.0.0/0)
+
+The security groups that are allowed SSH access (port 22) to the worker nodes.
+
+If you specify an Amazon EC2 SSH
+key but do not specify a source security group when you create a managed node group, then port 22 on the worker
+nodes is opened to the internet (0.0.0.0/0).
+
+---
+
+### OpenIdConnectProviderProps <a name=\\"software.amazon.awscdk.services.eks.OpenIdConnectProviderProps\\"></a>
+
+Initialization properties for \`OpenIdConnectProvider\`.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.OpenIdConnectProviderProps;
+
+OpenIdConnectProviderProps.builder()
+    .url(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`url\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.OpenIdConnectProviderProps.property.url\\"></a>
+
+\`\`\`java
+public java.lang.String getUrl();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The URL of the identity provider.
+
+The URL must begin with https:// and
+should correspond to the iss claim in the provider's OpenID Connect ID
+tokens. Per the OIDC standard, path components are allowed but query
+parameters are not. Typically the URL consists of only a hostname, like
+https://server.example.org or https://example.com.
+
+You can find your OIDC Issuer URL by:
+aws eks describe-cluster --name %cluster_name% --query \\"cluster.identity.oidc.issuer\\" --output text
+
+---
+
+### ProviderProperty <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.ProviderProperty\\"></a>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-provider.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-provider.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnCluster.ProviderProperty;
+
+ProviderProperty.builder()
+//  .keyArn(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`keyArn\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.ProviderProperty.property.keyArn\\"></a>
+
+\`\`\`java
+public java.lang.String getKeyArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`CfnCluster.ProviderProperty.KeyArn\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-provider.html#cfn-eks-cluster-provider-keyarn](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-provider.html#cfn-eks-cluster-provider-keyarn)
+
+---
+
+### RemoteAccessProperty <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty\\"></a>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty;
+
+RemoteAccessProperty.builder()
+    .ec2SshKey(java.lang.String)
+//  .sourceSecurityGroups(java.util.List<java.lang.String>)
+    .build();
+\`\`\`
+
+##### \`ec2SshKey\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty.property.ec2SshKey\\"></a>
+
+\`\`\`java
+public java.lang.String getEc2SshKey();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`CfnNodegroup.RemoteAccessProperty.Ec2SshKey\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html#cfn-eks-nodegroup-remoteaccess-ec2sshkey](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html#cfn-eks-nodegroup-remoteaccess-ec2sshkey)
+
+---
+
+##### \`sourceSecurityGroups\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.RemoteAccessProperty.property.sourceSecurityGroups\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getSourceSecurityGroups();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`CfnNodegroup.RemoteAccessProperty.SourceSecurityGroups\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html#cfn-eks-nodegroup-remoteaccess-sourcesecuritygroups](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-remoteaccess.html#cfn-eks-nodegroup-remoteaccess-sourcesecuritygroups)
+
+---
+
+### ResourcesVpcConfigProperty <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty\\"></a>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty;
+
+ResourcesVpcConfigProperty.builder()
+    .subnetIds(java.util.List<java.lang.String>)
+//  .securityGroupIds(java.util.List<java.lang.String>)
+    .build();
+\`\`\`
+
+##### \`subnetIds\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty.property.subnetIds\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getSubnetIds();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`CfnCluster.ResourcesVpcConfigProperty.SubnetIds\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html#cfn-eks-cluster-resourcesvpcconfig-subnetids](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html#cfn-eks-cluster-resourcesvpcconfig-subnetids)
+
+---
+
+##### \`securityGroupIds\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnCluster.ResourcesVpcConfigProperty.property.securityGroupIds\\"></a>
+
+\`\`\`java
+public java.util.List<java.lang.String> getSecurityGroupIds();
+\`\`\`
+
+- *Type:* java.util.List<\`java.lang.String\`>
+
+\`CfnCluster.ResourcesVpcConfigProperty.SecurityGroupIds\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html#cfn-eks-cluster-resourcesvpcconfig-securitygroupids](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-cluster-resourcesvpcconfig.html#cfn-eks-cluster-resourcesvpcconfig-securitygroupids)
+
+---
+
+### ScalingConfigProperty <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty\\"></a>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty;
+
+ScalingConfigProperty.builder()
+//  .desiredSize(java.lang.Number)
+//  .maxSize(java.lang.Number)
+//  .minSize(java.lang.Number)
+    .build();
+\`\`\`
+
+##### \`desiredSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty.property.desiredSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getDesiredSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+
+\`CfnNodegroup.ScalingConfigProperty.DesiredSize\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html#cfn-eks-nodegroup-scalingconfig-desiredsize](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html#cfn-eks-nodegroup-scalingconfig-desiredsize)
+
+---
+
+##### \`maxSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty.property.maxSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getMaxSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+
+\`CfnNodegroup.ScalingConfigProperty.MaxSize\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html#cfn-eks-nodegroup-scalingconfig-maxsize](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html#cfn-eks-nodegroup-scalingconfig-maxsize)
+
+---
+
+##### \`minSize\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.ScalingConfigProperty.property.minSize\\"></a>
+
+\`\`\`java
+public java.lang.Number getMinSize();
+\`\`\`
+
+- *Type:* \`java.lang.Number\`
+
+\`CfnNodegroup.ScalingConfigProperty.MinSize\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html#cfn-eks-nodegroup-scalingconfig-minsize](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-scalingconfig.html#cfn-eks-nodegroup-scalingconfig-minsize)
+
+---
+
+### Selector <a name=\\"software.amazon.awscdk.services.eks.Selector\\"></a>
+
+Fargate profile selector.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.Selector;
+
+Selector.builder()
+    .namespace(java.lang.String)
+//  .labels(java.util.Map<java.lang.String, java.lang.String>)
+    .build();
+\`\`\`
+
+##### \`namespace\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.Selector.property.namespace\\"></a>
+
+\`\`\`java
+public java.lang.String getNamespace();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The Kubernetes namespace that the selector should match.
+
+You must specify a namespace for a selector. The selector only matches pods
+that are created in this namespace, but you can create multiple selectors
+to target multiple namespaces.
+
+---
+
+##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.Selector.property.labels\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getLabels();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+- *Default:* all pods within the namespace will be selected.
+
+The Kubernetes labels that the selector should match.
+
+A pod must contain
+all of the labels that are specified in the selector for it to be
+considered a match.
+
+---
+
+### SelectorProperty <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty\\"></a>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-selector.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-selector.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty;
+
+SelectorProperty.builder()
+    .namespace(java.lang.String)
+//  .labels(IResolvable)
+//  .labels(java.util.List<LabelProperty)
+//  .labels(IResolvable>)
+    .build();
+\`\`\`
+
+##### \`namespace\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty.property.namespace\\"></a>
+
+\`\`\`java
+public java.lang.String getNamespace();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`CfnFargateProfile.SelectorProperty.Namespace\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-selector.html#cfn-eks-fargateprofile-selector-namespace](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-selector.html#cfn-eks-fargateprofile-selector-namespace)
+
+---
+
+##### \`labels\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnFargateProfile.SelectorProperty.property.labels\\"></a>
+
+\`\`\`java
+public java.lang.Object getLabels();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable) OR java.util.List<[\`software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty\`](#software.amazon.awscdk.services.eks.CfnFargateProfile.LabelProperty) OR [\`software.amazon.awscdk.core.IResolvable\`](#software.amazon.awscdk.core.IResolvable)>
+
+\`CfnFargateProfile.SelectorProperty.Labels\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-selector.html#cfn-eks-fargateprofile-selector-labels](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-fargateprofile-selector.html#cfn-eks-fargateprofile-selector-labels)
+
+---
+
+### ServiceAccountOptions <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountOptions\\"></a>
+
+Options for \`ServiceAccount\`.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.ServiceAccountOptions;
+
+ServiceAccountOptions.builder()
+//  .name(java.lang.String)
+//  .namespace(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountOptions.property.name\\"></a>
+
+\`\`\`java
+public java.lang.String getName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* If no name is given, it will use the id of the resource.
+
+The name of the service account.
+
+---
+
+##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountOptions.property.namespace\\"></a>
+
+\`\`\`java
+public java.lang.String getNamespace();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* \\"default\\"
+
+The namespace of the service account.
+
+---
+
+### ServiceAccountProps <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps\\"></a>
+
+Properties for defining service accounts.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.ServiceAccountProps;
+
+ServiceAccountProps.builder()
+//  .name(java.lang.String)
+//  .namespace(java.lang.String)
+    .cluster(ICluster)
+    .build();
+\`\`\`
+
+##### \`name\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps.property.name\\"></a>
+
+\`\`\`java
+public java.lang.String getName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* If no name is given, it will use the id of the resource.
+
+The name of the service account.
+
+---
+
+##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps.property.namespace\\"></a>
+
+\`\`\`java
+public java.lang.String getNamespace();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* \\"default\\"
+
+The namespace of the service account.
+
+---
+
+##### \`cluster\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceAccountProps.property.cluster\\"></a>
+
+\`\`\`java
+public ICluster getCluster();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+The cluster to apply the patch to.
+
+---
+
+### ServiceLoadBalancerAddressOptions <a name=\\"software.amazon.awscdk.services.eks.ServiceLoadBalancerAddressOptions\\"></a>
+
+Options for fetching a ServiceLoadBalancerAddress.
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.ServiceLoadBalancerAddressOptions;
+
+ServiceLoadBalancerAddressOptions.builder()
+//  .namespace(java.lang.String)
+//  .timeout(Duration)
+    .build();
+\`\`\`
+
+##### \`namespace\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceLoadBalancerAddressOptions.property.namespace\\"></a>
+
+\`\`\`java
+public java.lang.String getNamespace();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+- *Default:* 'default'
+
+The namespace the service belongs to.
+
+---
+
+##### \`timeout\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ServiceLoadBalancerAddressOptions.property.timeout\\"></a>
+
+\`\`\`java
+public Duration getTimeout();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Duration\`](#software.amazon.awscdk.core.Duration)
+- *Default:* Duration.minutes(5)
+
+Timeout for waiting on the load balancer address.
+
+---
+
+### TaintProperty <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty\\"></a>
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html)
+
+#### Initializer <a name=\\"[object Object].Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty;
+
+TaintProperty.builder()
+//  .effect(java.lang.String)
+//  .key(java.lang.String)
+//  .value(java.lang.String)
+    .build();
+\`\`\`
+
+##### \`effect\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty.property.effect\\"></a>
+
+\`\`\`java
+public java.lang.String getEffect();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`CfnNodegroup.TaintProperty.Effect\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html#cfn-eks-nodegroup-taint-effect](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html#cfn-eks-nodegroup-taint-effect)
+
+---
+
+##### \`key\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty.property.key\\"></a>
+
+\`\`\`java
+public java.lang.String getKey();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`CfnNodegroup.TaintProperty.Key\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html#cfn-eks-nodegroup-taint-key](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html#cfn-eks-nodegroup-taint-key)
+
+---
+
+##### \`value\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.CfnNodegroup.TaintProperty.property.value\\"></a>
+
+\`\`\`java
+public java.lang.String getValue();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+\`CfnNodegroup.TaintProperty.Value\`.
+
+> [http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html#cfn-eks-nodegroup-taint-value](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-eks-nodegroup-taint.html#cfn-eks-nodegroup-taint-value)
+
+---
+
+## Classes <a name=\\"Classes\\"></a>
+
+### EksOptimizedImage <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImage\\"></a>
+
+- *Implements:* [\`software.amazon.awscdk.services.ec2.IMachineImage\`](#software.amazon.awscdk.services.ec2.IMachineImage)
+
+Construct an Amazon Linux 2 image from the latest EKS Optimized AMI published in SSM.
+
+#### Initializers <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImage.Initializer\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.EksOptimizedImage;
+
+EksOptimizedImage.Builder.create()
+//  .cpuArch(CpuArch)
+//  .kubernetesVersion(java.lang.String)
+//  .nodeType(NodeType)
+    .build();
+\`\`\`
+
+##### \`cpuArch\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps.parameter.cpuArch\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.CpuArch\`](#software.amazon.awscdk.services.eks.CpuArch)
+- *Default:* CpuArch.X86_64
+
+What cpu architecture to retrieve the image for (arm64 or x86_64).
+
+---
+
+##### \`kubernetesVersion\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps.parameter.kubernetesVersion\\"></a>
+
+- *Type:* \`java.lang.String\`
+- *Default:* The latest version
+
+The Kubernetes version to use.
+
+---
+
+##### \`nodeType\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImageProps.parameter.nodeType\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.NodeType\`](#software.amazon.awscdk.services.eks.NodeType)
+- *Default:* NodeType.STANDARD
+
+What instance type to retrieve the image for (standard or GPU-optimized).
+
+---
+
+#### Methods <a name=\\"Methods\\"></a>
+
+##### \`getImage\` <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImage.getImage\\"></a>
+
+\`\`\`java
+public getImage(Construct scope)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.EksOptimizedImage.parameter.scope\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.core.Construct\`](#software.amazon.awscdk.core.Construct)
+
+---
+
+
+
+
+### EndpointAccess <a name=\\"software.amazon.awscdk.services.eks.EndpointAccess\\"></a>
+
+Endpoint access characteristics.
+
+#### Methods <a name=\\"Methods\\"></a>
+
+##### \`onlyFrom\` <a name=\\"software.amazon.awscdk.services.eks.EndpointAccess.onlyFrom\\"></a>
+
+\`\`\`java
+public onlyFrom(java.lang.String cidr)
+\`\`\`
+
+###### \`cidr\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.EndpointAccess.parameter.cidr\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+CIDR blocks.
+
+---
+
+
+
+#### Constants <a name=\\"Constants\\"></a>
+
+##### \`PRIVATE\` <a name=\\"software.amazon.awscdk.services.eks.EndpointAccess.property.PRIVATE\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
+
+The cluster endpoint is only accessible through your VPC.
+
+Worker node traffic to the endpoint will stay within your VPC.
+
+---
+
+##### \`PUBLIC\` <a name=\\"software.amazon.awscdk.services.eks.EndpointAccess.property.PUBLIC\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
+
+The cluster endpoint is accessible from outside of your VPC.
+
+Worker node traffic will leave your VPC to connect to the endpoint.
+
+By default, the endpoint is exposed to all adresses. You can optionally limit the CIDR blocks that can access the public endpoint using the \`PUBLIC.onlyFrom\` method.
+If you limit access to specific CIDR blocks, you must ensure that the CIDR blocks that you
+specify include the addresses that worker nodes and Fargate pods (if you use them)
+access the public endpoint from.
+
+---
+
+##### \`PUBLIC_AND_PRIVATE\` <a name=\\"software.amazon.awscdk.services.eks.EndpointAccess.property.PUBLIC_AND_PRIVATE\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.EndpointAccess\`](#software.amazon.awscdk.services.eks.EndpointAccess)
+
+The cluster endpoint is accessible from outside of your VPC.
+
+Worker node traffic to the endpoint will stay within your VPC.
+
+By default, the endpoint is exposed to all adresses. You can optionally limit the CIDR blocks that can access the public endpoint using the \`PUBLIC_AND_PRIVATE.onlyFrom\` method.
+If you limit access to specific CIDR blocks, you must ensure that the CIDR blocks that you
+specify include the addresses that worker nodes and Fargate pods (if you use them)
+access the public endpoint from.
+
+---
+
+### KubernetesVersion <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion\\"></a>
+
+Kubernetes cluster version.
+
+
+#### Static Functions <a name=\\"Static Functions\\"></a>
+
+##### \`of\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.of\\"></a>
+
+\`\`\`java
+import software.amazon.awscdk.services.eks.KubernetesVersion;
+
+KubernetesVersion.of(java.lang.String version)
+\`\`\`
+
+###### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.parameter.version\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+custom version number.
+
+---
+
+#### Properties <a name=\\"Properties\\"></a>
+
+##### \`version\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.version\\"></a>
+
+\`\`\`java
+public java.lang.String getVersion();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+cluster version number.
+
+---
+
+#### Constants <a name=\\"Constants\\"></a>
+
+##### \`V1_14\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_14\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
+
+Kubernetes version 1.14.
+
+---
+
+##### \`V1_15\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_15\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
+
+Kubernetes version 1.15.
+
+---
+
+##### \`V1_16\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_16\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
+
+Kubernetes version 1.16.
+
+---
+
+##### \`V1_17\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_17\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
+
+Kubernetes version 1.17.
+
+---
+
+##### \`V1_18\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_18\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
+
+Kubernetes version 1.18.
+
+---
+
+##### \`V1_19\` <a name=\\"software.amazon.awscdk.services.eks.KubernetesVersion.property.V1_19\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.KubernetesVersion\`](#software.amazon.awscdk.services.eks.KubernetesVersion)
+
+Kubernetes version 1.19.
+
+---
+
+## Protocols <a name=\\"Protocols\\"></a>
+
+### ICluster <a name=\\"software.amazon.awscdk.services.eks.ICluster\\"></a>
+
+- *Extends:* [\`software.amazon.awscdk.core.IResource\`](#software.amazon.awscdk.core.IResource), [\`software.amazon.awscdk.services.ec2.IConnectable\`](#software.amazon.awscdk.services.ec2.IConnectable)
+
+- *Implemented By:* [\`software.amazon.awscdk.services.eks.Cluster\`](#software.amazon.awscdk.services.eks.Cluster), [\`software.amazon.awscdk.services.eks.FargateCluster\`](#software.amazon.awscdk.services.eks.FargateCluster), [\`software.amazon.awscdk.services.eks.ICluster\`](#software.amazon.awscdk.services.eks.ICluster)
+
+An EKS cluster.
+
+#### Methods <a name=\\"Methods\\"></a>
+
+##### \`addCdk8sChart\` <a name=\\"software.amazon.awscdk.services.eks.ICluster.addCdk8sChart\\"></a>
+
+\`\`\`java
+public addCdk8sChart(java.lang.String id, Construct chart)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+logical id of this chart.
+
+---
+
+###### \`chart\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.parameter.chart\\"></a>
+
+- *Type:* [\`software.constructs.Construct\`](#software.constructs.Construct)
+
+the cdk8s chart.
+
+---
+
+##### \`addHelmChart\` <a name=\\"software.amazon.awscdk.services.eks.ICluster.addHelmChart\\"></a>
+
+\`\`\`java
+public addHelmChart(java.lang.String id, HelmChartOptions options)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+logical id of this chart.
+
+---
+
+###### \`options\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.parameter.options\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.HelmChartOptions\`](#software.amazon.awscdk.services.eks.HelmChartOptions)
+
+options of this chart.
+
+---
+
+##### \`addManifest\` <a name=\\"software.amazon.awscdk.services.eks.ICluster.addManifest\\"></a>
+
+\`\`\`java
+public addManifest(java.lang.String id, java.util.Map<java.lang.String, java.lang.Object> manifest)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+logical id of this manifest.
+
+---
+
+###### \`manifest\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.parameter.manifest\\"></a>
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.Object\`>
+
+a list of Kubernetes resource specifications.
+
+---
+
+##### \`addServiceAccount\` <a name=\\"software.amazon.awscdk.services.eks.ICluster.addServiceAccount\\"></a>
+
+\`\`\`java
+public addServiceAccount(java.lang.String id)
+public addServiceAccount(java.lang.String id, ServiceAccountOptions options)
+\`\`\`
+
+###### \`id\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.parameter.id\\"></a>
+
+- *Type:* \`java.lang.String\`
+
+logical id of service account.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.parameter.options\\"></a>
+
+- *Type:* [\`software.amazon.awscdk.services.eks.ServiceAccountOptions\`](#software.amazon.awscdk.services.eks.ServiceAccountOptions)
+
+service account options.
+
+---
+
+#### Properties <a name=\\"Properties\\"></a>
+
+##### \`node\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.node\\"></a>
+
+\`\`\`java
+public ConstructNode getNode();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.ConstructNode\`](#software.amazon.awscdk.core.ConstructNode)
+
+The construct tree node for this construct.
+
+---
+
+##### \`env\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.env\\"></a>
+
+\`\`\`java
+public ResourceEnvironment getEnv();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.ResourceEnvironment\`](#software.amazon.awscdk.core.ResourceEnvironment)
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### \`stack\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.stack\\"></a>
+
+\`\`\`java
+public Stack getStack();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Stack\`](#software.amazon.awscdk.core.Stack)
+
+The stack in which this resource is defined.
+
+---
+
+##### \`connections\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.connections\\"></a>
+
+\`\`\`java
+public Connections getConnections();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.Connections\`](#software.amazon.awscdk.services.ec2.Connections)
+
+---
+
+##### \`clusterArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterArn\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The unique ARN assigned to the service by AWS in the form of arn:aws:eks:.
+
+---
+
+##### \`clusterCertificateAuthorityData\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterCertificateAuthorityData\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterCertificateAuthorityData();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The certificate-authority-data for your cluster.
+
+---
+
+##### \`clusterEncryptionConfigKeyArn\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterEncryptionConfigKeyArn\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterEncryptionConfigKeyArn();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+Amazon Resource Name (ARN) or alias of the customer master key (CMK).
+
+---
+
+##### \`clusterEndpoint\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterEndpoint\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterEndpoint();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The API Server endpoint URL.
+
+---
+
+##### \`clusterName\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterName\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterName();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The physical name of the Cluster.
+
+---
+
+##### \`clusterSecurityGroup\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterSecurityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getClusterSecurityGroup();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
+
+The cluster security group that was created by Amazon EKS for the cluster.
+
+---
+
+##### \`clusterSecurityGroupId\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.clusterSecurityGroupId\\"></a>
+
+\`\`\`java
+public java.lang.String getClusterSecurityGroupId();
+\`\`\`
+
+- *Type:* \`java.lang.String\`
+
+The id of the cluster security group that was created by Amazon EKS for the cluster.
+
+---
+
+##### \`openIdConnectProvider\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.openIdConnectProvider\\"></a>
+
+\`\`\`java
+public IOpenIdConnectProvider getOpenIdConnectProvider();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IOpenIdConnectProvider\`](#software.amazon.awscdk.services.iam.IOpenIdConnectProvider)
+
+The Open ID Connect Provider of the cluster used to configure Service Accounts.
+
+---
+
+##### \`prune\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.prune\\"></a>
+
+\`\`\`java
+public java.lang.Boolean getPrune();
+\`\`\`
+
+- *Type:* \`java.lang.Boolean\`
+
+Indicates whether Kubernetes resources can be automatically pruned.
+
+When
+this is enabled (default), prune labels will be allocated and injected to
+each resource. These labels will then be used when issuing the \`kubectl
+apply\` operation with the \`--prune\` switch.
+
+---
+
+##### \`vpc\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.vpc\\"></a>
+
+\`\`\`java
+public IVpc getVpc();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.IVpc\`](#software.amazon.awscdk.services.ec2.IVpc)
+
+The VPC in which this Cluster was created.
+
+---
+
+##### \`kubectlEnvironment\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlEnvironment\\"></a>
+
+\`\`\`java
+public java.util.Map<java.lang.String, java.lang.String> getKubectlEnvironment();
+\`\`\`
+
+- *Type:* java.util.Map<java.lang.String, \`java.lang.String\`>
+
+Custom environment variables when running \`kubectl\` against this cluster.
+
+---
+
+##### \`kubectlLayer\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlLayer\\"></a>
+
+\`\`\`java
+public ILayerVersion getKubectlLayer();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.lambda.ILayerVersion\`](#software.amazon.awscdk.services.lambda.ILayerVersion)
+
+An AWS Lambda layer that includes \`kubectl\`, \`helm\` and the \`aws\` CLI.
+
+If not defined, a default layer will be used.
+
+---
+
+##### \`kubectlMemory\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlMemory\\"></a>
+
+\`\`\`java
+public Size getKubectlMemory();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Size\`](#software.amazon.awscdk.core.Size)
+
+Amount of memory to allocate to the provider's lambda function.
+
+---
+
+##### \`kubectlPrivateSubnets\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlPrivateSubnets\\"></a>
+
+\`\`\`java
+public java.util.List<ISubnet> getKubectlPrivateSubnets();
+\`\`\`
+
+- *Type:* java.util.List<[\`software.amazon.awscdk.services.ec2.ISubnet\`](#software.amazon.awscdk.services.ec2.ISubnet)>
+
+Subnets to host the \`kubectl\` compute resources.
+
+If this is undefined, the k8s endpoint is expected to be accessible
+publicly.
+
+---
+
+##### \`kubectlRole\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlRole\\"></a>
+
+\`\`\`java
+public IRole getKubectlRole();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.iam.IRole\`](#software.amazon.awscdk.services.iam.IRole)
+
+An IAM role that can perform kubectl operations against this cluster.
+
+The role should be mapped to the \`system:masters\` Kubernetes RBAC role.
+
+---
+
+##### \`kubectlSecurityGroup\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.eks.ICluster.property.kubectlSecurityGroup\\"></a>
+
+\`\`\`java
+public ISecurityGroup getKubectlSecurityGroup();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.services.ec2.ISecurityGroup\`](#software.amazon.awscdk.services.ec2.ISecurityGroup)
+
+A security group to use for \`kubectl\` execution.
+
+If this is undefined, the k8s endpoint is expected to be accessible
+publicly.
+
+---
+
+### INodegroup <a name=\\"software.amazon.awscdk.services.eks.INodegroup\\"></a>
+
+- *Extends:* [\`software.amazon.awscdk.core.IResource\`](#software.amazon.awscdk.core.IResource)
+
+- *Implemented By:* [\`software.amazon.awscdk.services.eks.Nodegroup\`](#software.amazon.awscdk.services.eks.Nodegroup), [\`software.amazon.awscdk.services.eks.INodegroup\`](#software.amazon.awscdk.services.eks.INodegroup)
+
+NodeGroup interface.
+
+
+#### Properties <a name=\\"Properties\\"></a>
+
+##### \`node\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.INodegroup.property.node\\"></a>
+
+\`\`\`java
+public ConstructNode getNode();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.ConstructNode\`](#software.amazon.awscdk.core.ConstructNode)
+
+The construct tree node for this construct.
+
+---
+
+##### \`env\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.INodegroup.property.env\\"></a>
+
+\`\`\`java
+public ResourceEnvironment getEnv();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.ResourceEnvironment\`](#software.amazon.awscdk.core.ResourceEnvironment)
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### \`stack\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.eks.INodegroup.property.stack\\"></a>
+
+\`\`\`java
+public Stack getStack();
+\`\`\`
+
+- *Type:* [\`software.amazon.awscdk.core.Stack\`](#software.amazon.awscdk.core.Stack)
 
 The stack in which this resource is defined.
 

--- a/test/docgen/view/documentation.test.ts
+++ b/test/docgen/view/documentation.test.ts
@@ -135,4 +135,12 @@ describe('java', () => {
     const markdown = docs.render({ submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
   });
+
+  test('snapshot - submodules 2', async () => {
+    const docs = await Documentation.forAssembly('monocdk', ASSEMBLIES, {
+      language: Language.JAVA,
+    });
+    const markdown = docs.render({ submodule: 'aws_eks' });
+    expect(markdown.render()).toMatchSnapshot();
+  });
 });

--- a/test/docgen/view/documentation.test.ts
+++ b/test/docgen/view/documentation.test.ts
@@ -10,7 +10,7 @@ const LIBRARIES = `${__dirname}/../../__fixtures__/libraries`;
 
 // this is a little concerning...we should be mindful
 // if need to keep increasing this.
-jest.setTimeout(60 * 1000);
+jest.setTimeout(120 * 1000);
 
 
 describe('extractPackageName', () => {


### PR DESCRIPTION
Fixes #442

jsii-docgen's Java transpiler falsely assumed that package names for submodules were always "prefixed" by their parent module's package name. While this happens to be the case for many packages, such as aws-cdk-lib, it is not the case for others, such as monocdk:

```
aws-cdk-lib
parent module: software.amazon.awscdk
child modules: software.amazon.awscdk.services.ecr

monocdk
parent module: software.amazon.awscdk.core
child modules: software.amazon.awscdk.services.ecr
```

This caused the monocdk docs to not be generated. To fix this I pulled out the abstract method "type" to the individual transpiler classes since there isn't enough shared functionality to merit keeping it in the superclass. I added a snapshot test for generating Java docs on monocdk to prevent regressions.

I also fixed a bug where static function code examples for submodules were not being generated correctly.