### PR TITLE
chore: also lift up NPM error codes (numeric)

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -63,7 +63,7 @@ export class NpmError extends Error {
 
     this.name = `${name}.${this.constructor.name}`;
 
-    const ERROR_CODE_REGEX = /^npm\s+ERR!\s+(?:code|errno)\s+(E[^\s]+)$/gm;
+    const ERROR_CODE_REGEX = /^npm\s+ERR!\s+(?:code|errno)\s+(E[^\s]+|\d+)$/gm;
     for (const output of [this.stderr, this.stdout]) {
       const [, match] = ERROR_CODE_REGEX.exec(output) ?? [];
       if (match) {


### PR DESCRIPTION
Make it possible to categorize the following kind of error based on the
error name, too:

```
npm ERR! code 128
npm ERR! A git connection error occurred
npm ERR! command git --no-replace-objects ls-remote ssh://git@github.com/xmldom/xmldom.git
npm ERR! ssh: connect to host github.com port 22: Connection timed out
npm ERR! fatal: Could not read from remote repository.
npm ERR!
npm ERR! Please make sure you have the correct access rights
npm ERR! and the repository exists.
npm ERR! A complete log of this run can be found in:
npm ERR!     /tmp/fake-home1LnNHz/.npm/_logs/2021-10-14T12_10_10_986Z-debug.log
```

This will happen when attempting to install a GitHub dependency from a
network-isolated environment (no access to GitHub), and cannot be
recovered from in this particular case.
