### PR TITLE
feat: add `toJson` method to `Documentation`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,14 +8,18 @@ export async function main() {
     .usage('Usage: $0')
     .option('output', { type: 'string', alias: 'o', required: false, desc: 'Output filename (defaults to API.md)' })
     .option('language', { alias: 'l', default: 'typescript', choices: Language.values().map(x => x.toString()), desc: 'Output language' })
+    .option('format', { alias: 'f', default: 'md', choices: ['md', 'json'], desc: 'Output format, markdown or json' })
     .example('$0', 'Generate documentation for the current module as a single file (auto-resolves node depedencies)')
     .argv;
 
   const language = Language.fromString(args.language);
   const docs = await Documentation.forProject(process.cwd(), { language });
-  const output = args.output ?? 'API.md';
-  const markdown = docs.render({ readme: false });
-  fs.writeFileSync(output, markdown.render());
+
+  const options = { readme: false };
+  const fileSuffix = args.format === 'md' ? 'md' : 'json';
+  const output = args.output ?? `API.${fileSuffix}`;
+  const content = args.format === 'md' ? docs.toMarkdown(options) : docs.toJson(options);
+  fs.writeFileSync(output, content.render());
 }
 
 main().catch(e => {

--- a/src/docgen/render/index.ts
+++ b/src/docgen/render/index.ts
@@ -1,0 +1,2 @@
+export * from './json';
+export * from './markdown';

--- a/src/docgen/render/json.ts
+++ b/src/docgen/render/json.ts
@@ -1,0 +1,10 @@
+/**
+ * Type-safe Json renderer.
+ */
+export class Json<T> {
+  constructor(private readonly content: T) {};
+
+  public render(): string {
+    return JSON.stringify(this.content, null, 2);
+  }
+}

--- a/src/docgen/schema.ts
+++ b/src/docgen/schema.ts
@@ -1,0 +1,335 @@
+/**
+ * Describes a type.
+ */
+export interface TypeSchema {
+
+  /**
+   * The type FQN. If missing, the type is a reference (array, map..)
+   */
+  readonly fqn?: string;
+
+  /**
+   * The name of the type (Map, List...)
+   */
+  readonly name: string;
+
+  /**
+   * The various types of the reference.
+   */
+  readonly types?: TypeSchema[];
+}
+
+/**
+ * Describes a property.
+ */
+export interface PropertySchema {
+
+  /**
+   * Unique id of the property.
+   */
+  readonly id: string;
+
+  /**
+   * Name.
+   */
+  readonly name: string;
+
+  /**
+   * Whether or not the property is optional.
+   */
+  readonly optional: boolean;
+
+  /**
+   * Whether or not the property is deprecated.
+   */
+  readonly deprecated: boolean;
+
+  /**
+   * Deprecation reason (if applicable)
+   */
+  readonly deprecationReason?: string;
+
+  /**
+   * Doc strings of the property.
+   */
+  readonly docs: string;
+
+  /**
+   * The type of the property.
+   */
+  readonly type: TypeSchema;
+
+  /**
+   * The default value of the property
+   */
+  readonly default?: string;
+}
+
+/**
+ * Describes a parameter.
+ */
+export interface ParameterSchema extends PropertySchema {}
+
+/**
+ * Common properties of a method.
+ */
+export interface MethodSchemaBase {
+
+  /**
+   * Unique id of the method.
+   */
+  readonly id: string;
+
+  /**
+   * Code snippet to display.
+   */
+  readonly snippet: string;
+
+  /**
+   * Method parameters.
+   */
+  readonly parameters: ParameterSchema[];
+}
+
+/**
+ * Describes a constructor.
+ */
+export interface InitializerSchema extends MethodSchemaBase {}
+
+/**
+ * Describes a method.
+ */
+export interface MethodSchema extends MethodSchemaBase {
+
+  /**
+   * Method name.
+   */
+  readonly name: string;
+}
+
+/**
+ * Describes a class.
+ */
+export interface ClassSchema {
+
+  /**
+   * Unique class id.
+   */
+  readonly id: string;
+
+  /**
+   * Class name.
+   */
+  readonly name: string;
+
+  /**
+   * Interfaces this class implements.
+   */
+  readonly interfaces: TypeSchema[];
+
+  /**
+   * Doc string for the class.
+   */
+  readonly docs: string;
+
+  /**
+   * Class initializer.
+   */
+  readonly initializer?: InitializerSchema;
+
+  /**
+   * Instance methods.
+   */
+  readonly instanceMethods: MethodSchema[];
+
+  /**
+   * Static functions.
+   */
+  readonly staticFunctions: MethodSchema[];
+
+  /**
+   * Properties.
+   */
+  readonly properties: PropertySchema[];
+
+  /**
+   * Constants.
+   */
+  readonly constants: PropertySchema[];
+}
+
+/**
+ * Describes a construct.
+ */
+export interface ConstructSchema extends ClassSchema {}
+
+/**
+ * Describes a struct.
+ */
+export interface StructSchema {
+
+  /**
+   * Unique struct id.
+   */
+  readonly id: string;
+
+  /**
+   * Struct name.
+   */
+  readonly name: string;
+
+  /**
+   * Doc string of the struct.
+   */
+  readonly docs?: string;
+
+  /**
+   * How to initialize the struct.
+   */
+  readonly initializer: string;
+
+  /**
+   * Properties.
+   */
+  readonly properties: PropertySchema[];
+}
+
+/**
+ * Describes an interface.
+ */
+export interface InterfaceSchema {
+
+  /**
+   * Unique interface id.
+   */
+  readonly id: string;
+
+  /**
+   * Interface name.
+   */
+  readonly name: string;
+
+  /**
+   * Interfaces that this interface extends.
+   */
+  readonly interfaces: TypeSchema[];
+
+  /**
+   * Types implementing this interface.
+   */
+  readonly implementations: TypeSchema[];
+
+  /**
+   * Doc string for this interface.
+   */
+  readonly docs: string;
+
+  /**
+   * Methods.
+   */
+  readonly instanceMethods: MethodSchema[];
+
+  /**
+   * Properties.
+   */
+  readonly properties: PropertySchema[];
+}
+
+/**
+ * Describes an enum member.
+ */
+export interface EnumMemberSchema {
+
+  /**
+   * Unique enum member id.
+   */
+  readonly id: string;
+
+  /**
+   * Member name.
+   */
+  readonly name: string;
+
+  /**
+   * Whether or not the member is deprecated.
+   */
+  readonly deprecated: boolean;
+
+  /**
+   * Deprecation reason (if applicable).
+   */
+  readonly deprecationReason?: string;
+
+  /**
+   * Doc string of the member.
+   */
+  readonly docs: string;
+}
+
+/**
+ * Describes an enum.
+ */
+export interface EnumSchema {
+
+  /**
+   * Enum name.
+   */
+  readonly name: string;
+
+  /**
+   * Doc string for the enum.
+   */
+  readonly docs: string;
+
+  /**
+   * Enum members.
+   */
+  readonly members: EnumMemberSchema[];
+}
+
+/**
+ * Describes the Api Reference.
+ */
+export interface ApiReferenceSchema {
+
+  /**
+   * Constructs.
+   */
+  readonly constructs: ConstructSchema[];
+
+  /**
+   * Classes.
+   */
+  readonly classes: ClassSchema[];
+
+  /**
+   * Structs.
+   */
+  readonly structs: StructSchema[];
+
+  /**
+   * Interfaces.
+   */
+  readonly interfaces: InterfaceSchema[];
+
+  /**
+   * Enums.
+   */
+  readonly enums: EnumSchema[];
+}
+
+/**
+ * Describes the schema.
+ */
+export interface Schema {
+
+  /**
+   * Readme.
+   */
+  readonly readme?: string;
+
+  /**
+   * Api Reference.
+   */
+  readonly apiReference?: ApiReferenceSchema;
+}

--- a/src/docgen/transpile/transpile.ts
+++ b/src/docgen/transpile/transpile.ts
@@ -1,4 +1,5 @@
 import * as reflect from 'jsii-reflect';
+import { TypeSchema } from '../schema';
 
 /**
  * Supported languages to generate documentation in.
@@ -376,6 +377,49 @@ export class TranspiledTypeReference {
       const refs = this.unionOfTypes.map((t) => t.toString(options));
       return this.transpile.unionOf(refs);
     }
+    throw new Error(`Invalid type reference: ${this.ref.toString()}`);
+  }
+
+  public toJson(): TypeSchema {
+    if (this.primitive) {
+      return {
+        name: this.primitive,
+      };
+    }
+
+    if (this.type) {
+      return {
+        fqn: this.ref.fqn,
+        name: this.type.fqn,
+      };
+    }
+
+    if (this.isAny) {
+      return {
+        name: this.transpile.any(),
+      };
+    }
+
+    if (this.arrayOfType) {
+      return {
+        name: this.transpile.listOf('%'),
+        types: [this.arrayOfType.toJson()],
+      };
+    }
+    if (this.mapOfType) {
+      return {
+        name: this.transpile.mapOf('%'),
+        types: [this.mapOfType.toJson()],
+      };
+    }
+    if (this.unionOfTypes) {
+      const inner = [...Array(this.unionOfTypes.length)].map(() => '%');
+      return {
+        name: this.transpile.unionOf(inner),
+        types: this.unionOfTypes.map((t) => t.toJson()),
+      };
+    }
+
     throw new Error(`Invalid type reference: ${this.ref.toString()}`);
   }
 }

--- a/src/docgen/view/api-reference.ts
+++ b/src/docgen/view/api-reference.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { ApiReferenceSchema } from '../schema';
 import { Transpile, TranspiledType } from '../transpile/transpile';
 import { Classes } from './classes';
 import { Constructs } from './constructs';
@@ -40,14 +41,24 @@ export class ApiReference {
   /**
    * Generate markdown.
    */
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     const md = new Markdown({ header: { title: 'API Reference' } });
-    md.section(this.constructs.render());
-    md.section(this.structs.render());
-    md.section(this.classes.render());
-    md.section(this.interfaces.render());
-    md.section(this.enums.render());
+    md.section(this.constructs.toMarkdown());
+    md.section(this.structs.toMarkdown());
+    md.section(this.classes.toMarkdown());
+    md.section(this.interfaces.toMarkdown());
+    md.section(this.enums.toMarkdown());
     return md;
+  }
+
+  public toJson(): ApiReferenceSchema {
+    return {
+      constructs: this.constructs.toJson(),
+      classes: this.classes.toJson(),
+      structs: this.structs.toJson(),
+      interfaces: this.interfaces.toJson(),
+      enums: this.enums.toJson(),
+    };
   }
 
   private sortByName<Type extends reflect.Type>(arr: readonly Type[]): Type[] {

--- a/src/docgen/view/api-reference.ts
+++ b/src/docgen/view/api-reference.ts
@@ -20,7 +20,6 @@ export class ApiReference {
   constructor(
     transpile: Transpile,
     assembly: reflect.Assembly,
-    linkFormatter: (type: TranspiledType) => string,
     submodule?: reflect.Submodule,
   ) {
     const classes = this.sortByName(
@@ -31,22 +30,24 @@ export class ApiReference {
     );
     const enums = this.sortByName(submodule ? submodule.enums : assembly.enums);
 
-    this.constructs = new Constructs(transpile, classes, linkFormatter);
-    this.classes = new Classes(transpile, classes, linkFormatter);
-    this.structs = new Structs(transpile, interfaces, linkFormatter);
-    this.interfaces = new Interfaces(transpile, interfaces, linkFormatter);
+    this.constructs = new Constructs(transpile, classes);
+    this.classes = new Classes(transpile, classes);
+    this.structs = new Structs(transpile, interfaces);
+    this.interfaces = new Interfaces(transpile, interfaces);
     this.enums = new Enums(transpile, enums);
   }
 
   /**
    * Generate markdown.
    */
-  public toMarkdown(): Markdown {
+  public toMarkdown(
+    linkFormatter: (type: TranspiledType) => string,
+  ): Markdown {
     const md = new Markdown({ header: { title: 'API Reference' } });
-    md.section(this.constructs.toMarkdown());
-    md.section(this.structs.toMarkdown());
-    md.section(this.classes.toMarkdown());
-    md.section(this.interfaces.toMarkdown());
+    md.section(this.constructs.toMarkdown(linkFormatter));
+    md.section(this.structs.toMarkdown(linkFormatter));
+    md.section(this.classes.toMarkdown(linkFormatter));
+    md.section(this.interfaces.toMarkdown(linkFormatter));
     md.section(this.enums.toMarkdown());
     return md;
   }

--- a/src/docgen/view/class.ts
+++ b/src/docgen/view/class.ts
@@ -32,19 +32,18 @@ export class Class {
   constructor(
     private readonly transpile: Transpile,
     private readonly klass: reflect.ClassType,
-    private readonly linkFormatter: (type: TranspiledType) => string,
   ) {
     if (klass.initializer) {
-      this.initializer = new Initializer(transpile, klass.initializer, linkFormatter);
+      this.initializer = new Initializer(transpile, klass.initializer);
     }
-    this.instanceMethods = new InstanceMethods(transpile, klass.ownMethods, linkFormatter);
-    this.staticFunctions = new StaticFunctions(transpile, klass.ownMethods, linkFormatter);
-    this.constants = new Constants(transpile, klass.ownProperties, linkFormatter);
-    this.properties = new Properties(transpile, klass.ownProperties, linkFormatter);
+    this.instanceMethods = new InstanceMethods(transpile, klass.ownMethods);
+    this.staticFunctions = new StaticFunctions(transpile, klass.ownMethods);
+    this.constants = new Constants(transpile, klass.ownProperties);
+    this.properties = new Properties(transpile, klass.ownProperties);
     this.transpiled = transpile.class(klass);
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     const md = new Markdown({
       id: this.transpiled.type.fqn,
       header: { title: this.transpiled.name },
@@ -54,7 +53,7 @@ export class Class {
       const ifaces = [];
       for (const iface of this.klass.interfaces) {
         const transpiled = this.transpile.type(iface);
-        ifaces.push(`[${Markdown.pre(transpiled.fqn)}](${this.linkFormatter(transpiled)})`);
+        ifaces.push(`[${Markdown.pre(transpiled.fqn)}](${linkFormatter(transpiled)})`);
       }
       md.bullet(`${Markdown.italic('Implements:')} ${ifaces.join(', ')}`);
       md.lines('');
@@ -65,12 +64,12 @@ export class Class {
     }
 
     if (this.initializer) {
-      md.section(this.initializer.toMarkdown());
+      md.section(this.initializer.toMarkdown(linkFormatter));
     }
-    md.section(this.instanceMethods.toMarkdown());
-    md.section(this.staticFunctions.toMarkdown());
-    md.section(this.properties.toMarkdown());
-    md.section(this.constants.toMarkdown());
+    md.section(this.instanceMethods.toMarkdown(linkFormatter));
+    md.section(this.staticFunctions.toMarkdown(linkFormatter));
+    md.section(this.properties.toMarkdown(linkFormatter));
+    md.section(this.constants.toMarkdown(linkFormatter));
     return md;
   }
 

--- a/src/docgen/view/class.ts
+++ b/src/docgen/view/class.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { ClassSchema } from '../schema';
 import { Transpile, TranspiledClass, TranspiledType } from '../transpile/transpile';
 import { Constants } from './constants';
 import { Initializer } from './initializer';
@@ -43,7 +44,7 @@ export class Class {
     this.transpiled = transpile.class(klass);
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     const md = new Markdown({
       id: this.transpiled.type.fqn,
       header: { title: this.transpiled.name },
@@ -64,12 +65,32 @@ export class Class {
     }
 
     if (this.initializer) {
-      md.section(this.initializer.render());
+      md.section(this.initializer.toMarkdown());
     }
-    md.section(this.instanceMethods.render());
-    md.section(this.staticFunctions.render());
-    md.section(this.properties.render());
-    md.section(this.constants.render());
+    md.section(this.instanceMethods.toMarkdown());
+    md.section(this.staticFunctions.toMarkdown());
+    md.section(this.properties.toMarkdown());
+    md.section(this.constants.toMarkdown());
     return md;
+  }
+
+  public toJson(): ClassSchema {
+    return {
+      id: this.transpiled.type.fqn,
+      name: this.transpiled.name,
+      interfaces: this.klass.interfaces.map((iface) => {
+        const transpiled = this.transpile.type(iface);
+        return {
+          fqn: iface.fqn,
+          name: transpiled.fqn,
+        };
+      }),
+      docs: this.klass.docs.toString(),
+      initializer: this.initializer?.toJson(),
+      instanceMethods: this.instanceMethods.toJson(),
+      staticFunctions: this.staticFunctions.toJson(),
+      properties: this.properties.toJson(),
+      constants: this.constants.toJson(),
+    };
   }
 }

--- a/src/docgen/view/classes.ts
+++ b/src/docgen/view/classes.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { ClassSchema } from '../schema';
 import { Transpile, TranspiledType } from '../transpile/transpile';
 import { Class } from './class';
 
@@ -11,15 +12,19 @@ export class Classes {
       .map((c) => new Class(transpile, c, linkFormatter));
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     if (this.classes.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Classes' } });
     for (const klass of this.classes) {
-      md.section(klass.render());
+      md.section(klass.toMarkdown());
     }
     return md;
+  }
+
+  public toJson(): ClassSchema[] {
+    return this.classes.map((klass) => klass.toJson());
   }
 }

--- a/src/docgen/view/classes.ts
+++ b/src/docgen/view/classes.ts
@@ -6,20 +6,20 @@ import { Class } from './class';
 
 export class Classes {
   private readonly classes: Class[];
-  constructor(transpile: Transpile, classes: reflect.ClassType[], linkFormatter: (type: TranspiledType) => string) {
+  constructor(transpile: Transpile, classes: reflect.ClassType[]) {
     this.classes = classes
       .filter((c) => !Class.isConstruct(c))
-      .map((c) => new Class(transpile, c, linkFormatter));
+      .map((c) => new Class(transpile, c));
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     if (this.classes.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Classes' } });
     for (const klass of this.classes) {
-      md.section(klass.toMarkdown());
+      md.section(klass.toMarkdown(linkFormatter));
     }
     return md;
   }

--- a/src/docgen/view/constant.ts
+++ b/src/docgen/view/constant.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { PropertySchema } from '../schema';
 import { Transpile, TranspiledType } from '../transpile/transpile';
 import { Property } from './property';
 
@@ -8,7 +9,10 @@ export class Constant {
   constructor(transpile: Transpile, property: reflect.Property, linkFormatter: (type: TranspiledType) => string) {
     this.constant = new Property(transpile, property, linkFormatter);
   }
-  public render(): Markdown {
-    return this.constant.render();
+  public toMarkdown(): Markdown {
+    return this.constant.toMarkdown();
+  }
+  public toJson(): PropertySchema {
+    return this.constant.toJson();
   }
 }

--- a/src/docgen/view/constant.ts
+++ b/src/docgen/view/constant.ts
@@ -6,11 +6,11 @@ import { Property } from './property';
 
 export class Constant {
   private readonly constant: Property;
-  constructor(transpile: Transpile, property: reflect.Property, linkFormatter: (type: TranspiledType) => string) {
-    this.constant = new Property(transpile, property, linkFormatter);
+  constructor(transpile: Transpile, property: reflect.Property) {
+    this.constant = new Property(transpile, property);
   }
-  public toMarkdown(): Markdown {
-    return this.constant.toMarkdown();
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
+    return this.constant.toMarkdown(linkFormatter);
   }
   public toJson(): PropertySchema {
     return this.constant.toJson();

--- a/src/docgen/view/constants.ts
+++ b/src/docgen/view/constants.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { PropertySchema } from '../schema';
 import { Transpile, TranspiledType } from '../transpile/transpile';
 import { Constant } from './constant';
 
@@ -11,15 +12,19 @@ export class Constants {
       .map((p) => new Constant(transpile, p, linkFormatter));
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     if (this.constants.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Constants' } });
     for (const c of this.constants) {
-      md.section(c.render());
+      md.section(c.toMarkdown());
     }
     return md;
+  }
+
+  public toJson(): PropertySchema[] {
+    return this.constants.map((constant) => constant.toJson());
   }
 }

--- a/src/docgen/view/constants.ts
+++ b/src/docgen/view/constants.ts
@@ -6,20 +6,20 @@ import { Constant } from './constant';
 
 export class Constants {
   private readonly constants: Constant[];
-  constructor(transpile: Transpile, properties: reflect.Property[], linkFormatter: (type: TranspiledType) => string) {
+  constructor(transpile: Transpile, properties: reflect.Property[]) {
     this.constants = properties
       .filter((p) => !p.protected && p.const)
-      .map((p) => new Constant(transpile, p, linkFormatter));
+      .map((p) => new Constant(transpile, p));
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     if (this.constants.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Constants' } });
     for (const c of this.constants) {
-      md.section(c.toMarkdown());
+      md.section(c.toMarkdown(linkFormatter));
     }
     return md;
   }

--- a/src/docgen/view/construct.ts
+++ b/src/docgen/view/construct.ts
@@ -6,11 +6,11 @@ import { Class } from './class';
 
 export class Construct {
   private readonly construct: Class;
-  constructor(transpile: Transpile, klass: reflect.ClassType, linkFormatter: (type: TranspiledType) => string) {
-    this.construct = new Class(transpile, klass, linkFormatter);
+  constructor(transpile: Transpile, klass: reflect.ClassType) {
+    this.construct = new Class(transpile, klass);
   }
-  public toMarkdown(): Markdown {
-    return this.construct.toMarkdown();
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
+    return this.construct.toMarkdown(linkFormatter);
   }
   public toJson(): ConstructSchema {
     return this.construct.toJson();

--- a/src/docgen/view/construct.ts
+++ b/src/docgen/view/construct.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { ConstructSchema } from '../schema';
 import { Transpile, TranspiledType } from '../transpile/transpile';
 import { Class } from './class';
 
@@ -8,7 +9,10 @@ export class Construct {
   constructor(transpile: Transpile, klass: reflect.ClassType, linkFormatter: (type: TranspiledType) => string) {
     this.construct = new Class(transpile, klass, linkFormatter);
   }
-  public render(): Markdown {
-    return this.construct.render();
+  public toMarkdown(): Markdown {
+    return this.construct.toMarkdown();
+  }
+  public toJson(): ConstructSchema {
+    return this.construct.toJson();
   }
 }

--- a/src/docgen/view/constructs.ts
+++ b/src/docgen/view/constructs.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { ConstructSchema } from '../schema';
 import { Transpile, TranspiledType } from '../transpile/transpile';
 import { Class } from './class';
 import { Construct } from './construct';
@@ -12,15 +13,19 @@ export class Constructs {
       .map((c) => new Construct(transpile, c, linkFormatter));
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     if (this.constructs.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Constructs' } });
     for (const construct of this.constructs) {
-      md.section(construct.render());
+      md.section(construct.toMarkdown());
     }
     return md;
+  }
+
+  public toJson(): ConstructSchema[] {
+    return this.constructs.map((construct) => construct.toJson());
   }
 }

--- a/src/docgen/view/constructs.ts
+++ b/src/docgen/view/constructs.ts
@@ -7,20 +7,20 @@ import { Construct } from './construct';
 
 export class Constructs {
   private readonly constructs: Construct[];
-  constructor(transpile: Transpile, classes: reflect.ClassType[], linkFormatter: (type: TranspiledType) => string) {
+  constructor(transpile: Transpile, classes: reflect.ClassType[]) {
     this.constructs = classes
       .filter((c) => Class.isConstruct(c))
-      .map((c) => new Construct(transpile, c, linkFormatter));
+      .map((c) => new Construct(transpile, c));
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     if (this.constructs.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Constructs' } });
     for (const construct of this.constructs) {
-      md.section(construct.toMarkdown());
+      md.section(construct.toMarkdown(linkFormatter));
     }
     return md;
   }

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -5,7 +5,8 @@ import * as glob from 'glob-promise';
 import * as reflect from 'jsii-reflect';
 import { TargetLanguage } from 'jsii-rosetta';
 import { transliterateAssembly } from 'jsii-rosetta/lib/commands/transliterate';
-import { Markdown } from '../render/markdown';
+import { Json, Markdown } from '../render';
+import { Schema } from '../schema';
 import { CSharpTranspile } from '../transpile/csharp';
 import { JavaTranspile } from '../transpile/java';
 import { PythonTranspile } from '../transpile/python';
@@ -200,21 +201,45 @@ export class Documentation {
   /**
    * Generate markdown.
    */
-  public render(options?: RenderOptions): Markdown {
-    const submodule = options?.submodule ? this.findSubmodule(this.assembly, options.submodule) : undefined;
+  public toMarkdown(options?: RenderOptions): Markdown {
     const documentation = new Markdown();
 
-    if (options?.readme ?? true) {
-      const readme = new Readme(this.transpile, this.assembly, submodule);
-      documentation.section(readme.render());
+    const readme = this.createReadme(options);
+    const apiReference = this.createApiReference(options);
+    if (readme) {
+      documentation.section(readme.toMarkdown());
     }
-
-    if (options?.apiReference ?? true) {
-      const apiReference = new ApiReference(this.transpile, this.assembly, options?.linkFormatter ?? ((t: TranspiledType) => `#${t.fqn}`), submodule);
-      documentation.section(apiReference.render());
+    if (apiReference) {
+      documentation.section(apiReference.toMarkdown());
     }
 
     return documentation;
+  }
+
+  /**
+   * Generate JSON.
+   */
+  public toJson(options?: RenderOptions): Json<Schema> {
+    const readme = this.createReadme(options);
+    const apiReference = this.createApiReference(options);
+    return new Json({
+      readme: readme ? readme.toMarkdown().render() : undefined,
+      apiReference: apiReference ? apiReference.toJson() : undefined,
+    });
+  }
+
+  private createReadme(options?: RenderOptions): Readme | undefined {
+    const submodule = options?.submodule ? this.findSubmodule(this.assembly, options.submodule) : undefined;
+    return (options?.readme ?? true)
+      ? new Readme(this.transpile, this.assembly, submodule)
+      : undefined;
+  }
+
+  private createApiReference(options?: RenderOptions): ApiReference | undefined {
+    const submodule = options?.submodule ? this.findSubmodule(this.assembly, options.submodule) : undefined;
+    return (options?.apiReference ?? true)
+      ? new ApiReference(this.transpile, this.assembly, options?.linkFormatter ?? ((t: TranspiledType) => `#${t.fqn}`), submodule)
+      : undefined;
   }
 
   /**

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -41,6 +41,9 @@ export interface RenderOptions {
     * @default - Documentation is generated for the root module only.
     */
   readonly submodule?: string;
+}
+
+export interface MDRenderOptions extends RenderOptions {
 
   /**
    * How should links to types be rendered.
@@ -201,7 +204,7 @@ export class Documentation {
   /**
    * Generate markdown.
    */
-  public toMarkdown(options?: RenderOptions): Markdown {
+  public toMarkdown(options?: MDRenderOptions): Markdown {
     const documentation = new Markdown();
 
     const readme = this.createReadme(options);
@@ -210,7 +213,7 @@ export class Documentation {
       documentation.section(readme.toMarkdown());
     }
     if (apiReference) {
-      documentation.section(apiReference.toMarkdown());
+      documentation.section(apiReference.toMarkdown(options?.linkFormatter ?? ((t) => `#${t.fqn}`)));
     }
 
     return documentation;
@@ -238,7 +241,7 @@ export class Documentation {
   private createApiReference(options?: RenderOptions): ApiReference | undefined {
     const submodule = options?.submodule ? this.findSubmodule(this.assembly, options.submodule) : undefined;
     return (options?.apiReference ?? true)
-      ? new ApiReference(this.transpile, this.assembly, options?.linkFormatter ?? ((t: TranspiledType) => `#${t.fqn}`), submodule)
+      ? new ApiReference(this.transpile, this.assembly, submodule)
       : undefined;
   }
 

--- a/src/docgen/view/enum-member.ts
+++ b/src/docgen/view/enum-member.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { EnumMemberSchema } from '../schema';
 import { Transpile, TranspiledEnumMember } from '../transpile/transpile';
 
 export class EnumMember {
@@ -7,7 +8,7 @@ export class EnumMember {
   constructor(transpile: Transpile, private readonly em: reflect.EnumMember) {
     this.transpiled = transpile.enumMember(em);
   }
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     const md = new Markdown({
       id: `${this.transpiled.fqn}`,
       header: {
@@ -32,5 +33,15 @@ export class EnumMember {
     md.lines('');
 
     return md;
+  }
+
+  public toJson(): EnumMemberSchema {
+    return {
+      id: this.transpiled.fqn,
+      name: this.transpiled.name,
+      deprecated: this.em.docs.deprecated,
+      deprecationReason: this.em.docs.deprecationReason,
+      docs: this.em.docs.toString(),
+    };
   }
 }

--- a/src/docgen/view/enum.ts
+++ b/src/docgen/view/enum.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { EnumSchema } from '../schema';
 import { Transpile } from '../transpile/transpile';
 import { EnumMember } from './enum-member';
 
@@ -12,7 +13,7 @@ export class Enum {
     this.members = enu.members.map((em) => new EnumMember(transpile, em));
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     const transpiled = this.transpile.enum(this.enu);
     const md = new Markdown({ header: { title: transpiled.name } });
 
@@ -21,9 +22,18 @@ export class Enum {
     }
 
     for (const m of this.members) {
-      md.section(m.render());
+      md.section(m.toMarkdown());
     }
 
     return md;
+  }
+
+  public toJson(): EnumSchema {
+    const transpiled = this.transpile.enum(this.enu);
+    return {
+      name: transpiled.name,
+      docs: this.enu.docs.toString(),
+      members: this.members.map((member) => member.toJson()),
+    };
   }
 }

--- a/src/docgen/view/enums.ts
+++ b/src/docgen/view/enums.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { EnumSchema } from '../schema';
 import { Transpile } from '../transpile/transpile';
 import { Enum } from './enum';
 
@@ -9,15 +10,19 @@ export class Enums {
     this.enums = enums.map((e) => new Enum(transpile, e));
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     if (this.enums.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Enums' } });
     for (const e of this.enums) {
-      md.section(e.render());
+      md.section(e.toMarkdown());
     }
     return md;
+  }
+
+  public toJson(): EnumSchema[] {
+    return this.enums.map((e) => e.toJson());
   }
 }

--- a/src/docgen/view/initializer.ts
+++ b/src/docgen/view/initializer.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { InitializerSchema } from '../schema';
 import { Transpile, TranspiledCallable, TranspiledType } from '../transpile/transpile';
 import { Parameter } from './parameter';
 
@@ -17,7 +18,7 @@ export class Initializer {
     );
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     const md = new Markdown({
       id: `${this.transpiled.parentType.fqn}.Initializer`,
       header: {
@@ -33,9 +34,25 @@ export class Initializer {
     );
 
     for (const parameter of this.parameters) {
-      md.section(parameter.render());
+      md.section(parameter.toMarkdown());
     }
 
     return md;
+  }
+
+  public toJson(): InitializerSchema {
+    const md = new Markdown();
+    md.code(
+      this.transpile.language.toString(),
+      `${this.transpiled.import}`,
+      '',
+      ...this.transpiled.invocations,
+    );
+
+    return {
+      id: `${this.transpiled.parentType.fqn}.Initializer`,
+      snippet: md.render(),
+      parameters: this.parameters.map((parameter) => parameter.toJson()),
+    };
   }
 }

--- a/src/docgen/view/initializer.ts
+++ b/src/docgen/view/initializer.ts
@@ -10,15 +10,16 @@ export class Initializer {
   constructor(
     private readonly transpile: Transpile,
     initializer: reflect.Initializer,
-    linkFormatter: (type: TranspiledType) => string,
   ) {
     this.transpiled = transpile.callable(initializer);
     this.parameters = this.transpiled.parameters.map(
-      (p) => new Parameter(this.transpile, p, linkFormatter),
+      (p) => new Parameter(this.transpile, p),
     );
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(
+    linkFormatter: (type: TranspiledType) => string,
+  ): Markdown {
     const md = new Markdown({
       id: `${this.transpiled.parentType.fqn}.Initializer`,
       header: {
@@ -34,7 +35,7 @@ export class Initializer {
     );
 
     for (const parameter of this.parameters) {
-      md.section(parameter.toMarkdown());
+      md.section(parameter.toMarkdown(linkFormatter));
     }
 
     return md;

--- a/src/docgen/view/instance-method.ts
+++ b/src/docgen/view/instance-method.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { MethodSchema } from '../schema';
 import { Transpile, TranspiledCallable, TranspiledType } from '../transpile/transpile';
 import { Parameter } from './parameter';
 
@@ -17,7 +18,7 @@ export class InstanceMethod {
     );
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     const md = new Markdown({
       id: `${this.transpiled.parentType.fqn}.${this.transpiled.name}`,
       header: {
@@ -30,9 +31,20 @@ export class InstanceMethod {
     md.code(this.transpile.language.toString(), this.transpiled.signatures.join('\n'));
 
     for (const parameter of this.parameters) {
-      md.section(parameter.render());
+      md.section(parameter.toMarkdown());
     }
 
     return md;
+  }
+
+  public toJson(): MethodSchema {
+    const md = new Markdown();
+    md.code(this.transpile.language.toString(), this.transpiled.signatures.join('\n'));
+    return {
+      id: `${this.transpiled.parentType.fqn}.${this.transpiled.name}`,
+      name: this.transpiled.name,
+      snippet: md.render(),
+      parameters: this.parameters.map((parameter) => parameter.toJson()),
+    };
   }
 }

--- a/src/docgen/view/instance-method.ts
+++ b/src/docgen/view/instance-method.ts
@@ -10,15 +10,14 @@ export class InstanceMethod {
   constructor(
     private readonly transpile: Transpile,
     private readonly method: reflect.Method,
-    linkFormatter: (type: TranspiledType) => string,
   ) {
     this.transpiled = transpile.callable(method);
     this.parameters = this.transpiled.parameters.map(
-      (p) => new Parameter(this.transpile, p, linkFormatter),
+      (p) => new Parameter(this.transpile, p),
     );
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     const md = new Markdown({
       id: `${this.transpiled.parentType.fqn}.${this.transpiled.name}`,
       header: {
@@ -31,7 +30,7 @@ export class InstanceMethod {
     md.code(this.transpile.language.toString(), this.transpiled.signatures.join('\n'));
 
     for (const parameter of this.parameters) {
-      md.section(parameter.toMarkdown());
+      md.section(parameter.toMarkdown(linkFormatter));
     }
 
     return md;

--- a/src/docgen/view/instance-methods.ts
+++ b/src/docgen/view/instance-methods.ts
@@ -6,20 +6,20 @@ import { InstanceMethod } from './instance-method';
 
 export class InstanceMethods {
   private readonly instanceMethods: InstanceMethod[];
-  constructor(transpile: Transpile, methods: reflect.Method[], linkFormatter: (type: TranspiledType) => string) {
+  constructor(transpile: Transpile, methods: reflect.Method[]) {
     this.instanceMethods = methods
       .filter((m) => !m.protected && !m.static)
-      .map((m) => new InstanceMethod(transpile, m, linkFormatter));
+      .map((m) => new InstanceMethod(transpile, m));
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     if (this.instanceMethods.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Methods' } });
     for (const method of this.instanceMethods) {
-      md.section(method.toMarkdown());
+      md.section(method.toMarkdown(linkFormatter));
     }
     return md;
   }

--- a/src/docgen/view/instance-methods.ts
+++ b/src/docgen/view/instance-methods.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { MethodSchema } from '../schema';
 import { Transpile, TranspiledType } from '../transpile/transpile';
 import { InstanceMethod } from './instance-method';
 
@@ -11,15 +12,19 @@ export class InstanceMethods {
       .map((m) => new InstanceMethod(transpile, m, linkFormatter));
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     if (this.instanceMethods.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Methods' } });
     for (const method of this.instanceMethods) {
-      md.section(method.render());
+      md.section(method.toMarkdown());
     }
     return md;
+  }
+
+  public toJson(): MethodSchema[] {
+    return this.instanceMethods.map((method) => method.toJson());
   }
 }

--- a/src/docgen/view/interface.ts
+++ b/src/docgen/view/interface.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { InterfaceSchema } from '../schema';
 import { Transpile, TranspiledInterface, TranspiledType } from '../transpile/transpile';
 import { InstanceMethods } from './instance-methods';
 import { Properties } from './properties';
@@ -24,7 +25,7 @@ export class Interface {
     this.properties = new Properties(transpile, iface.allProperties, linkFormatter);
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     const md = new Markdown({
       id: this.transpiled.type.fqn,
       header: { title: this.transpiled.name },
@@ -54,8 +55,32 @@ export class Interface {
       md.docs(this.iface.docs);
     }
 
-    md.section(this.instanceMethods.render());
-    md.section(this.properties.render());
+    md.section(this.instanceMethods.toMarkdown());
+    md.section(this.properties.toMarkdown());
     return md;
+  }
+
+  public toJson(): InterfaceSchema {
+    return {
+      id: this.transpiled.type.fqn,
+      name: this.transpiled.name,
+      interfaces: this.iface.interfaces.map((iface) => {
+        const transpiled = this.transpile.type(iface);
+        return {
+          fqn: iface.fqn,
+          name: transpiled.fqn,
+        };
+      }),
+      implementations: this.iface.allImplementations.map((impl) => {
+        const transpiled = this.transpile.type(impl);
+        return {
+          fqn: impl.fqn,
+          name: transpiled.fqn,
+        };
+      }),
+      docs: this.iface.docs.toString(),
+      instanceMethods: this.instanceMethods.toJson(),
+      properties: this.properties.toJson(),
+    };
   }
 }

--- a/src/docgen/view/interface.ts
+++ b/src/docgen/view/interface.ts
@@ -18,14 +18,13 @@ export class Interface {
   constructor(
     private readonly transpile: Transpile,
     private readonly iface: reflect.InterfaceType,
-    private readonly linkFormatter: (type: TranspiledType) => string,
   ) {
     this.transpiled = transpile.interface(iface);
-    this.instanceMethods = new InstanceMethods(transpile, iface.ownMethods, linkFormatter);
-    this.properties = new Properties(transpile, iface.allProperties, linkFormatter);
+    this.instanceMethods = new InstanceMethods(transpile, iface.ownMethods);
+    this.properties = new Properties(transpile, iface.allProperties);
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     const md = new Markdown({
       id: this.transpiled.type.fqn,
       header: { title: this.transpiled.name },
@@ -35,7 +34,7 @@ export class Interface {
       const ifaces = [];
       for (const iface of this.iface.interfaces) {
         const transpiled = this.transpile.type(iface);
-        ifaces.push(`[${Markdown.pre(transpiled.fqn)}](${this.linkFormatter(transpiled)})`);
+        ifaces.push(`[${Markdown.pre(transpiled.fqn)}](${linkFormatter(transpiled)})`);
       }
       md.bullet(`${Markdown.italic('Extends:')} ${ifaces.join(', ')}`);
       md.lines('');
@@ -45,7 +44,7 @@ export class Interface {
       const impls = [];
       for (const impl of this.iface.allImplementations) {
         const transpiled = this.transpile.type(impl);
-        impls.push(`[${Markdown.pre(transpiled.fqn)}](${this.linkFormatter(transpiled)})`);
+        impls.push(`[${Markdown.pre(transpiled.fqn)}](${linkFormatter(transpiled)})`);
       }
       md.bullet(`${Markdown.italic('Implemented By:')} ${impls.join(', ')}`);
       md.lines('');
@@ -55,8 +54,8 @@ export class Interface {
       md.docs(this.iface.docs);
     }
 
-    md.section(this.instanceMethods.toMarkdown());
-    md.section(this.properties.toMarkdown());
+    md.section(this.instanceMethods.toMarkdown(linkFormatter));
+    md.section(this.properties.toMarkdown(linkFormatter));
     return md;
   }
 

--- a/src/docgen/view/interfaces.ts
+++ b/src/docgen/view/interfaces.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { InterfaceSchema } from '../schema';
 import { Transpile, TranspiledType } from '../transpile/transpile';
 import { Interface } from './interface';
 
@@ -11,7 +12,7 @@ export class Interfaces {
       .filter((i) => !Interface.isStruct(i))
       .map((i) => new Interface(transpile, i, linkFormatter));
   }
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     if (this.interfaces.length === 0) {
       return Markdown.EMPTY;
     }
@@ -19,9 +20,13 @@ export class Interfaces {
     const md = new Markdown({ header: { title: 'Protocols' } });
 
     for (const iface of this.interfaces) {
-      md.section(iface.render());
+      md.section(iface.toMarkdown());
     }
 
     return md;
+  }
+
+  public toJson(): InterfaceSchema[] {
+    return this.interfaces.map((iface) => iface.toJson());
   }
 }

--- a/src/docgen/view/interfaces.ts
+++ b/src/docgen/view/interfaces.ts
@@ -7,12 +7,12 @@ import { Interface } from './interface';
 export class Interfaces {
   private readonly interfaces: Interface[];
 
-  constructor(transpile: Transpile, interfaces: reflect.InterfaceType[], linkFormatter: (type: TranspiledType) => string) {
+  constructor(transpile: Transpile, interfaces: reflect.InterfaceType[]) {
     this.interfaces = interfaces
       .filter((i) => !Interface.isStruct(i))
-      .map((i) => new Interface(transpile, i, linkFormatter));
+      .map((i) => new Interface(transpile, i));
   }
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     if (this.interfaces.length === 0) {
       return Markdown.EMPTY;
     }
@@ -20,7 +20,7 @@ export class Interfaces {
     const md = new Markdown({ header: { title: 'Protocols' } });
 
     for (const iface of this.interfaces) {
-      md.section(iface.toMarkdown());
+      md.section(iface.toMarkdown(linkFormatter));
     }
 
     return md;

--- a/src/docgen/view/parameter.ts
+++ b/src/docgen/view/parameter.ts
@@ -8,12 +8,11 @@ export class Parameter {
   constructor(
     transpile: Transpile,
     private readonly parameter: reflect.Parameter,
-    private readonly linkFormatter: (type: TranspiledType) => string,
   ) {
     this.transpiled = transpile.parameter(parameter);
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     const optionality = this.parameter.optional ? 'Optional' : 'Required';
 
     const md = new Markdown({
@@ -37,7 +36,7 @@ export class Parameter {
 
     const metadata: any = {
       Type: this.transpiled.typeReference.toString({
-        typeFormatter: (t) => `[${Markdown.pre(t.fqn)}](${this.linkFormatter(t)})`,
+        typeFormatter: (t) => `[${Markdown.pre(t.fqn)}](${linkFormatter(t)})`,
         stringFormatter: Markdown.pre,
       }),
     };

--- a/src/docgen/view/parameter.ts
+++ b/src/docgen/view/parameter.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { ParameterSchema } from '../schema';
 import { Transpile, TranspiledParameter, TranspiledType } from '../transpile/transpile';
 
 export class Parameter {
@@ -12,7 +13,7 @@ export class Parameter {
     this.transpiled = transpile.parameter(parameter);
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     const optionality = this.parameter.optional ? 'Optional' : 'Required';
 
     const md = new Markdown({
@@ -57,5 +58,18 @@ export class Parameter {
     md.split();
 
     return md;
+  }
+
+  public toJson(): ParameterSchema {
+    return {
+      id: `${this.transpiled.parentType.fqn}.${this.transpiled.name}`,
+      name: this.transpiled.name,
+      optional: this.parameter.optional,
+      deprecated: this.parameter.docs.deprecated,
+      deprecationReason: this.parameter.docs.deprecationReason,
+      docs: this.parameter.docs.toString(),
+      default: this.parameter.spec.docs?.default,
+      type: this.transpiled.typeReference.toJson(),
+    };
   }
 }

--- a/src/docgen/view/properties.ts
+++ b/src/docgen/view/properties.ts
@@ -6,20 +6,20 @@ import { Property } from './property';
 
 export class Properties {
   private readonly properties: Property[];
-  constructor(transpile: Transpile, properties: reflect.Property[], linkFormatter: (type: TranspiledType) => string) {
+  constructor(transpile: Transpile, properties: reflect.Property[]) {
     this.properties = properties
       .filter((p) => !p.protected && !p.const)
-      .map((p) => new Property(transpile, p, linkFormatter));
+      .map((p) => new Property(transpile, p));
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     if (this.properties.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Properties' } });
     for (const property of this.properties) {
-      md.section(property.toMarkdown());
+      md.section(property.toMarkdown(linkFormatter));
     }
     return md;
   }

--- a/src/docgen/view/properties.ts
+++ b/src/docgen/view/properties.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { PropertySchema } from '../schema';
 import { Transpile, TranspiledType } from '../transpile/transpile';
 import { Property } from './property';
 
@@ -11,15 +12,19 @@ export class Properties {
       .map((p) => new Property(transpile, p, linkFormatter));
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     if (this.properties.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Properties' } });
     for (const property of this.properties) {
-      md.section(property.render());
+      md.section(property.toMarkdown());
     }
     return md;
+  }
+
+  public toJson(): PropertySchema[] {
+    return this.properties.map((property) => property.toJson());
   }
 }

--- a/src/docgen/view/property.ts
+++ b/src/docgen/view/property.ts
@@ -8,12 +8,11 @@ export class Property {
   constructor(
     private readonly transpile: Transpile,
     private readonly property: reflect.Property,
-    private readonly linkFormatter: (type: TranspiledType) => string,
   ) {
     this.transpiled = transpile.property(property);
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     const optionality = this.property.const
       ? undefined
       : this.property.optional
@@ -45,7 +44,7 @@ export class Property {
 
     const metadata: any = {
       Type: this.transpiled.typeReference.toString({
-        typeFormatter: (t) => `[${Markdown.pre(t.fqn)}](${this.linkFormatter(t)})`,
+        typeFormatter: (t) => `[${Markdown.pre(t.fqn)}](${linkFormatter(t)})`,
         stringFormatter: Markdown.pre,
       }),
     };

--- a/src/docgen/view/property.ts
+++ b/src/docgen/view/property.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { PropertySchema } from '../schema';
 import { Transpile, TranspiledProperty, TranspiledType } from '../transpile/transpile';
 
 export class Property {
@@ -12,7 +13,7 @@ export class Property {
     this.transpiled = transpile.property(property);
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     const optionality = this.property.const
       ? undefined
       : this.property.optional
@@ -65,5 +66,18 @@ export class Property {
     md.split();
 
     return md;
+  }
+
+  public toJson(): PropertySchema {
+    return {
+      id: `${this.transpiled.parentType.fqn}.${this.transpiled.name}`,
+      name: this.transpiled.name,
+      optional: this.property.const ? false : this.property.optional,
+      deprecated: this.property.docs.deprecated,
+      deprecationReason: this.property.docs.deprecationReason,
+      docs: this.property.docs.toString(),
+      default: this.property.spec.docs?.default,
+      type: this.transpiled.typeReference.toJson(),
+    };
   }
 }

--- a/src/docgen/view/readme.ts
+++ b/src/docgen/view/readme.ts
@@ -20,7 +20,7 @@ export class Readme {
   /**
    * Generate markdown.
    */
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     if (!this.readme) {
       return Markdown.EMPTY;
     }

--- a/src/docgen/view/static-function.ts
+++ b/src/docgen/view/static-function.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { MethodSchema } from '../schema';
 import { Transpile, TranspiledCallable, TranspiledType } from '../transpile/transpile';
 import { Parameter } from './parameter';
 
@@ -17,7 +18,7 @@ export class StaticFunction {
     );
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     const md = new Markdown({
       id: `${this.transpiled.parentType.fqn}.${this.transpiled.name}`,
       header: {
@@ -35,9 +36,26 @@ export class StaticFunction {
     );
 
     for (const parameter of this.parameters) {
-      md.section(parameter.render());
+      md.section(parameter.toMarkdown());
     }
 
     return md;
+  }
+
+  public toJson(): MethodSchema {
+    const md = new Markdown();
+    md.code(
+      this.transpile.language.toString(),
+      `${this.transpiled.import}`,
+      '',
+      ...this.transpiled.invocations,
+    );
+
+    return {
+      id: `${this.transpiled.parentType.fqn}.Initializer`,
+      name: this.transpiled.name,
+      snippet: md.render(),
+      parameters: this.parameters.map((parameter) => parameter.toJson()),
+    };
   }
 }

--- a/src/docgen/view/static-function.ts
+++ b/src/docgen/view/static-function.ts
@@ -10,15 +10,14 @@ export class StaticFunction {
   constructor(
     private readonly transpile: Transpile,
     private readonly method: reflect.Method,
-    linkFormatter: (type: TranspiledType) => string,
   ) {
     this.transpiled = transpile.callable(method);
     this.parameters = this.transpiled.parameters.map(
-      (p) => new Parameter(this.transpile, p, linkFormatter),
+      (p) => new Parameter(this.transpile, p),
     );
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     const md = new Markdown({
       id: `${this.transpiled.parentType.fqn}.${this.transpiled.name}`,
       header: {
@@ -36,7 +35,7 @@ export class StaticFunction {
     );
 
     for (const parameter of this.parameters) {
-      md.section(parameter.toMarkdown());
+      md.section(parameter.toMarkdown(linkFormatter));
     }
 
     return md;

--- a/src/docgen/view/static-functions.ts
+++ b/src/docgen/view/static-functions.ts
@@ -6,20 +6,20 @@ import { StaticFunction } from './static-function';
 
 export class StaticFunctions {
   private readonly staticFunctions: StaticFunction[];
-  constructor(transpile: Transpile, methods: reflect.Method[], linkFormatter: (type: TranspiledType) => string) {
+  constructor(transpile: Transpile, methods: reflect.Method[]) {
     this.staticFunctions = methods
       .filter((m) => !m.protected && m.static)
-      .map((m) => new StaticFunction(transpile, m, linkFormatter));
+      .map((m) => new StaticFunction(transpile, m));
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     if (this.staticFunctions.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Static Functions' } });
     for (const func of this.staticFunctions) {
-      md.section(func.toMarkdown());
+      md.section(func.toMarkdown(linkFormatter));
     }
     return md;
   }

--- a/src/docgen/view/static-functions.ts
+++ b/src/docgen/view/static-functions.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { MethodSchema } from '../schema';
 import { Transpile, TranspiledType } from '../transpile/transpile';
 import { StaticFunction } from './static-function';
 
@@ -11,15 +12,19 @@ export class StaticFunctions {
       .map((m) => new StaticFunction(transpile, m, linkFormatter));
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     if (this.staticFunctions.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Static Functions' } });
     for (const func of this.staticFunctions) {
-      md.section(func.render());
+      md.section(func.toMarkdown());
     }
     return md;
+  }
+
+  public toJson(): MethodSchema[] {
+    return this.staticFunctions.map((func) => func.toJson());
   }
 }

--- a/src/docgen/view/struct.ts
+++ b/src/docgen/view/struct.ts
@@ -10,15 +10,14 @@ export class Struct {
   constructor(
     private readonly transpile: Transpile,
     private readonly iface: reflect.InterfaceType,
-    linkFormatter: (type: TranspiledType) => string,
   ) {
     this.transpiled = transpile.struct(iface);
     for (const property of this.iface.allProperties) {
-      this.properties.push(new Property(this.transpile, property, linkFormatter));
+      this.properties.push(new Property(this.transpile, property));
     }
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     const md = new Markdown({
       id: this.transpiled.type.fqn,
       header: { title: this.transpiled.name },
@@ -41,7 +40,7 @@ export class Struct {
     );
 
     for (const property of this.properties) {
-      initializer.section(property.toMarkdown());
+      initializer.section(property.toMarkdown(linkFormatter));
     }
 
     md.section(initializer);

--- a/src/docgen/view/struct.ts
+++ b/src/docgen/view/struct.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { StructSchema } from '../schema';
 import { Transpile, TranspiledStruct, TranspiledType } from '../transpile/transpile';
 import { Property } from './property';
 
@@ -17,7 +18,7 @@ export class Struct {
     }
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     const md = new Markdown({
       id: this.transpiled.type.fqn,
       header: { title: this.transpiled.name },
@@ -40,10 +41,28 @@ export class Struct {
     );
 
     for (const property of this.properties) {
-      initializer.section(property.render());
+      initializer.section(property.toMarkdown());
     }
 
     md.section(initializer);
     return md;
+  }
+
+  public toJson(): StructSchema {
+    const initializer = new Markdown();
+    initializer.code(
+      this.transpile.language.toString(),
+      `${this.transpiled.import}`,
+      '',
+      `${this.transpiled.initialization}`,
+    );
+
+    return {
+      id: this.transpiled.type.fqn,
+      name: this.transpiled.name,
+      docs: this.iface.docs.toString(),
+      initializer: initializer.render(),
+      properties: this.properties.map((property) => property.toJson()),
+    };
   }
 }

--- a/src/docgen/view/structs.ts
+++ b/src/docgen/view/structs.ts
@@ -7,20 +7,20 @@ import { Struct } from './struct';
 
 export class Structs {
   private readonly structs: Struct[];
-  constructor(transpile: Transpile, interfaces: reflect.InterfaceType[], linkFormatter: (type: TranspiledType) => string) {
+  constructor(transpile: Transpile, interfaces: reflect.InterfaceType[]) {
     this.structs = interfaces
       .filter((i) => Interface.isStruct(i))
-      .map((i) => new Struct(transpile, i, linkFormatter));
+      .map((i) => new Struct(transpile, i));
   }
 
-  public toMarkdown(): Markdown {
+  public toMarkdown(linkFormatter: (type: TranspiledType) => string): Markdown {
     if (this.structs.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Structs' } });
     for (const struct of this.structs) {
-      md.section(struct.toMarkdown());
+      md.section(struct.toMarkdown(linkFormatter));
     }
     return md;
   }

--- a/src/docgen/view/structs.ts
+++ b/src/docgen/view/structs.ts
@@ -1,5 +1,6 @@
 import * as reflect from 'jsii-reflect';
 import { Markdown } from '../render/markdown';
+import { StructSchema } from '../schema';
 import { Transpile, TranspiledType } from '../transpile/transpile';
 import { Interface } from './interface';
 import { Struct } from './struct';
@@ -12,15 +13,19 @@ export class Structs {
       .map((i) => new Struct(transpile, i, linkFormatter));
   }
 
-  public render(): Markdown {
+  public toMarkdown(): Markdown {
     if (this.structs.length === 0) {
       return Markdown.EMPTY;
     }
 
     const md = new Markdown({ header: { title: 'Structs' } });
     for (const struct of this.structs) {
-      md.section(struct.render());
+      md.section(struct.toMarkdown());
     }
     return md;
+  }
+
+  public toJson(): StructSchema[] {
+    return this.structs.map((struct) => struct.toJson());
   }
 }

--- a/test/__fixtures__/libraries/construct-library/API.json
+++ b/test/__fixtures__/libraries/construct-library/API.json
@@ -1,0 +1,65 @@
+{
+  "apiReference": {
+    "constructs": [
+      {
+        "id": "construct-library.GreeterBucket",
+        "name": "GreeterBucket",
+        "interfaces": [],
+        "docs": "",
+        "initializer": {
+          "id": "construct-library.GreeterBucket.Initializer",
+          "snippet": "```typescript\nimport { GreeterBucket } from 'construct-library'\n\nnew GreeterBucket(scope: Construct, id: string, props?: BucketProps)\n```\n",
+          "parameters": [
+            {
+              "id": "construct-library.GreeterBucket.scope",
+              "name": "scope",
+              "optional": false,
+              "deprecated": false,
+              "docs": "",
+              "type": {
+                "fqn": "constructs.Construct",
+                "name": "constructs.Construct"
+              }
+            },
+            {
+              "id": "construct-library.GreeterBucket.id",
+              "name": "id",
+              "optional": false,
+              "deprecated": false,
+              "docs": "",
+              "type": {
+                "name": "string"
+              }
+            },
+            {
+              "id": "construct-library.GreeterBucket.props",
+              "name": "props",
+              "optional": true,
+              "deprecated": false,
+              "docs": "",
+              "type": {
+                "fqn": "@aws-cdk/aws-s3.BucketProps",
+                "name": "@aws-cdk/aws-s3.BucketProps"
+              }
+            }
+          ]
+        },
+        "instanceMethods": [
+          {
+            "id": "construct-library.GreeterBucket.greet",
+            "name": "greet",
+            "snippet": "```typescript\npublic greet()\n```\n",
+            "parameters": []
+          }
+        ],
+        "staticFunctions": [],
+        "properties": [],
+        "constants": []
+      }
+    ],
+    "classes": [],
+    "structs": [],
+    "interfaces": [],
+    "enums": []
+  }
+}

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -50,6 +50,74 @@ public greet()
 "
 `;
 
+exports[`specify format 1`] = `
+"{
+  \\"apiReference\\": {
+    \\"constructs\\": [
+      {
+        \\"id\\": \\"construct-library.GreeterBucket\\",
+        \\"name\\": \\"GreeterBucket\\",
+        \\"interfaces\\": [],
+        \\"docs\\": \\"\\",
+        \\"initializer\\": {
+          \\"id\\": \\"construct-library.GreeterBucket.Initializer\\",
+          \\"snippet\\": \\"\`\`\`typescript\\\\nimport { GreeterBucket } from 'construct-library'\\\\n\\\\nnew GreeterBucket(scope: Construct, id: string, props?: BucketProps)\\\\n\`\`\`\\\\n\\",
+          \\"parameters\\": [
+            {
+              \\"id\\": \\"construct-library.GreeterBucket.scope\\",
+              \\"name\\": \\"scope\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"\\",
+              \\"type\\": {
+                \\"fqn\\": \\"constructs.Construct\\",
+                \\"name\\": \\"constructs.Construct\\"
+              }
+            },
+            {
+              \\"id\\": \\"construct-library.GreeterBucket.id\\",
+              \\"name\\": \\"id\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"\\",
+              \\"type\\": {
+                \\"name\\": \\"string\\"
+              }
+            },
+            {
+              \\"id\\": \\"construct-library.GreeterBucket.props\\",
+              \\"name\\": \\"props\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-s3.BucketProps\\",
+                \\"name\\": \\"@aws-cdk/aws-s3.BucketProps\\"
+              }
+            }
+          ]
+        },
+        \\"instanceMethods\\": [
+          {
+            \\"id\\": \\"construct-library.GreeterBucket.greet\\",
+            \\"name\\": \\"greet\\",
+            \\"snippet\\": \\"\`\`\`typescript\\\\npublic greet()\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": []
+          }
+        ],
+        \\"staticFunctions\\": [],
+        \\"properties\\": [],
+        \\"constants\\": []
+      }
+    ],
+    \\"classes\\": [],
+    \\"structs\\": [],
+    \\"interfaces\\": [],
+    \\"enums\\": []
+  }
+}"
+`;
+
 exports[`specify language 1`] = `
 "# API Reference <a name=\\"API Reference\\"></a>
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -29,3 +29,15 @@ test('specify language', () => {
   expect(md).toMatchSnapshot();
 
 });
+
+test('specify format', () => {
+
+  const libraryName = 'construct-library';
+  const fixture = join(`${__dirname}/__fixtures__/libraries/${libraryName}`);
+
+  // generate the documentation
+  execSync(`${process.execPath} ${cli} --format json`, { cwd: fixture });
+
+  const json = readFileSync(join(fixture, 'API.json'), 'utf-8');
+  expect(json).toMatchSnapshot();
+});

--- a/test/docgen/transpile/__snapshots__/transpile.test.ts.snap
+++ b/test/docgen/transpile/__snapshots__/transpile.test.ts.snap
@@ -1,6 +1,939 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`submodules without an explicit name csharp 1`] = `
+exports[`submodules without an explicit name csharp json 1`] = `
+"{
+  \\"readme\\": \\"\\",
+  \\"apiReference\\": {
+    \\"constructs\\": [
+      {
+        \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction\\",
+        \\"name\\": \\"EdgeFunction\\",
+        \\"interfaces\\": [
+          {
+            \\"fqn\\": \\"@aws-cdk/aws-lambda.IVersion\\",
+            \\"name\\": \\"Amazon.CDK.AWS.Lambda.IVersion\\"
+          }
+        ],
+        \\"docs\\": \\"A Lambda@Edge function.\\\\n\\\\nConvenience resource for requesting a Lambda function in the 'us-east-1' region for use with Lambda@Edge.\\\\nImplements several restrictions enforced by Lambda@Edge.\\\\n\\\\nNote that this construct requires that the 'us-east-1' region has been bootstrapped.\\\\nSee https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html or 'cdk bootstrap --help' for options.\\",
+        \\"initializer\\": {
+          \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Initializer\\",
+          \\"snippet\\": \\"\`\`\`csharp\\\\nusing Amazon.CDK.AWS.CloudFront;\\\\n\\\\nnew EdgeFunction(Construct Scope, string Id, EdgeFunctionProps Props);\\\\n\`\`\`\\\\n\\",
+          \\"parameters\\": [
+            {
+              \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Scope\\",
+              \\"name\\": \\"Scope\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"\\",
+              \\"type\\": {
+                \\"fqn\\": \\"constructs.Construct\\",
+                \\"name\\": \\"Constructs.Construct\\"
+              }
+            },
+            {
+              \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Id\\",
+              \\"name\\": \\"Id\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"\\",
+              \\"type\\": {
+                \\"name\\": \\"string\\"
+              }
+            },
+            {
+              \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Props\\",
+              \\"name\\": \\"Props\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-cloudfront.experimental.EdgeFunctionProps\\",
+                \\"name\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps\\"
+              }
+            }
+          ]
+        },
+        \\"instanceMethods\\": [
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.AddAlias\\",
+            \\"name\\": \\"AddAlias\\",
+            \\"snippet\\": \\"\`\`\`csharp\\\\nprivate AddAlias(string AliasName, AliasOptions Options = null)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.AliasName\\",
+                \\"name\\": \\"AliasName\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"name\\": \\"string\\"
+                }
+              },
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Options\\",
+                \\"name\\": \\"Options\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.AliasOptions\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.Lambda.AliasOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.AddEventSource\\",
+            \\"name\\": \\"AddEventSource\\",
+            \\"snippet\\": \\"\`\`\`csharp\\\\nprivate AddEventSource(IEventSource Source)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Source\\",
+                \\"name\\": \\"Source\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.IEventSource\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.Lambda.IEventSource\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.AddEventSourceMapping\\",
+            \\"name\\": \\"AddEventSourceMapping\\",
+            \\"snippet\\": \\"\`\`\`csharp\\\\nprivate AddEventSourceMapping(string Id, EventSourceMappingOptions Options)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Id\\",
+                \\"name\\": \\"Id\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"name\\": \\"string\\"
+                }
+              },
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Options\\",
+                \\"name\\": \\"Options\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.EventSourceMappingOptions\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.Lambda.EventSourceMappingOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.AddPermission\\",
+            \\"name\\": \\"AddPermission\\",
+            \\"snippet\\": \\"\`\`\`csharp\\\\nprivate AddPermission(string Id, Permission Permission)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Id\\",
+                \\"name\\": \\"Id\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"name\\": \\"string\\"
+                }
+              },
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Permission\\",
+                \\"name\\": \\"Permission\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.Permission\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.Lambda.Permission\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.AddToRolePolicy\\",
+            \\"name\\": \\"AddToRolePolicy\\",
+            \\"snippet\\": \\"\`\`\`csharp\\\\nprivate AddToRolePolicy(PolicyStatement Statement)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Statement\\",
+                \\"name\\": \\"Statement\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-iam.PolicyStatement\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.IAM.PolicyStatement\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.ConfigureAsyncInvoke\\",
+            \\"name\\": \\"ConfigureAsyncInvoke\\",
+            \\"snippet\\": \\"\`\`\`csharp\\\\nprivate ConfigureAsyncInvoke(EventInvokeConfigOptions Options)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Options\\",
+                \\"name\\": \\"Options\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.EventInvokeConfigOptions\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.Lambda.EventInvokeConfigOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.GrantInvoke\\",
+            \\"name\\": \\"GrantInvoke\\",
+            \\"snippet\\": \\"\`\`\`csharp\\\\nprivate GrantInvoke(IGrantable Identity)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Identity\\",
+                \\"name\\": \\"Identity\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-iam.IGrantable\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.IAM.IGrantable\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Metric\\",
+            \\"name\\": \\"Metric\\",
+            \\"snippet\\": \\"\`\`\`csharp\\\\nprivate Metric(string MetricName, MetricOptions Props = null)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.MetricName\\",
+                \\"name\\": \\"MetricName\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"name\\": \\"string\\"
+                }
+              },
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Props\\",
+                \\"name\\": \\"Props\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.MetricOptions\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.CloudWatch.MetricOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.MetricDuration\\",
+            \\"name\\": \\"MetricDuration\\",
+            \\"snippet\\": \\"\`\`\`csharp\\\\nprivate MetricDuration(MetricOptions Props = null)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Props\\",
+                \\"name\\": \\"Props\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.MetricOptions\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.CloudWatch.MetricOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.MetricErrors\\",
+            \\"name\\": \\"MetricErrors\\",
+            \\"snippet\\": \\"\`\`\`csharp\\\\nprivate MetricErrors(MetricOptions Props = null)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Props\\",
+                \\"name\\": \\"Props\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.MetricOptions\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.CloudWatch.MetricOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.MetricInvocations\\",
+            \\"name\\": \\"MetricInvocations\\",
+            \\"snippet\\": \\"\`\`\`csharp\\\\nprivate MetricInvocations(MetricOptions Props = null)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Props\\",
+                \\"name\\": \\"Props\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.MetricOptions\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.CloudWatch.MetricOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.MetricThrottles\\",
+            \\"name\\": \\"MetricThrottles\\",
+            \\"snippet\\": \\"\`\`\`csharp\\\\nprivate MetricThrottles(MetricOptions Props = null)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Props\\",
+                \\"name\\": \\"Props\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.MetricOptions\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.CloudWatch.MetricOptions\\"
+                }
+              }
+            ]
+          }
+        ],
+        \\"staticFunctions\\": [],
+        \\"properties\\": [
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Connections\\",
+            \\"name\\": \\"Connections\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Not supported.\\\\n\\\\nConnections are only applicable to VPC-enabled functions.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-ec2.Connections\\",
+              \\"name\\": \\"Amazon.CDK.AWS.EC2.Connections\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.CurrentVersion\\",
+            \\"name\\": \\"CurrentVersion\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Convenience method to make \`EdgeFunction\` conform to the same interface as \`Function\`.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IVersion\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.IVersion\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.EdgeArn\\",
+            \\"name\\": \\"EdgeArn\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The ARN of the version for Lambda@Edge.\\",
+            \\"type\\": {
+              \\"name\\": \\"string\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.FunctionArn\\",
+            \\"name\\": \\"FunctionArn\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The ARN of the function.\\",
+            \\"type\\": {
+              \\"name\\": \\"string\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.FunctionName\\",
+            \\"name\\": \\"FunctionName\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The name of the function.\\",
+            \\"type\\": {
+              \\"name\\": \\"string\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.GrantPrincipal\\",
+            \\"name\\": \\"GrantPrincipal\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The principal to grant permissions to.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-iam.IPrincipal\\",
+              \\"name\\": \\"Amazon.CDK.AWS.IAM.IPrincipal\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.IsBoundToVpc\\",
+            \\"name\\": \\"IsBoundToVpc\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Whether or not this Lambda function was bound to a VPC.\\\\n\\\\nIf this is is \`false\`, trying to access the \`connections\` object will fail.\\",
+            \\"type\\": {
+              \\"name\\": \\"bool\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Lambda\\",
+            \\"name\\": \\"Lambda\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The underlying AWS Lambda function.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IFunction\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.IFunction\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.LatestVersion\\",
+            \\"name\\": \\"LatestVersion\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The \`$LATEST\` version of this function.\\\\n\\\\nNote that this is reference to a non-specific AWS Lambda version, which\\\\nmeans the function this version refers to can return different results in\\\\ndifferent invocations.\\\\n\\\\nTo obtain a reference to an explicit version which references the current\\\\nfunction configuration, use \`lambdaFunction.currentVersion\` instead.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IVersion\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.IVersion\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.PermissionsNode\\",
+            \\"name\\": \\"PermissionsNode\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The construct node where permissions are attached.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/core.ConstructNode\\",
+              \\"name\\": \\"Amazon.CDK.ConstructNode\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Version\\",
+            \\"name\\": \\"Version\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The most recently deployed version of this function.\\",
+            \\"type\\": {
+              \\"name\\": \\"string\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunction.Role\\",
+            \\"name\\": \\"Role\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The IAM role associated with this function.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+              \\"name\\": \\"Amazon.CDK.AWS.IAM.IRole\\"
+            }
+          }
+        ],
+        \\"constants\\": []
+      }
+    ],
+    \\"classes\\": [],
+    \\"structs\\": [
+      {
+        \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps\\",
+        \\"name\\": \\"EdgeFunctionProps\\",
+        \\"docs\\": \\"Properties for creating a Lambda@Edge function.\\",
+        \\"initializer\\": \\"\`\`\`csharp\\\\nusing Amazon.CDK.AWS.CloudFront;\\\\n\\\\nnew EdgeFunctionProps {\\\\n    Duration MaxEventAge = null,\\\\n    IDestination OnFailure = null,\\\\n    IDestination OnSuccess = null,\\\\n    double RetryAttempts = null,\\\\n    bool AllowAllOutbound = null,\\\\n    bool AllowPublicSubnet = null,\\\\n    Architecture[] Architectures = null,\\\\n    ICodeSigningConfig CodeSigningConfig = null,\\\\n    VersionOptions CurrentVersionOptions = null,\\\\n    IQueue DeadLetterQueue = null,\\\\n    bool DeadLetterQueueEnabled = null,\\\\n    string Description = null,\\\\n    System.Collections.Generic.IDictionary<string, string> Environment = null,\\\\n    IKey EnvironmentEncryption = null,\\\\n    IEventSource[] Events = null,\\\\n    FileSystem Filesystem = null,\\\\n    string FunctionName = null,\\\\n    PolicyStatement[] InitialPolicy = null,\\\\n    LambdaInsightsVersion InsightsVersion = null,\\\\n    ILayerVersion[] Layers = null,\\\\n    RetentionDays LogRetention = null,\\\\n    LogRetentionRetryOptions LogRetentionRetryOptions = null,\\\\n    IRole LogRetentionRole = null,\\\\n    double MemorySize = null,\\\\n    bool Profiling = null,\\\\n    IProfilingGroup ProfilingGroup = null,\\\\n    double ReservedConcurrentExecutions = null,\\\\n    IRole Role = null,\\\\n    ISecurityGroup SecurityGroup = null,\\\\n    ISecurityGroup[] SecurityGroups = null,\\\\n    Duration Timeout = null,\\\\n    Tracing Tracing = null,\\\\n    IVpc Vpc = null,\\\\n    SubnetSelection VpcSubnets = null,\\\\n    Code Code,\\\\n    string Handler,\\\\n    Runtime Runtime,\\\\n    string StackId = null\\\\n};\\\\n\`\`\`\\\\n\\",
+        \\"properties\\": [
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.MaxEventAge\\",
+            \\"name\\": \\"MaxEventAge\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The maximum age of a request that Lambda sends to a function for processing.\\\\n\\\\nMinimum: 60 seconds\\\\nMaximum: 6 hours\\",
+            \\"default\\": \\"Duration.hours(6)\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+              \\"name\\": \\"Amazon.CDK.Duration\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.OnFailure\\",
+            \\"name\\": \\"OnFailure\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The destination for failed invocations.\\",
+            \\"default\\": \\"- no destination\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.IDestination\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.OnSuccess\\",
+            \\"name\\": \\"OnSuccess\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The destination for successful invocations.\\",
+            \\"default\\": \\"- no destination\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.IDestination\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.RetryAttempts\\",
+            \\"name\\": \\"RetryAttempts\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The maximum number of times to retry when the function returns an error.\\\\n\\\\nMinimum: 0\\\\nMaximum: 2\\",
+            \\"default\\": \\"2\\",
+            \\"type\\": {
+              \\"name\\": \\"double\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.AllowAllOutbound\\",
+            \\"name\\": \\"AllowAllOutbound\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Whether to allow the Lambda to send all network traffic.\\\\n\\\\nIf set to false, you must individually add traffic rules to allow the\\\\nLambda to connect to network targets.\\",
+            \\"default\\": \\"true\\",
+            \\"type\\": {
+              \\"name\\": \\"bool\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.AllowPublicSubnet\\",
+            \\"name\\": \\"AllowPublicSubnet\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Lambda Functions in a public subnet can NOT access the internet.\\\\n\\\\nUse this property to acknowledge this limitation and still place the function in a public subnet.\\",
+            \\"default\\": \\"false\\",
+            \\"type\\": {
+              \\"name\\": \\"bool\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Architectures\\",
+            \\"name\\": \\"Architectures\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The system architectures compatible with this lambda function.\\",
+            \\"default\\": \\"[Architecture.X86_64]\\",
+            \\"type\\": {
+              \\"name\\": \\"%[]\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.Architecture\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.Lambda.Architecture\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.CodeSigningConfig\\",
+            \\"name\\": \\"CodeSigningConfig\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Code signing config associated with this function.\\",
+            \\"default\\": \\"- Not Sign the Code\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.ICodeSigningConfig\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.ICodeSigningConfig\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.CurrentVersionOptions\\",
+            \\"name\\": \\"CurrentVersionOptions\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Options for the \`lambda.Version\` resource automatically created by the \`fn.currentVersion\` method.\\",
+            \\"default\\": \\"- default options as described in \`VersionOptions\`\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.VersionOptions\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.VersionOptions\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.DeadLetterQueue\\",
+            \\"name\\": \\"DeadLetterQueue\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The SQS queue to use if DLQ is enabled.\\",
+            \\"default\\": \\"- SQS queue with 14 day retention period if \`deadLetterQueueEnabled\` is \`true\`\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-sqs.IQueue\\",
+              \\"name\\": \\"Amazon.CDK.AWS.SQS.IQueue\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.DeadLetterQueueEnabled\\",
+            \\"name\\": \\"DeadLetterQueueEnabled\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Enabled DLQ.\\\\n\\\\nIf \`deadLetterQueue\` is undefined,\\\\nan SQS queue with default options will be defined for your Function.\\",
+            \\"default\\": \\"- false unless \`deadLetterQueue\` is set, which implies DLQ is enabled.\\",
+            \\"type\\": {
+              \\"name\\": \\"bool\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Description\\",
+            \\"name\\": \\"Description\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"A description of the function.\\",
+            \\"default\\": \\"- No description.\\",
+            \\"type\\": {
+              \\"name\\": \\"string\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Environment\\",
+            \\"name\\": \\"Environment\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Key-value pairs that Lambda caches and makes available for your Lambda functions.\\\\n\\\\nUse environment variables to apply configuration changes, such\\\\nas test and production environment configurations, without changing your\\\\nLambda function source code.\\",
+            \\"default\\": \\"- No environment variables.\\",
+            \\"type\\": {
+              \\"name\\": \\"System.Collections.Generic.IDictionary<string, %>\\",
+              \\"types\\": [
+                {
+                  \\"name\\": \\"string\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.EnvironmentEncryption\\",
+            \\"name\\": \\"EnvironmentEncryption\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The AWS KMS key that's used to encrypt your function's environment variables.\\",
+            \\"default\\": \\"- AWS Lambda creates and uses an AWS managed customer master key (CMK).\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-kms.IKey\\",
+              \\"name\\": \\"Amazon.CDK.AWS.KMS.IKey\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Events\\",
+            \\"name\\": \\"Events\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Event sources for this function.\\\\n\\\\nYou can also add event sources using \`addEventSource\`.\\",
+            \\"default\\": \\"- No event sources.\\",
+            \\"type\\": {
+              \\"name\\": \\"%[]\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.IEventSource\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.Lambda.IEventSource\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Filesystem\\",
+            \\"name\\": \\"Filesystem\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The filesystem configuration for the lambda function.\\",
+            \\"default\\": \\"- will not mount any filesystem\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.FileSystem\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.FileSystem\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.FunctionName\\",
+            \\"name\\": \\"FunctionName\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"A name for the function.\\",
+            \\"default\\": \\"- AWS CloudFormation generates a unique physical ID and uses that\\\\nID for the function's name. For more information, see Name Type.\\",
+            \\"type\\": {
+              \\"name\\": \\"string\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.InitialPolicy\\",
+            \\"name\\": \\"InitialPolicy\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Initial policy statements to add to the created Lambda Role.\\\\n\\\\nYou can call \`addToRolePolicy\` to the created lambda to add statements post creation.\\",
+            \\"default\\": \\"- No policy statements are added to the created Lambda role.\\",
+            \\"type\\": {
+              \\"name\\": \\"%[]\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-iam.PolicyStatement\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.IAM.PolicyStatement\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.InsightsVersion\\",
+            \\"name\\": \\"InsightsVersion\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Specify the version of CloudWatch Lambda insights to use for monitoring.\\",
+            \\"default\\": \\"- No Lambda Insights\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.LambdaInsightsVersion\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.LambdaInsightsVersion\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Layers\\",
+            \\"name\\": \\"Layers\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"A list of layers to add to the function's execution environment.\\\\n\\\\nYou can configure your Lambda function to pull in\\\\nadditional code during initialization in the form of layers. Layers are packages of libraries or other dependencies\\\\nthat can be used by multiple functions.\\",
+            \\"default\\": \\"- No layers.\\",
+            \\"type\\": {
+              \\"name\\": \\"%[]\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.ILayerVersion\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.Lambda.ILayerVersion\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.LogRetention\\",
+            \\"name\\": \\"LogRetention\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The number of days log events are kept in CloudWatch Logs.\\\\n\\\\nWhen updating\\\\nthis property, unsetting it doesn't remove the log retention policy. To\\\\nremove the retention policy, set the value to \`INFINITE\`.\\",
+            \\"default\\": \\"logs.RetentionDays.INFINITE\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-logs.RetentionDays\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Logs.RetentionDays\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.LogRetentionRetryOptions\\",
+            \\"name\\": \\"LogRetentionRetryOptions\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"When log retention is specified, a custom resource attempts to create the CloudWatch log group.\\\\n\\\\nThese options control the retry policy when interacting with CloudWatch APIs.\\",
+            \\"default\\": \\"- Default AWS SDK retry options.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.LogRetentionRetryOptions\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.LogRetentionRetryOptions\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.LogRetentionRole\\",
+            \\"name\\": \\"LogRetentionRole\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The IAM role for the Lambda function associated with the custom resource that sets the retention policy.\\",
+            \\"default\\": \\"- A new role is created.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+              \\"name\\": \\"Amazon.CDK.AWS.IAM.IRole\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.MemorySize\\",
+            \\"name\\": \\"MemorySize\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The amount of memory, in MB, that is allocated to your Lambda function.\\\\n\\\\nLambda uses this value to proportionally allocate the amount of CPU\\\\npower. For more information, see Resource Model in the AWS Lambda\\\\nDeveloper Guide.\\",
+            \\"default\\": \\"128\\",
+            \\"type\\": {
+              \\"name\\": \\"double\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Profiling\\",
+            \\"name\\": \\"Profiling\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Enable profiling.\\",
+            \\"default\\": \\"- No profiling.\\",
+            \\"type\\": {
+              \\"name\\": \\"bool\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.ProfilingGroup\\",
+            \\"name\\": \\"ProfilingGroup\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Profiling Group.\\",
+            \\"default\\": \\"- A new profiling group will be created if \`profiling\` is set.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-codeguruprofiler.IProfilingGroup\\",
+              \\"name\\": \\"Amazon.CDK.AWS.CodeGuruProfiler.IProfilingGroup\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.ReservedConcurrentExecutions\\",
+            \\"name\\": \\"ReservedConcurrentExecutions\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The maximum of concurrent executions you want to reserve for the function.\\",
+            \\"default\\": \\"- No specific limit - account limit.\\",
+            \\"type\\": {
+              \\"name\\": \\"double\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Role\\",
+            \\"name\\": \\"Role\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Lambda execution role.\\\\n\\\\nThis is the role that will be assumed by the function upon execution.\\\\nIt controls the permissions that the function will have. The Role must\\\\nbe assumable by the 'lambda.amazonaws.com' service principal.\\\\n\\\\nThe default Role automatically has permissions granted for Lambda execution. If you\\\\nprovide a Role, you must add the relevant AWS managed policies yourself.\\\\n\\\\nThe relevant managed policies are \\\\\\"service-role/AWSLambdaBasicExecutionRole\\\\\\" and\\\\n\\\\\\"service-role/AWSLambdaVPCAccessExecutionRole\\\\\\".\\",
+            \\"default\\": \\"- A unique role will be generated for this lambda function.\\\\nBoth supplied and generated roles can always be changed by calling \`addToRolePolicy\`.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+              \\"name\\": \\"Amazon.CDK.AWS.IAM.IRole\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.SecurityGroup\\",
+            \\"name\\": \\"SecurityGroup\\",
+            \\"optional\\": true,
+            \\"deprecated\\": true,
+            \\"deprecationReason\\": \\"- This property is deprecated, use securityGroups instead\\",
+            \\"docs\\": \\"What security group to associate with the Lambda's network interfaces. This property is being deprecated, consider using securityGroups instead.\\\\n\\\\nOnly used if 'vpc' is supplied.\\\\n\\\\nUse securityGroups property instead.\\\\nFunction constructor will throw an error if both are specified.\\",
+            \\"default\\": \\"- If the function is placed within a VPC and a security group is\\\\nnot specified, either by this or securityGroups prop, a dedicated security\\\\ngroup will be created for this function.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-ec2.ISecurityGroup\\",
+              \\"name\\": \\"Amazon.CDK.AWS.EC2.ISecurityGroup\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.SecurityGroups\\",
+            \\"name\\": \\"SecurityGroups\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The list of security groups to associate with the Lambda's network interfaces.\\\\n\\\\nOnly used if 'vpc' is supplied.\\",
+            \\"default\\": \\"- If the function is placed within a VPC and a security group is\\\\nnot specified, either by this or securityGroup prop, a dedicated security\\\\ngroup will be created for this function.\\",
+            \\"type\\": {
+              \\"name\\": \\"%[]\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-ec2.ISecurityGroup\\",
+                  \\"name\\": \\"Amazon.CDK.AWS.EC2.ISecurityGroup\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Timeout\\",
+            \\"name\\": \\"Timeout\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The function execution time (in seconds) after which Lambda terminates the function.\\\\n\\\\nBecause the execution time affects cost, set this value\\\\nbased on the function's expected execution time.\\",
+            \\"default\\": \\"Duration.seconds(3)\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+              \\"name\\": \\"Amazon.CDK.Duration\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Tracing\\",
+            \\"name\\": \\"Tracing\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Enable AWS X-Ray Tracing for Lambda Function.\\",
+            \\"default\\": \\"Tracing.Disabled\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.Tracing\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.Tracing\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Vpc\\",
+            \\"name\\": \\"Vpc\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"VPC network to place Lambda network interfaces.\\\\n\\\\nSpecify this if the Lambda function needs to access resources in a VPC.\\",
+            \\"default\\": \\"- Function is not placed within a VPC.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-ec2.IVpc\\",
+              \\"name\\": \\"Amazon.CDK.AWS.EC2.IVpc\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.VpcSubnets\\",
+            \\"name\\": \\"VpcSubnets\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Where to place the network interfaces within the VPC.\\\\n\\\\nOnly used if 'vpc' is supplied. Note: internet access for Lambdas\\\\nrequires a NAT gateway, so picking Public subnets is not allowed.\\",
+            \\"default\\": \\"- the Vpc default strategy if not specified\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-ec2.SubnetSelection\\",
+              \\"name\\": \\"Amazon.CDK.AWS.EC2.SubnetSelection\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Code\\",
+            \\"name\\": \\"Code\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The source code of your Lambda function.\\\\n\\\\nYou can point to a file in an\\\\nAmazon Simple Storage Service (Amazon S3) bucket or specify your source\\\\ncode as inline text.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.Code\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.Code\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Handler\\",
+            \\"name\\": \\"Handler\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The name of the method within your code that Lambda calls to execute your function.\\\\n\\\\nThe format includes the file name. It can also include\\\\nnamespaces and other qualifiers, depending on the runtime.\\\\nFor more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.\\\\n\\\\nUse \`Handler.FROM_IMAGE\` when defining a function from a Docker image.\\\\n\\\\nNOTE: If you specify your source code as inline text by specifying the\\\\nZipFile property within the Code property, specify index.function_name as\\\\nthe handler.\\",
+            \\"type\\": {
+              \\"name\\": \\"string\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.Runtime\\",
+            \\"name\\": \\"Runtime\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The runtime environment for the Lambda function that you are uploading.\\\\n\\\\nFor valid values, see the Runtime property in the AWS Lambda Developer\\\\nGuide.\\\\n\\\\nUse \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.Runtime\\",
+              \\"name\\": \\"Amazon.CDK.AWS.Lambda.Runtime\\"
+            }
+          },
+          {
+            \\"id\\": \\"Amazon.CDK.AWS.CloudFront.experimental.EdgeFunctionProps.StackId\\",
+            \\"name\\": \\"StackId\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The stack ID of Lambda@Edge function.\\",
+            \\"default\\": \\"- \`edge-lambda-stack-\${region}\`\\",
+            \\"type\\": {
+              \\"name\\": \\"string\\"
+            }
+          }
+        ]
+      }
+    ],
+    \\"interfaces\\": [],
+    \\"enums\\": []
+  }
+}"
+`;
+
+exports[`submodules without an explicit name csharp markdown 1`] = `
 "
 # API Reference <a name=\\"API Reference\\"></a>
 
@@ -1020,7 +1953,1401 @@ The stack ID of Lambda@Edge function.
 "
 `;
 
-exports[`submodules without an explicit name java 1`] = `
+exports[`submodules without an explicit name java json 1`] = `
+"{
+  \\"readme\\": \\"\\",
+  \\"apiReference\\": {
+    \\"constructs\\": [
+      {
+        \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction\\",
+        \\"name\\": \\"EdgeFunction\\",
+        \\"interfaces\\": [
+          {
+            \\"fqn\\": \\"@aws-cdk/aws-lambda.IVersion\\",
+            \\"name\\": \\"software.amazon.awscdk.services.lambda.IVersion\\"
+          }
+        ],
+        \\"docs\\": \\"A Lambda@Edge function.\\\\n\\\\nConvenience resource for requesting a Lambda function in the 'us-east-1' region for use with Lambda@Edge.\\\\nImplements several restrictions enforced by Lambda@Edge.\\\\n\\\\nNote that this construct requires that the 'us-east-1' region has been bootstrapped.\\\\nSee https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html or 'cdk bootstrap --help' for options.\\",
+        \\"initializer\\": {
+          \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.Initializer\\",
+          \\"snippet\\": \\"\`\`\`java\\\\nimport software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction;\\\\n\\\\nEdgeFunction.Builder.create(Construct scope, java.lang.String id)\\\\n//  .maxEventAge(Duration)\\\\n//  .onFailure(IDestination)\\\\n//  .onSuccess(IDestination)\\\\n//  .retryAttempts(java.lang.Number)\\\\n//  .allowAllOutbound(java.lang.Boolean)\\\\n//  .allowPublicSubnet(java.lang.Boolean)\\\\n//  .architectures(java.util.List<Architecture>)\\\\n//  .codeSigningConfig(ICodeSigningConfig)\\\\n//  .currentVersionOptions(VersionOptions)\\\\n//  .deadLetterQueue(IQueue)\\\\n//  .deadLetterQueueEnabled(java.lang.Boolean)\\\\n//  .description(java.lang.String)\\\\n//  .environment(java.util.Map<java.lang.String, java.lang.String>)\\\\n//  .environmentEncryption(IKey)\\\\n//  .events(java.util.List<IEventSource>)\\\\n//  .filesystem(FileSystem)\\\\n//  .functionName(java.lang.String)\\\\n//  .initialPolicy(java.util.List<PolicyStatement>)\\\\n//  .insightsVersion(LambdaInsightsVersion)\\\\n//  .layers(java.util.List<ILayerVersion>)\\\\n//  .logRetention(RetentionDays)\\\\n//  .logRetentionRetryOptions(LogRetentionRetryOptions)\\\\n//  .logRetentionRole(IRole)\\\\n//  .memorySize(java.lang.Number)\\\\n//  .profiling(java.lang.Boolean)\\\\n//  .profilingGroup(IProfilingGroup)\\\\n//  .reservedConcurrentExecutions(java.lang.Number)\\\\n//  .role(IRole)\\\\n//  .securityGroup(ISecurityGroup)\\\\n//  .securityGroups(java.util.List<ISecurityGroup>)\\\\n//  .timeout(Duration)\\\\n//  .tracing(Tracing)\\\\n//  .vpc(IVpc)\\\\n//  .vpcSubnets(SubnetSelection)\\\\n    .code(Code)\\\\n    .handler(java.lang.String)\\\\n    .runtime(Runtime)\\\\n//  .stackId(java.lang.String)\\\\n    .build();\\\\n\`\`\`\\\\n\\",
+          \\"parameters\\": [
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.scope\\",
+              \\"name\\": \\"scope\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"\\",
+              \\"type\\": {
+                \\"fqn\\": \\"constructs.Construct\\",
+                \\"name\\": \\"software.constructs.Construct\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.id\\",
+              \\"name\\": \\"id\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"\\",
+              \\"type\\": {
+                \\"name\\": \\"java.lang.String\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.maxEventAge\\",
+              \\"name\\": \\"maxEventAge\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The maximum age of a request that Lambda sends to a function for processing.\\\\n\\\\nMinimum: 60 seconds\\\\nMaximum: 6 hours\\",
+              \\"default\\": \\"Duration.hours(6)\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                \\"name\\": \\"software.amazon.awscdk.core.Duration\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.onFailure\\",
+              \\"name\\": \\"onFailure\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The destination for failed invocations.\\",
+              \\"default\\": \\"- no destination\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+                \\"name\\": \\"software.amazon.awscdk.services.lambda.IDestination\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.onSuccess\\",
+              \\"name\\": \\"onSuccess\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The destination for successful invocations.\\",
+              \\"default\\": \\"- no destination\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+                \\"name\\": \\"software.amazon.awscdk.services.lambda.IDestination\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.retryAttempts\\",
+              \\"name\\": \\"retryAttempts\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The maximum number of times to retry when the function returns an error.\\\\n\\\\nMinimum: 0\\\\nMaximum: 2\\",
+              \\"default\\": \\"2\\",
+              \\"type\\": {
+                \\"name\\": \\"java.lang.Number\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.allowAllOutbound\\",
+              \\"name\\": \\"allowAllOutbound\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Whether to allow the Lambda to send all network traffic.\\\\n\\\\nIf set to false, you must individually add traffic rules to allow the\\\\nLambda to connect to network targets.\\",
+              \\"default\\": \\"true\\",
+              \\"type\\": {
+                \\"name\\": \\"java.lang.Boolean\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.allowPublicSubnet\\",
+              \\"name\\": \\"allowPublicSubnet\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Lambda Functions in a public subnet can NOT access the internet.\\\\n\\\\nUse this property to acknowledge this limitation and still place the function in a public subnet.\\",
+              \\"default\\": \\"false\\",
+              \\"type\\": {
+                \\"name\\": \\"java.lang.Boolean\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.architectures\\",
+              \\"name\\": \\"architectures\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The system architectures compatible with this lambda function.\\",
+              \\"default\\": \\"[Architecture.X86_64]\\",
+              \\"type\\": {
+                \\"name\\": \\"java.util.List<%>\\",
+                \\"types\\": [
+                  {
+                    \\"fqn\\": \\"@aws-cdk/aws-lambda.Architecture\\",
+                    \\"name\\": \\"software.amazon.awscdk.services.lambda.Architecture\\"
+                  }
+                ]
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.codeSigningConfig\\",
+              \\"name\\": \\"codeSigningConfig\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Code signing config associated with this function.\\",
+              \\"default\\": \\"- Not Sign the Code\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.ICodeSigningConfig\\",
+                \\"name\\": \\"software.amazon.awscdk.services.lambda.ICodeSigningConfig\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.currentVersionOptions\\",
+              \\"name\\": \\"currentVersionOptions\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Options for the \`lambda.Version\` resource automatically created by the \`fn.currentVersion\` method.\\",
+              \\"default\\": \\"- default options as described in \`VersionOptions\`\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.VersionOptions\\",
+                \\"name\\": \\"software.amazon.awscdk.services.lambda.VersionOptions\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.deadLetterQueue\\",
+              \\"name\\": \\"deadLetterQueue\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The SQS queue to use if DLQ is enabled.\\",
+              \\"default\\": \\"- SQS queue with 14 day retention period if \`deadLetterQueueEnabled\` is \`true\`\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-sqs.IQueue\\",
+                \\"name\\": \\"software.amazon.awscdk.services.sqs.IQueue\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.deadLetterQueueEnabled\\",
+              \\"name\\": \\"deadLetterQueueEnabled\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Enabled DLQ.\\\\n\\\\nIf \`deadLetterQueue\` is undefined,\\\\nan SQS queue with default options will be defined for your Function.\\",
+              \\"default\\": \\"- false unless \`deadLetterQueue\` is set, which implies DLQ is enabled.\\",
+              \\"type\\": {
+                \\"name\\": \\"java.lang.Boolean\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.description\\",
+              \\"name\\": \\"description\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"A description of the function.\\",
+              \\"default\\": \\"- No description.\\",
+              \\"type\\": {
+                \\"name\\": \\"java.lang.String\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.environment\\",
+              \\"name\\": \\"environment\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Key-value pairs that Lambda caches and makes available for your Lambda functions.\\\\n\\\\nUse environment variables to apply configuration changes, such\\\\nas test and production environment configurations, without changing your\\\\nLambda function source code.\\",
+              \\"default\\": \\"- No environment variables.\\",
+              \\"type\\": {
+                \\"name\\": \\"java.util.Map<java.lang.String, %>\\",
+                \\"types\\": [
+                  {
+                    \\"name\\": \\"java.lang.String\\"
+                  }
+                ]
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.environmentEncryption\\",
+              \\"name\\": \\"environmentEncryption\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The AWS KMS key that's used to encrypt your function's environment variables.\\",
+              \\"default\\": \\"- AWS Lambda creates and uses an AWS managed customer master key (CMK).\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-kms.IKey\\",
+                \\"name\\": \\"software.amazon.awscdk.services.kms.IKey\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.events\\",
+              \\"name\\": \\"events\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Event sources for this function.\\\\n\\\\nYou can also add event sources using \`addEventSource\`.\\",
+              \\"default\\": \\"- No event sources.\\",
+              \\"type\\": {
+                \\"name\\": \\"java.util.List<%>\\",
+                \\"types\\": [
+                  {
+                    \\"fqn\\": \\"@aws-cdk/aws-lambda.IEventSource\\",
+                    \\"name\\": \\"software.amazon.awscdk.services.lambda.IEventSource\\"
+                  }
+                ]
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.filesystem\\",
+              \\"name\\": \\"filesystem\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The filesystem configuration for the lambda function.\\",
+              \\"default\\": \\"- will not mount any filesystem\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.FileSystem\\",
+                \\"name\\": \\"software.amazon.awscdk.services.lambda.FileSystem\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.functionName\\",
+              \\"name\\": \\"functionName\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"A name for the function.\\",
+              \\"default\\": \\"- AWS CloudFormation generates a unique physical ID and uses that\\\\nID for the function's name. For more information, see Name Type.\\",
+              \\"type\\": {
+                \\"name\\": \\"java.lang.String\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.initialPolicy\\",
+              \\"name\\": \\"initialPolicy\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Initial policy statements to add to the created Lambda Role.\\\\n\\\\nYou can call \`addToRolePolicy\` to the created lambda to add statements post creation.\\",
+              \\"default\\": \\"- No policy statements are added to the created Lambda role.\\",
+              \\"type\\": {
+                \\"name\\": \\"java.util.List<%>\\",
+                \\"types\\": [
+                  {
+                    \\"fqn\\": \\"@aws-cdk/aws-iam.PolicyStatement\\",
+                    \\"name\\": \\"software.amazon.awscdk.services.iam.PolicyStatement\\"
+                  }
+                ]
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.insightsVersion\\",
+              \\"name\\": \\"insightsVersion\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Specify the version of CloudWatch Lambda insights to use for monitoring.\\",
+              \\"default\\": \\"- No Lambda Insights\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.LambdaInsightsVersion\\",
+                \\"name\\": \\"software.amazon.awscdk.services.lambda.LambdaInsightsVersion\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.layers\\",
+              \\"name\\": \\"layers\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"A list of layers to add to the function's execution environment.\\\\n\\\\nYou can configure your Lambda function to pull in\\\\nadditional code during initialization in the form of layers. Layers are packages of libraries or other dependencies\\\\nthat can be used by multiple functions.\\",
+              \\"default\\": \\"- No layers.\\",
+              \\"type\\": {
+                \\"name\\": \\"java.util.List<%>\\",
+                \\"types\\": [
+                  {
+                    \\"fqn\\": \\"@aws-cdk/aws-lambda.ILayerVersion\\",
+                    \\"name\\": \\"software.amazon.awscdk.services.lambda.ILayerVersion\\"
+                  }
+                ]
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.logRetention\\",
+              \\"name\\": \\"logRetention\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The number of days log events are kept in CloudWatch Logs.\\\\n\\\\nWhen updating\\\\nthis property, unsetting it doesn't remove the log retention policy. To\\\\nremove the retention policy, set the value to \`INFINITE\`.\\",
+              \\"default\\": \\"logs.RetentionDays.INFINITE\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-logs.RetentionDays\\",
+                \\"name\\": \\"software.amazon.awscdk.services.logs.RetentionDays\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.logRetentionRetryOptions\\",
+              \\"name\\": \\"logRetentionRetryOptions\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"When log retention is specified, a custom resource attempts to create the CloudWatch log group.\\\\n\\\\nThese options control the retry policy when interacting with CloudWatch APIs.\\",
+              \\"default\\": \\"- Default AWS SDK retry options.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.LogRetentionRetryOptions\\",
+                \\"name\\": \\"software.amazon.awscdk.services.lambda.LogRetentionRetryOptions\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.logRetentionRole\\",
+              \\"name\\": \\"logRetentionRole\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The IAM role for the Lambda function associated with the custom resource that sets the retention policy.\\",
+              \\"default\\": \\"- A new role is created.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+                \\"name\\": \\"software.amazon.awscdk.services.iam.IRole\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.memorySize\\",
+              \\"name\\": \\"memorySize\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The amount of memory, in MB, that is allocated to your Lambda function.\\\\n\\\\nLambda uses this value to proportionally allocate the amount of CPU\\\\npower. For more information, see Resource Model in the AWS Lambda\\\\nDeveloper Guide.\\",
+              \\"default\\": \\"128\\",
+              \\"type\\": {
+                \\"name\\": \\"java.lang.Number\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.profiling\\",
+              \\"name\\": \\"profiling\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Enable profiling.\\",
+              \\"default\\": \\"- No profiling.\\",
+              \\"type\\": {
+                \\"name\\": \\"java.lang.Boolean\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.profilingGroup\\",
+              \\"name\\": \\"profilingGroup\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Profiling Group.\\",
+              \\"default\\": \\"- A new profiling group will be created if \`profiling\` is set.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-codeguruprofiler.IProfilingGroup\\",
+                \\"name\\": \\"software.amazon.awscdk.services.codeguruprofiler.IProfilingGroup\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.reservedConcurrentExecutions\\",
+              \\"name\\": \\"reservedConcurrentExecutions\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The maximum of concurrent executions you want to reserve for the function.\\",
+              \\"default\\": \\"- No specific limit - account limit.\\",
+              \\"type\\": {
+                \\"name\\": \\"java.lang.Number\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.role\\",
+              \\"name\\": \\"role\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Lambda execution role.\\\\n\\\\nThis is the role that will be assumed by the function upon execution.\\\\nIt controls the permissions that the function will have. The Role must\\\\nbe assumable by the 'lambda.amazonaws.com' service principal.\\\\n\\\\nThe default Role automatically has permissions granted for Lambda execution. If you\\\\nprovide a Role, you must add the relevant AWS managed policies yourself.\\\\n\\\\nThe relevant managed policies are \\\\\\"service-role/AWSLambdaBasicExecutionRole\\\\\\" and\\\\n\\\\\\"service-role/AWSLambdaVPCAccessExecutionRole\\\\\\".\\",
+              \\"default\\": \\"- A unique role will be generated for this lambda function.\\\\nBoth supplied and generated roles can always be changed by calling \`addToRolePolicy\`.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+                \\"name\\": \\"software.amazon.awscdk.services.iam.IRole\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.securityGroup\\",
+              \\"name\\": \\"securityGroup\\",
+              \\"optional\\": true,
+              \\"deprecated\\": true,
+              \\"deprecationReason\\": \\"- This property is deprecated, use securityGroups instead\\",
+              \\"docs\\": \\"What security group to associate with the Lambda's network interfaces. This property is being deprecated, consider using securityGroups instead.\\\\n\\\\nOnly used if 'vpc' is supplied.\\\\n\\\\nUse securityGroups property instead.\\\\nFunction constructor will throw an error if both are specified.\\",
+              \\"default\\": \\"- If the function is placed within a VPC and a security group is\\\\nnot specified, either by this or securityGroups prop, a dedicated security\\\\ngroup will be created for this function.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-ec2.ISecurityGroup\\",
+                \\"name\\": \\"software.amazon.awscdk.services.ec2.ISecurityGroup\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.securityGroups\\",
+              \\"name\\": \\"securityGroups\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The list of security groups to associate with the Lambda's network interfaces.\\\\n\\\\nOnly used if 'vpc' is supplied.\\",
+              \\"default\\": \\"- If the function is placed within a VPC and a security group is\\\\nnot specified, either by this or securityGroup prop, a dedicated security\\\\ngroup will be created for this function.\\",
+              \\"type\\": {
+                \\"name\\": \\"java.util.List<%>\\",
+                \\"types\\": [
+                  {
+                    \\"fqn\\": \\"@aws-cdk/aws-ec2.ISecurityGroup\\",
+                    \\"name\\": \\"software.amazon.awscdk.services.ec2.ISecurityGroup\\"
+                  }
+                ]
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.timeout\\",
+              \\"name\\": \\"timeout\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The function execution time (in seconds) after which Lambda terminates the function.\\\\n\\\\nBecause the execution time affects cost, set this value\\\\nbased on the function's expected execution time.\\",
+              \\"default\\": \\"Duration.seconds(3)\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                \\"name\\": \\"software.amazon.awscdk.core.Duration\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.tracing\\",
+              \\"name\\": \\"tracing\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Enable AWS X-Ray Tracing for Lambda Function.\\",
+              \\"default\\": \\"Tracing.Disabled\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.Tracing\\",
+                \\"name\\": \\"software.amazon.awscdk.services.lambda.Tracing\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.vpc\\",
+              \\"name\\": \\"vpc\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"VPC network to place Lambda network interfaces.\\\\n\\\\nSpecify this if the Lambda function needs to access resources in a VPC.\\",
+              \\"default\\": \\"- Function is not placed within a VPC.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-ec2.IVpc\\",
+                \\"name\\": \\"software.amazon.awscdk.services.ec2.IVpc\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.vpcSubnets\\",
+              \\"name\\": \\"vpcSubnets\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Where to place the network interfaces within the VPC.\\\\n\\\\nOnly used if 'vpc' is supplied. Note: internet access for Lambdas\\\\nrequires a NAT gateway, so picking Public subnets is not allowed.\\",
+              \\"default\\": \\"- the Vpc default strategy if not specified\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-ec2.SubnetSelection\\",
+                \\"name\\": \\"software.amazon.awscdk.services.ec2.SubnetSelection\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.code\\",
+              \\"name\\": \\"code\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The source code of your Lambda function.\\\\n\\\\nYou can point to a file in an\\\\nAmazon Simple Storage Service (Amazon S3) bucket or specify your source\\\\ncode as inline text.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.Code\\",
+                \\"name\\": \\"software.amazon.awscdk.services.lambda.Code\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.handler\\",
+              \\"name\\": \\"handler\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The name of the method within your code that Lambda calls to execute your function.\\\\n\\\\nThe format includes the file name. It can also include\\\\nnamespaces and other qualifiers, depending on the runtime.\\\\nFor more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.\\\\n\\\\nUse \`Handler.FROM_IMAGE\` when defining a function from a Docker image.\\\\n\\\\nNOTE: If you specify your source code as inline text by specifying the\\\\nZipFile property within the Code property, specify index.function_name as\\\\nthe handler.\\",
+              \\"type\\": {
+                \\"name\\": \\"java.lang.String\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.runtime\\",
+              \\"name\\": \\"runtime\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The runtime environment for the Lambda function that you are uploading.\\\\n\\\\nFor valid values, see the Runtime property in the AWS Lambda Developer\\\\nGuide.\\\\n\\\\nUse \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.Runtime\\",
+                \\"name\\": \\"software.amazon.awscdk.services.lambda.Runtime\\"
+              }
+            },
+            {
+              \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.stackId\\",
+              \\"name\\": \\"stackId\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The stack ID of Lambda@Edge function.\\",
+              \\"default\\": \\"- \`edge-lambda-stack-\${region}\`\\",
+              \\"type\\": {
+                \\"name\\": \\"java.lang.String\\"
+              }
+            }
+          ]
+        },
+        \\"instanceMethods\\": [
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.addAlias\\",
+            \\"name\\": \\"addAlias\\",
+            \\"snippet\\": \\"\`\`\`java\\\\npublic addAlias(java.lang.String aliasName)\\\\npublic addAlias(java.lang.String aliasName, AliasOptions options)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.aliasName\\",
+                \\"name\\": \\"aliasName\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"name\\": \\"java.lang.String\\"
+                }
+              },
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.options\\",
+                \\"name\\": \\"options\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.AliasOptions\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.lambda.AliasOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.addEventSource\\",
+            \\"name\\": \\"addEventSource\\",
+            \\"snippet\\": \\"\`\`\`java\\\\npublic addEventSource(IEventSource source)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.source\\",
+                \\"name\\": \\"source\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.IEventSource\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.lambda.IEventSource\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.addEventSourceMapping\\",
+            \\"name\\": \\"addEventSourceMapping\\",
+            \\"snippet\\": \\"\`\`\`java\\\\npublic addEventSourceMapping(java.lang.String id, EventSourceMappingOptions options)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.id\\",
+                \\"name\\": \\"id\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"name\\": \\"java.lang.String\\"
+                }
+              },
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.options\\",
+                \\"name\\": \\"options\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.EventSourceMappingOptions\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.lambda.EventSourceMappingOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.addPermission\\",
+            \\"name\\": \\"addPermission\\",
+            \\"snippet\\": \\"\`\`\`java\\\\npublic addPermission(java.lang.String id, Permission permission)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.id\\",
+                \\"name\\": \\"id\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"name\\": \\"java.lang.String\\"
+                }
+              },
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.permission\\",
+                \\"name\\": \\"permission\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.Permission\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.lambda.Permission\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.addToRolePolicy\\",
+            \\"name\\": \\"addToRolePolicy\\",
+            \\"snippet\\": \\"\`\`\`java\\\\npublic addToRolePolicy(PolicyStatement statement)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.statement\\",
+                \\"name\\": \\"statement\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-iam.PolicyStatement\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.iam.PolicyStatement\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.configureAsyncInvoke\\",
+            \\"name\\": \\"configureAsyncInvoke\\",
+            \\"snippet\\": \\"\`\`\`java\\\\npublic configureAsyncInvoke(EventInvokeConfigOptions options)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.options\\",
+                \\"name\\": \\"options\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.EventInvokeConfigOptions\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.lambda.EventInvokeConfigOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.grantInvoke\\",
+            \\"name\\": \\"grantInvoke\\",
+            \\"snippet\\": \\"\`\`\`java\\\\npublic grantInvoke(IGrantable identity)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.identity\\",
+                \\"name\\": \\"identity\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-iam.IGrantable\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.iam.IGrantable\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.metric\\",
+            \\"name\\": \\"metric\\",
+            \\"snippet\\": \\"\`\`\`java\\\\npublic metric(java.lang.String metricName)\\\\npublic metric(java.lang.String metricName, MetricOptions props)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.metricName\\",
+                \\"name\\": \\"metricName\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"name\\": \\"java.lang.String\\"
+                }
+              },
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.props\\",
+                \\"name\\": \\"props\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.MetricOptions\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.cloudwatch.MetricOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.metricDuration\\",
+            \\"name\\": \\"metricDuration\\",
+            \\"snippet\\": \\"\`\`\`java\\\\npublic metricDuration()\\\\npublic metricDuration(MetricOptions props)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.props\\",
+                \\"name\\": \\"props\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.MetricOptions\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.cloudwatch.MetricOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.metricErrors\\",
+            \\"name\\": \\"metricErrors\\",
+            \\"snippet\\": \\"\`\`\`java\\\\npublic metricErrors()\\\\npublic metricErrors(MetricOptions props)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.props\\",
+                \\"name\\": \\"props\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.MetricOptions\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.cloudwatch.MetricOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.metricInvocations\\",
+            \\"name\\": \\"metricInvocations\\",
+            \\"snippet\\": \\"\`\`\`java\\\\npublic metricInvocations()\\\\npublic metricInvocations(MetricOptions props)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.props\\",
+                \\"name\\": \\"props\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.MetricOptions\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.cloudwatch.MetricOptions\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.metricThrottles\\",
+            \\"name\\": \\"metricThrottles\\",
+            \\"snippet\\": \\"\`\`\`java\\\\npublic metricThrottles()\\\\npublic metricThrottles(MetricOptions props)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.props\\",
+                \\"name\\": \\"props\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.MetricOptions\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.cloudwatch.MetricOptions\\"
+                }
+              }
+            ]
+          }
+        ],
+        \\"staticFunctions\\": [],
+        \\"properties\\": [
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.connections\\",
+            \\"name\\": \\"connections\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Not supported.\\\\n\\\\nConnections are only applicable to VPC-enabled functions.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-ec2.Connections\\",
+              \\"name\\": \\"software.amazon.awscdk.services.ec2.Connections\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.currentVersion\\",
+            \\"name\\": \\"currentVersion\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Convenience method to make \`EdgeFunction\` conform to the same interface as \`Function\`.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IVersion\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.IVersion\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.edgeArn\\",
+            \\"name\\": \\"edgeArn\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The ARN of the version for Lambda@Edge.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.String\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.functionArn\\",
+            \\"name\\": \\"functionArn\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The ARN of the function.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.String\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.functionName\\",
+            \\"name\\": \\"functionName\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The name of the function.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.String\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.grantPrincipal\\",
+            \\"name\\": \\"grantPrincipal\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The principal to grant permissions to.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-iam.IPrincipal\\",
+              \\"name\\": \\"software.amazon.awscdk.services.iam.IPrincipal\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.isBoundToVpc\\",
+            \\"name\\": \\"isBoundToVpc\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Whether or not this Lambda function was bound to a VPC.\\\\n\\\\nIf this is is \`false\`, trying to access the \`connections\` object will fail.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.Boolean\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.lambda\\",
+            \\"name\\": \\"lambda\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The underlying AWS Lambda function.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IFunction\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.IFunction\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.latestVersion\\",
+            \\"name\\": \\"latestVersion\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The \`$LATEST\` version of this function.\\\\n\\\\nNote that this is reference to a non-specific AWS Lambda version, which\\\\nmeans the function this version refers to can return different results in\\\\ndifferent invocations.\\\\n\\\\nTo obtain a reference to an explicit version which references the current\\\\nfunction configuration, use \`lambdaFunction.currentVersion\` instead.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IVersion\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.IVersion\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.permissionsNode\\",
+            \\"name\\": \\"permissionsNode\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The construct node where permissions are attached.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/core.ConstructNode\\",
+              \\"name\\": \\"software.amazon.awscdk.core.ConstructNode\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.version\\",
+            \\"name\\": \\"version\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The most recently deployed version of this function.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.String\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunction.role\\",
+            \\"name\\": \\"role\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The IAM role associated with this function.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+              \\"name\\": \\"software.amazon.awscdk.services.iam.IRole\\"
+            }
+          }
+        ],
+        \\"constants\\": []
+      }
+    ],
+    \\"classes\\": [],
+    \\"structs\\": [
+      {
+        \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps\\",
+        \\"name\\": \\"EdgeFunctionProps\\",
+        \\"docs\\": \\"Properties for creating a Lambda@Edge function.\\",
+        \\"initializer\\": \\"\`\`\`java\\\\nimport software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps;\\\\n\\\\nEdgeFunctionProps.builder()\\\\n//  .maxEventAge(Duration)\\\\n//  .onFailure(IDestination)\\\\n//  .onSuccess(IDestination)\\\\n//  .retryAttempts(java.lang.Number)\\\\n//  .allowAllOutbound(java.lang.Boolean)\\\\n//  .allowPublicSubnet(java.lang.Boolean)\\\\n//  .architectures(java.util.List<Architecture>)\\\\n//  .codeSigningConfig(ICodeSigningConfig)\\\\n//  .currentVersionOptions(VersionOptions)\\\\n//  .deadLetterQueue(IQueue)\\\\n//  .deadLetterQueueEnabled(java.lang.Boolean)\\\\n//  .description(java.lang.String)\\\\n//  .environment(java.util.Map<java.lang.String, java.lang.String>)\\\\n//  .environmentEncryption(IKey)\\\\n//  .events(java.util.List<IEventSource>)\\\\n//  .filesystem(FileSystem)\\\\n//  .functionName(java.lang.String)\\\\n//  .initialPolicy(java.util.List<PolicyStatement>)\\\\n//  .insightsVersion(LambdaInsightsVersion)\\\\n//  .layers(java.util.List<ILayerVersion>)\\\\n//  .logRetention(RetentionDays)\\\\n//  .logRetentionRetryOptions(LogRetentionRetryOptions)\\\\n//  .logRetentionRole(IRole)\\\\n//  .memorySize(java.lang.Number)\\\\n//  .profiling(java.lang.Boolean)\\\\n//  .profilingGroup(IProfilingGroup)\\\\n//  .reservedConcurrentExecutions(java.lang.Number)\\\\n//  .role(IRole)\\\\n//  .securityGroup(ISecurityGroup)\\\\n//  .securityGroups(java.util.List<ISecurityGroup>)\\\\n//  .timeout(Duration)\\\\n//  .tracing(Tracing)\\\\n//  .vpc(IVpc)\\\\n//  .vpcSubnets(SubnetSelection)\\\\n    .code(Code)\\\\n    .handler(java.lang.String)\\\\n    .runtime(Runtime)\\\\n//  .stackId(java.lang.String)\\\\n    .build();\\\\n\`\`\`\\\\n\\",
+        \\"properties\\": [
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.maxEventAge\\",
+            \\"name\\": \\"maxEventAge\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The maximum age of a request that Lambda sends to a function for processing.\\\\n\\\\nMinimum: 60 seconds\\\\nMaximum: 6 hours\\",
+            \\"default\\": \\"Duration.hours(6)\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+              \\"name\\": \\"software.amazon.awscdk.core.Duration\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.onFailure\\",
+            \\"name\\": \\"onFailure\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The destination for failed invocations.\\",
+            \\"default\\": \\"- no destination\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.IDestination\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.onSuccess\\",
+            \\"name\\": \\"onSuccess\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The destination for successful invocations.\\",
+            \\"default\\": \\"- no destination\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.IDestination\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.retryAttempts\\",
+            \\"name\\": \\"retryAttempts\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The maximum number of times to retry when the function returns an error.\\\\n\\\\nMinimum: 0\\\\nMaximum: 2\\",
+            \\"default\\": \\"2\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.Number\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.allowAllOutbound\\",
+            \\"name\\": \\"allowAllOutbound\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Whether to allow the Lambda to send all network traffic.\\\\n\\\\nIf set to false, you must individually add traffic rules to allow the\\\\nLambda to connect to network targets.\\",
+            \\"default\\": \\"true\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.Boolean\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.allowPublicSubnet\\",
+            \\"name\\": \\"allowPublicSubnet\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Lambda Functions in a public subnet can NOT access the internet.\\\\n\\\\nUse this property to acknowledge this limitation and still place the function in a public subnet.\\",
+            \\"default\\": \\"false\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.Boolean\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.architectures\\",
+            \\"name\\": \\"architectures\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The system architectures compatible with this lambda function.\\",
+            \\"default\\": \\"[Architecture.X86_64]\\",
+            \\"type\\": {
+              \\"name\\": \\"java.util.List<%>\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.Architecture\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.lambda.Architecture\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.codeSigningConfig\\",
+            \\"name\\": \\"codeSigningConfig\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Code signing config associated with this function.\\",
+            \\"default\\": \\"- Not Sign the Code\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.ICodeSigningConfig\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.ICodeSigningConfig\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.currentVersionOptions\\",
+            \\"name\\": \\"currentVersionOptions\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Options for the \`lambda.Version\` resource automatically created by the \`fn.currentVersion\` method.\\",
+            \\"default\\": \\"- default options as described in \`VersionOptions\`\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.VersionOptions\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.VersionOptions\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.deadLetterQueue\\",
+            \\"name\\": \\"deadLetterQueue\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The SQS queue to use if DLQ is enabled.\\",
+            \\"default\\": \\"- SQS queue with 14 day retention period if \`deadLetterQueueEnabled\` is \`true\`\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-sqs.IQueue\\",
+              \\"name\\": \\"software.amazon.awscdk.services.sqs.IQueue\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.deadLetterQueueEnabled\\",
+            \\"name\\": \\"deadLetterQueueEnabled\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Enabled DLQ.\\\\n\\\\nIf \`deadLetterQueue\` is undefined,\\\\nan SQS queue with default options will be defined for your Function.\\",
+            \\"default\\": \\"- false unless \`deadLetterQueue\` is set, which implies DLQ is enabled.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.Boolean\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.description\\",
+            \\"name\\": \\"description\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"A description of the function.\\",
+            \\"default\\": \\"- No description.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.String\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.environment\\",
+            \\"name\\": \\"environment\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Key-value pairs that Lambda caches and makes available for your Lambda functions.\\\\n\\\\nUse environment variables to apply configuration changes, such\\\\nas test and production environment configurations, without changing your\\\\nLambda function source code.\\",
+            \\"default\\": \\"- No environment variables.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.util.Map<java.lang.String, %>\\",
+              \\"types\\": [
+                {
+                  \\"name\\": \\"java.lang.String\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.environmentEncryption\\",
+            \\"name\\": \\"environmentEncryption\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The AWS KMS key that's used to encrypt your function's environment variables.\\",
+            \\"default\\": \\"- AWS Lambda creates and uses an AWS managed customer master key (CMK).\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-kms.IKey\\",
+              \\"name\\": \\"software.amazon.awscdk.services.kms.IKey\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.events\\",
+            \\"name\\": \\"events\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Event sources for this function.\\\\n\\\\nYou can also add event sources using \`addEventSource\`.\\",
+            \\"default\\": \\"- No event sources.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.util.List<%>\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.IEventSource\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.lambda.IEventSource\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.filesystem\\",
+            \\"name\\": \\"filesystem\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The filesystem configuration for the lambda function.\\",
+            \\"default\\": \\"- will not mount any filesystem\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.FileSystem\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.FileSystem\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.functionName\\",
+            \\"name\\": \\"functionName\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"A name for the function.\\",
+            \\"default\\": \\"- AWS CloudFormation generates a unique physical ID and uses that\\\\nID for the function's name. For more information, see Name Type.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.String\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.initialPolicy\\",
+            \\"name\\": \\"initialPolicy\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Initial policy statements to add to the created Lambda Role.\\\\n\\\\nYou can call \`addToRolePolicy\` to the created lambda to add statements post creation.\\",
+            \\"default\\": \\"- No policy statements are added to the created Lambda role.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.util.List<%>\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-iam.PolicyStatement\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.iam.PolicyStatement\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.insightsVersion\\",
+            \\"name\\": \\"insightsVersion\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Specify the version of CloudWatch Lambda insights to use for monitoring.\\",
+            \\"default\\": \\"- No Lambda Insights\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.LambdaInsightsVersion\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.LambdaInsightsVersion\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.layers\\",
+            \\"name\\": \\"layers\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"A list of layers to add to the function's execution environment.\\\\n\\\\nYou can configure your Lambda function to pull in\\\\nadditional code during initialization in the form of layers. Layers are packages of libraries or other dependencies\\\\nthat can be used by multiple functions.\\",
+            \\"default\\": \\"- No layers.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.util.List<%>\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.ILayerVersion\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.lambda.ILayerVersion\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.logRetention\\",
+            \\"name\\": \\"logRetention\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The number of days log events are kept in CloudWatch Logs.\\\\n\\\\nWhen updating\\\\nthis property, unsetting it doesn't remove the log retention policy. To\\\\nremove the retention policy, set the value to \`INFINITE\`.\\",
+            \\"default\\": \\"logs.RetentionDays.INFINITE\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-logs.RetentionDays\\",
+              \\"name\\": \\"software.amazon.awscdk.services.logs.RetentionDays\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.logRetentionRetryOptions\\",
+            \\"name\\": \\"logRetentionRetryOptions\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"When log retention is specified, a custom resource attempts to create the CloudWatch log group.\\\\n\\\\nThese options control the retry policy when interacting with CloudWatch APIs.\\",
+            \\"default\\": \\"- Default AWS SDK retry options.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.LogRetentionRetryOptions\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.LogRetentionRetryOptions\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.logRetentionRole\\",
+            \\"name\\": \\"logRetentionRole\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The IAM role for the Lambda function associated with the custom resource that sets the retention policy.\\",
+            \\"default\\": \\"- A new role is created.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+              \\"name\\": \\"software.amazon.awscdk.services.iam.IRole\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.memorySize\\",
+            \\"name\\": \\"memorySize\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The amount of memory, in MB, that is allocated to your Lambda function.\\\\n\\\\nLambda uses this value to proportionally allocate the amount of CPU\\\\npower. For more information, see Resource Model in the AWS Lambda\\\\nDeveloper Guide.\\",
+            \\"default\\": \\"128\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.Number\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.profiling\\",
+            \\"name\\": \\"profiling\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Enable profiling.\\",
+            \\"default\\": \\"- No profiling.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.Boolean\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.profilingGroup\\",
+            \\"name\\": \\"profilingGroup\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Profiling Group.\\",
+            \\"default\\": \\"- A new profiling group will be created if \`profiling\` is set.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-codeguruprofiler.IProfilingGroup\\",
+              \\"name\\": \\"software.amazon.awscdk.services.codeguruprofiler.IProfilingGroup\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.reservedConcurrentExecutions\\",
+            \\"name\\": \\"reservedConcurrentExecutions\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The maximum of concurrent executions you want to reserve for the function.\\",
+            \\"default\\": \\"- No specific limit - account limit.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.Number\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.role\\",
+            \\"name\\": \\"role\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Lambda execution role.\\\\n\\\\nThis is the role that will be assumed by the function upon execution.\\\\nIt controls the permissions that the function will have. The Role must\\\\nbe assumable by the 'lambda.amazonaws.com' service principal.\\\\n\\\\nThe default Role automatically has permissions granted for Lambda execution. If you\\\\nprovide a Role, you must add the relevant AWS managed policies yourself.\\\\n\\\\nThe relevant managed policies are \\\\\\"service-role/AWSLambdaBasicExecutionRole\\\\\\" and\\\\n\\\\\\"service-role/AWSLambdaVPCAccessExecutionRole\\\\\\".\\",
+            \\"default\\": \\"- A unique role will be generated for this lambda function.\\\\nBoth supplied and generated roles can always be changed by calling \`addToRolePolicy\`.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+              \\"name\\": \\"software.amazon.awscdk.services.iam.IRole\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.securityGroup\\",
+            \\"name\\": \\"securityGroup\\",
+            \\"optional\\": true,
+            \\"deprecated\\": true,
+            \\"deprecationReason\\": \\"- This property is deprecated, use securityGroups instead\\",
+            \\"docs\\": \\"What security group to associate with the Lambda's network interfaces. This property is being deprecated, consider using securityGroups instead.\\\\n\\\\nOnly used if 'vpc' is supplied.\\\\n\\\\nUse securityGroups property instead.\\\\nFunction constructor will throw an error if both are specified.\\",
+            \\"default\\": \\"- If the function is placed within a VPC and a security group is\\\\nnot specified, either by this or securityGroups prop, a dedicated security\\\\ngroup will be created for this function.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-ec2.ISecurityGroup\\",
+              \\"name\\": \\"software.amazon.awscdk.services.ec2.ISecurityGroup\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.securityGroups\\",
+            \\"name\\": \\"securityGroups\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The list of security groups to associate with the Lambda's network interfaces.\\\\n\\\\nOnly used if 'vpc' is supplied.\\",
+            \\"default\\": \\"- If the function is placed within a VPC and a security group is\\\\nnot specified, either by this or securityGroup prop, a dedicated security\\\\ngroup will be created for this function.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.util.List<%>\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-ec2.ISecurityGroup\\",
+                  \\"name\\": \\"software.amazon.awscdk.services.ec2.ISecurityGroup\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.timeout\\",
+            \\"name\\": \\"timeout\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The function execution time (in seconds) after which Lambda terminates the function.\\\\n\\\\nBecause the execution time affects cost, set this value\\\\nbased on the function's expected execution time.\\",
+            \\"default\\": \\"Duration.seconds(3)\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+              \\"name\\": \\"software.amazon.awscdk.core.Duration\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.tracing\\",
+            \\"name\\": \\"tracing\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Enable AWS X-Ray Tracing for Lambda Function.\\",
+            \\"default\\": \\"Tracing.Disabled\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.Tracing\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.Tracing\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.vpc\\",
+            \\"name\\": \\"vpc\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"VPC network to place Lambda network interfaces.\\\\n\\\\nSpecify this if the Lambda function needs to access resources in a VPC.\\",
+            \\"default\\": \\"- Function is not placed within a VPC.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-ec2.IVpc\\",
+              \\"name\\": \\"software.amazon.awscdk.services.ec2.IVpc\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.vpcSubnets\\",
+            \\"name\\": \\"vpcSubnets\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Where to place the network interfaces within the VPC.\\\\n\\\\nOnly used if 'vpc' is supplied. Note: internet access for Lambdas\\\\nrequires a NAT gateway, so picking Public subnets is not allowed.\\",
+            \\"default\\": \\"- the Vpc default strategy if not specified\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-ec2.SubnetSelection\\",
+              \\"name\\": \\"software.amazon.awscdk.services.ec2.SubnetSelection\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.code\\",
+            \\"name\\": \\"code\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The source code of your Lambda function.\\\\n\\\\nYou can point to a file in an\\\\nAmazon Simple Storage Service (Amazon S3) bucket or specify your source\\\\ncode as inline text.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.Code\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.Code\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.handler\\",
+            \\"name\\": \\"handler\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The name of the method within your code that Lambda calls to execute your function.\\\\n\\\\nThe format includes the file name. It can also include\\\\nnamespaces and other qualifiers, depending on the runtime.\\\\nFor more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.\\\\n\\\\nUse \`Handler.FROM_IMAGE\` when defining a function from a Docker image.\\\\n\\\\nNOTE: If you specify your source code as inline text by specifying the\\\\nZipFile property within the Code property, specify index.function_name as\\\\nthe handler.\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.String\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.runtime\\",
+            \\"name\\": \\"runtime\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The runtime environment for the Lambda function that you are uploading.\\\\n\\\\nFor valid values, see the Runtime property in the AWS Lambda Developer\\\\nGuide.\\\\n\\\\nUse \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.Runtime\\",
+              \\"name\\": \\"software.amazon.awscdk.services.lambda.Runtime\\"
+            }
+          },
+          {
+            \\"id\\": \\"software.amazon.awscdk.services.cloudfront.experimental.EdgeFunctionProps.stackId\\",
+            \\"name\\": \\"stackId\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The stack ID of Lambda@Edge function.\\",
+            \\"default\\": \\"- \`edge-lambda-stack-\${region}\`\\",
+            \\"type\\": {
+              \\"name\\": \\"java.lang.String\\"
+            }
+          }
+        ]
+      }
+    ],
+    \\"interfaces\\": [],
+    \\"enums\\": []
+  }
+}"
+`;
+
+exports[`submodules without an explicit name java markdown 1`] = `
 "
 # API Reference <a name=\\"API Reference\\"></a>
 
@@ -2516,7 +4843,2241 @@ The stack ID of Lambda@Edge function.
 "
 `;
 
-exports[`submodules without an explicit name python 1`] = `
+exports[`submodules without an explicit name python json 1`] = `
+"{
+  \\"readme\\": \\"\\",
+  \\"apiReference\\": {
+    \\"constructs\\": [
+      {
+        \\"id\\": \\"aws_cdk.experimental.EdgeFunction\\",
+        \\"name\\": \\"EdgeFunction\\",
+        \\"interfaces\\": [
+          {
+            \\"fqn\\": \\"@aws-cdk/aws-lambda.IVersion\\",
+            \\"name\\": \\"aws_cdk.aws_lambda.IVersion\\"
+          }
+        ],
+        \\"docs\\": \\"A Lambda@Edge function.\\\\n\\\\nConvenience resource for requesting a Lambda function in the 'us-east-1' region for use with Lambda@Edge.\\\\nImplements several restrictions enforced by Lambda@Edge.\\\\n\\\\nNote that this construct requires that the 'us-east-1' region has been bootstrapped.\\\\nSee https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html or 'cdk bootstrap --help' for options.\\",
+        \\"initializer\\": {
+          \\"id\\": \\"aws_cdk.experimental.EdgeFunction.Initializer\\",
+          \\"snippet\\": \\"\`\`\`python\\\\nfrom aws_cdk import aws_cloudfront\\\\n\\\\nexperimental.EdgeFunction(\\\\n  scope: Construct,\\\\n  id: str,\\\\n  max_event_age: Duration = None,\\\\n  on_failure: IDestination = None,\\\\n  on_success: IDestination = None,\\\\n  retry_attempts: typing.Union[int, float] = None,\\\\n  allow_all_outbound: bool = None,\\\\n  allow_public_subnet: bool = None,\\\\n  architectures: typing.List[Architecture] = None,\\\\n  code_signing_config: ICodeSigningConfig = None,\\\\n  current_version_options: VersionOptions = None,\\\\n  dead_letter_queue: IQueue = None,\\\\n  dead_letter_queue_enabled: bool = None,\\\\n  description: str = None,\\\\n  environment: typing.Mapping[str] = None,\\\\n  environment_encryption: IKey = None,\\\\n  events: typing.List[IEventSource] = None,\\\\n  filesystem: FileSystem = None,\\\\n  function_name: str = None,\\\\n  initial_policy: typing.List[PolicyStatement] = None,\\\\n  insights_version: LambdaInsightsVersion = None,\\\\n  layers: typing.List[ILayerVersion] = None,\\\\n  log_retention: RetentionDays = None,\\\\n  log_retention_retry_options: LogRetentionRetryOptions = None,\\\\n  log_retention_role: IRole = None,\\\\n  memory_size: typing.Union[int, float] = None,\\\\n  profiling: bool = None,\\\\n  profiling_group: IProfilingGroup = None,\\\\n  reserved_concurrent_executions: typing.Union[int, float] = None,\\\\n  role: IRole = None,\\\\n  security_group: ISecurityGroup = None,\\\\n  security_groups: typing.List[ISecurityGroup] = None,\\\\n  timeout: Duration = None,\\\\n  tracing: Tracing = None,\\\\n  vpc: IVpc = None,\\\\n  vpc_subnets: SubnetSelection = None,\\\\n  code: Code,\\\\n  handler: str,\\\\n  runtime: Runtime,\\\\n  stack_id: str = None\\\\n)\\\\n\`\`\`\\\\n\\",
+          \\"parameters\\": [
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunction.scope\\",
+              \\"name\\": \\"scope\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"\\",
+              \\"type\\": {
+                \\"fqn\\": \\"constructs.Construct\\",
+                \\"name\\": \\"constructs.Construct\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunction.id\\",
+              \\"name\\": \\"id\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"\\",
+              \\"type\\": {
+                \\"name\\": \\"str\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.max_event_age\\",
+              \\"name\\": \\"max_event_age\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The maximum age of a request that Lambda sends to a function for processing.\\\\n\\\\nMinimum: 60 seconds\\\\nMaximum: 6 hours\\",
+              \\"default\\": \\"Duration.hours(6)\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                \\"name\\": \\"aws_cdk.core.Duration\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.on_failure\\",
+              \\"name\\": \\"on_failure\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The destination for failed invocations.\\",
+              \\"default\\": \\"- no destination\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+                \\"name\\": \\"aws_cdk.aws_lambda.IDestination\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.on_success\\",
+              \\"name\\": \\"on_success\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The destination for successful invocations.\\",
+              \\"default\\": \\"- no destination\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+                \\"name\\": \\"aws_cdk.aws_lambda.IDestination\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.retry_attempts\\",
+              \\"name\\": \\"retry_attempts\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The maximum number of times to retry when the function returns an error.\\\\n\\\\nMinimum: 0\\\\nMaximum: 2\\",
+              \\"default\\": \\"2\\",
+              \\"type\\": {
+                \\"name\\": \\"typing.Union[int, float]\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.allow_all_outbound\\",
+              \\"name\\": \\"allow_all_outbound\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Whether to allow the Lambda to send all network traffic.\\\\n\\\\nIf set to false, you must individually add traffic rules to allow the\\\\nLambda to connect to network targets.\\",
+              \\"default\\": \\"true\\",
+              \\"type\\": {
+                \\"name\\": \\"bool\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.allow_public_subnet\\",
+              \\"name\\": \\"allow_public_subnet\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Lambda Functions in a public subnet can NOT access the internet.\\\\n\\\\nUse this property to acknowledge this limitation and still place the function in a public subnet.\\",
+              \\"default\\": \\"false\\",
+              \\"type\\": {
+                \\"name\\": \\"bool\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.architectures\\",
+              \\"name\\": \\"architectures\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The system architectures compatible with this lambda function.\\",
+              \\"default\\": \\"[Architecture.X86_64]\\",
+              \\"type\\": {
+                \\"name\\": \\"typing.List[%]\\",
+                \\"types\\": [
+                  {
+                    \\"fqn\\": \\"@aws-cdk/aws-lambda.Architecture\\",
+                    \\"name\\": \\"aws_cdk.aws_lambda.Architecture\\"
+                  }
+                ]
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.code_signing_config\\",
+              \\"name\\": \\"code_signing_config\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Code signing config associated with this function.\\",
+              \\"default\\": \\"- Not Sign the Code\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.ICodeSigningConfig\\",
+                \\"name\\": \\"aws_cdk.aws_lambda.ICodeSigningConfig\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.current_version_options\\",
+              \\"name\\": \\"current_version_options\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Options for the \`lambda.Version\` resource automatically created by the \`fn.currentVersion\` method.\\",
+              \\"default\\": \\"- default options as described in \`VersionOptions\`\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.VersionOptions\\",
+                \\"name\\": \\"aws_cdk.aws_lambda.VersionOptions\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.dead_letter_queue\\",
+              \\"name\\": \\"dead_letter_queue\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The SQS queue to use if DLQ is enabled.\\",
+              \\"default\\": \\"- SQS queue with 14 day retention period if \`deadLetterQueueEnabled\` is \`true\`\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-sqs.IQueue\\",
+                \\"name\\": \\"aws_cdk.aws_sqs.IQueue\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.dead_letter_queue_enabled\\",
+              \\"name\\": \\"dead_letter_queue_enabled\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Enabled DLQ.\\\\n\\\\nIf \`deadLetterQueue\` is undefined,\\\\nan SQS queue with default options will be defined for your Function.\\",
+              \\"default\\": \\"- false unless \`deadLetterQueue\` is set, which implies DLQ is enabled.\\",
+              \\"type\\": {
+                \\"name\\": \\"bool\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.description\\",
+              \\"name\\": \\"description\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"A description of the function.\\",
+              \\"default\\": \\"- No description.\\",
+              \\"type\\": {
+                \\"name\\": \\"str\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.environment\\",
+              \\"name\\": \\"environment\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Key-value pairs that Lambda caches and makes available for your Lambda functions.\\\\n\\\\nUse environment variables to apply configuration changes, such\\\\nas test and production environment configurations, without changing your\\\\nLambda function source code.\\",
+              \\"default\\": \\"- No environment variables.\\",
+              \\"type\\": {
+                \\"name\\": \\"typing.Mapping[%]\\",
+                \\"types\\": [
+                  {
+                    \\"name\\": \\"str\\"
+                  }
+                ]
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.environment_encryption\\",
+              \\"name\\": \\"environment_encryption\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The AWS KMS key that's used to encrypt your function's environment variables.\\",
+              \\"default\\": \\"- AWS Lambda creates and uses an AWS managed customer master key (CMK).\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-kms.IKey\\",
+                \\"name\\": \\"aws_cdk.aws_kms.IKey\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.events\\",
+              \\"name\\": \\"events\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Event sources for this function.\\\\n\\\\nYou can also add event sources using \`addEventSource\`.\\",
+              \\"default\\": \\"- No event sources.\\",
+              \\"type\\": {
+                \\"name\\": \\"typing.List[%]\\",
+                \\"types\\": [
+                  {
+                    \\"fqn\\": \\"@aws-cdk/aws-lambda.IEventSource\\",
+                    \\"name\\": \\"aws_cdk.aws_lambda.IEventSource\\"
+                  }
+                ]
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.filesystem\\",
+              \\"name\\": \\"filesystem\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The filesystem configuration for the lambda function.\\",
+              \\"default\\": \\"- will not mount any filesystem\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.FileSystem\\",
+                \\"name\\": \\"aws_cdk.aws_lambda.FileSystem\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.function_name\\",
+              \\"name\\": \\"function_name\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"A name for the function.\\",
+              \\"default\\": \\"- AWS CloudFormation generates a unique physical ID and uses that\\\\nID for the function's name. For more information, see Name Type.\\",
+              \\"type\\": {
+                \\"name\\": \\"str\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.initial_policy\\",
+              \\"name\\": \\"initial_policy\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Initial policy statements to add to the created Lambda Role.\\\\n\\\\nYou can call \`addToRolePolicy\` to the created lambda to add statements post creation.\\",
+              \\"default\\": \\"- No policy statements are added to the created Lambda role.\\",
+              \\"type\\": {
+                \\"name\\": \\"typing.List[%]\\",
+                \\"types\\": [
+                  {
+                    \\"fqn\\": \\"@aws-cdk/aws-iam.PolicyStatement\\",
+                    \\"name\\": \\"aws_cdk.aws_iam.PolicyStatement\\"
+                  }
+                ]
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.insights_version\\",
+              \\"name\\": \\"insights_version\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Specify the version of CloudWatch Lambda insights to use for monitoring.\\",
+              \\"default\\": \\"- No Lambda Insights\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.LambdaInsightsVersion\\",
+                \\"name\\": \\"aws_cdk.aws_lambda.LambdaInsightsVersion\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.layers\\",
+              \\"name\\": \\"layers\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"A list of layers to add to the function's execution environment.\\\\n\\\\nYou can configure your Lambda function to pull in\\\\nadditional code during initialization in the form of layers. Layers are packages of libraries or other dependencies\\\\nthat can be used by multiple functions.\\",
+              \\"default\\": \\"- No layers.\\",
+              \\"type\\": {
+                \\"name\\": \\"typing.List[%]\\",
+                \\"types\\": [
+                  {
+                    \\"fqn\\": \\"@aws-cdk/aws-lambda.ILayerVersion\\",
+                    \\"name\\": \\"aws_cdk.aws_lambda.ILayerVersion\\"
+                  }
+                ]
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.log_retention\\",
+              \\"name\\": \\"log_retention\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The number of days log events are kept in CloudWatch Logs.\\\\n\\\\nWhen updating\\\\nthis property, unsetting it doesn't remove the log retention policy. To\\\\nremove the retention policy, set the value to \`INFINITE\`.\\",
+              \\"default\\": \\"logs.RetentionDays.INFINITE\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-logs.RetentionDays\\",
+                \\"name\\": \\"aws_cdk.aws_logs.RetentionDays\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.log_retention_retry_options\\",
+              \\"name\\": \\"log_retention_retry_options\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"When log retention is specified, a custom resource attempts to create the CloudWatch log group.\\\\n\\\\nThese options control the retry policy when interacting with CloudWatch APIs.\\",
+              \\"default\\": \\"- Default AWS SDK retry options.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.LogRetentionRetryOptions\\",
+                \\"name\\": \\"aws_cdk.aws_lambda.LogRetentionRetryOptions\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.log_retention_role\\",
+              \\"name\\": \\"log_retention_role\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The IAM role for the Lambda function associated with the custom resource that sets the retention policy.\\",
+              \\"default\\": \\"- A new role is created.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+                \\"name\\": \\"aws_cdk.aws_iam.IRole\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.memory_size\\",
+              \\"name\\": \\"memory_size\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The amount of memory, in MB, that is allocated to your Lambda function.\\\\n\\\\nLambda uses this value to proportionally allocate the amount of CPU\\\\npower. For more information, see Resource Model in the AWS Lambda\\\\nDeveloper Guide.\\",
+              \\"default\\": \\"128\\",
+              \\"type\\": {
+                \\"name\\": \\"typing.Union[int, float]\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.profiling\\",
+              \\"name\\": \\"profiling\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Enable profiling.\\",
+              \\"default\\": \\"- No profiling.\\",
+              \\"type\\": {
+                \\"name\\": \\"bool\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.profiling_group\\",
+              \\"name\\": \\"profiling_group\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Profiling Group.\\",
+              \\"default\\": \\"- A new profiling group will be created if \`profiling\` is set.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-codeguruprofiler.IProfilingGroup\\",
+                \\"name\\": \\"aws_cdk.aws_codeguruprofiler.IProfilingGroup\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.reserved_concurrent_executions\\",
+              \\"name\\": \\"reserved_concurrent_executions\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The maximum of concurrent executions you want to reserve for the function.\\",
+              \\"default\\": \\"- No specific limit - account limit.\\",
+              \\"type\\": {
+                \\"name\\": \\"typing.Union[int, float]\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.role\\",
+              \\"name\\": \\"role\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Lambda execution role.\\\\n\\\\nThis is the role that will be assumed by the function upon execution.\\\\nIt controls the permissions that the function will have. The Role must\\\\nbe assumable by the 'lambda.amazonaws.com' service principal.\\\\n\\\\nThe default Role automatically has permissions granted for Lambda execution. If you\\\\nprovide a Role, you must add the relevant AWS managed policies yourself.\\\\n\\\\nThe relevant managed policies are \\\\\\"service-role/AWSLambdaBasicExecutionRole\\\\\\" and\\\\n\\\\\\"service-role/AWSLambdaVPCAccessExecutionRole\\\\\\".\\",
+              \\"default\\": \\"- A unique role will be generated for this lambda function.\\\\nBoth supplied and generated roles can always be changed by calling \`addToRolePolicy\`.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+                \\"name\\": \\"aws_cdk.aws_iam.IRole\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.security_group\\",
+              \\"name\\": \\"security_group\\",
+              \\"optional\\": true,
+              \\"deprecated\\": true,
+              \\"deprecationReason\\": \\"- This property is deprecated, use securityGroups instead\\",
+              \\"docs\\": \\"What security group to associate with the Lambda's network interfaces. This property is being deprecated, consider using securityGroups instead.\\\\n\\\\nOnly used if 'vpc' is supplied.\\\\n\\\\nUse securityGroups property instead.\\\\nFunction constructor will throw an error if both are specified.\\",
+              \\"default\\": \\"- If the function is placed within a VPC and a security group is\\\\nnot specified, either by this or securityGroups prop, a dedicated security\\\\ngroup will be created for this function.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-ec2.ISecurityGroup\\",
+                \\"name\\": \\"aws_cdk.aws_ec2.ISecurityGroup\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.security_groups\\",
+              \\"name\\": \\"security_groups\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The list of security groups to associate with the Lambda's network interfaces.\\\\n\\\\nOnly used if 'vpc' is supplied.\\",
+              \\"default\\": \\"- If the function is placed within a VPC and a security group is\\\\nnot specified, either by this or securityGroup prop, a dedicated security\\\\ngroup will be created for this function.\\",
+              \\"type\\": {
+                \\"name\\": \\"typing.List[%]\\",
+                \\"types\\": [
+                  {
+                    \\"fqn\\": \\"@aws-cdk/aws-ec2.ISecurityGroup\\",
+                    \\"name\\": \\"aws_cdk.aws_ec2.ISecurityGroup\\"
+                  }
+                ]
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.timeout\\",
+              \\"name\\": \\"timeout\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The function execution time (in seconds) after which Lambda terminates the function.\\\\n\\\\nBecause the execution time affects cost, set this value\\\\nbased on the function's expected execution time.\\",
+              \\"default\\": \\"Duration.seconds(3)\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                \\"name\\": \\"aws_cdk.core.Duration\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.tracing\\",
+              \\"name\\": \\"tracing\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Enable AWS X-Ray Tracing for Lambda Function.\\",
+              \\"default\\": \\"Tracing.Disabled\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.Tracing\\",
+                \\"name\\": \\"aws_cdk.aws_lambda.Tracing\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.vpc\\",
+              \\"name\\": \\"vpc\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"VPC network to place Lambda network interfaces.\\\\n\\\\nSpecify this if the Lambda function needs to access resources in a VPC.\\",
+              \\"default\\": \\"- Function is not placed within a VPC.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-ec2.IVpc\\",
+                \\"name\\": \\"aws_cdk.aws_ec2.IVpc\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.vpc_subnets\\",
+              \\"name\\": \\"vpc_subnets\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"Where to place the network interfaces within the VPC.\\\\n\\\\nOnly used if 'vpc' is supplied. Note: internet access for Lambdas\\\\nrequires a NAT gateway, so picking Public subnets is not allowed.\\",
+              \\"default\\": \\"- the Vpc default strategy if not specified\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-ec2.SubnetSelection\\",
+                \\"name\\": \\"aws_cdk.aws_ec2.SubnetSelection\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.code\\",
+              \\"name\\": \\"code\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The source code of your Lambda function.\\\\n\\\\nYou can point to a file in an\\\\nAmazon Simple Storage Service (Amazon S3) bucket or specify your source\\\\ncode as inline text.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.Code\\",
+                \\"name\\": \\"aws_cdk.aws_lambda.Code\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.handler\\",
+              \\"name\\": \\"handler\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The name of the method within your code that Lambda calls to execute your function.\\\\n\\\\nThe format includes the file name. It can also include\\\\nnamespaces and other qualifiers, depending on the runtime.\\\\nFor more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.\\\\n\\\\nUse \`Handler.FROM_IMAGE\` when defining a function from a Docker image.\\\\n\\\\nNOTE: If you specify your source code as inline text by specifying the\\\\nZipFile property within the Code property, specify index.function_name as\\\\nthe handler.\\",
+              \\"type\\": {
+                \\"name\\": \\"str\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.runtime\\",
+              \\"name\\": \\"runtime\\",
+              \\"optional\\": false,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The runtime environment for the Lambda function that you are uploading.\\\\n\\\\nFor valid values, see the Runtime property in the AWS Lambda Developer\\\\nGuide.\\\\n\\\\nUse \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.\\",
+              \\"type\\": {
+                \\"fqn\\": \\"@aws-cdk/aws-lambda.Runtime\\",
+                \\"name\\": \\"aws_cdk.aws_lambda.Runtime\\"
+              }
+            },
+            {
+              \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.stack_id\\",
+              \\"name\\": \\"stack_id\\",
+              \\"optional\\": true,
+              \\"deprecated\\": false,
+              \\"docs\\": \\"The stack ID of Lambda@Edge function.\\",
+              \\"default\\": \\"- \`edge-lambda-stack-\${region}\`\\",
+              \\"type\\": {
+                \\"name\\": \\"str\\"
+              }
+            }
+          ]
+        },
+        \\"instanceMethods\\": [
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.add_alias\\",
+            \\"name\\": \\"add_alias\\",
+            \\"snippet\\": \\"\`\`\`python\\\\ndef add_alias(\\\\n  alias_name: str,\\\\n  max_event_age: Duration = None,\\\\n  on_failure: IDestination = None,\\\\n  on_success: IDestination = None,\\\\n  retry_attempts: typing.Union[int, float] = None,\\\\n  additional_versions: typing.List[VersionWeight] = None,\\\\n  description: str = None,\\\\n  provisioned_concurrent_executions: typing.Union[int, float] = None\\\\n)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"aws_cdk.experimental.EdgeFunction.alias_name\\",
+                \\"name\\": \\"alias_name\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.AliasOptions.max_event_age\\",
+                \\"name\\": \\"max_event_age\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The maximum age of a request that Lambda sends to a function for processing.\\\\n\\\\nMinimum: 60 seconds\\\\nMaximum: 6 hours\\",
+                \\"default\\": \\"Duration.hours(6)\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                  \\"name\\": \\"aws_cdk.core.Duration\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.AliasOptions.on_failure\\",
+                \\"name\\": \\"on_failure\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The destination for failed invocations.\\",
+                \\"default\\": \\"- no destination\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+                  \\"name\\": \\"aws_cdk.aws_lambda.IDestination\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.AliasOptions.on_success\\",
+                \\"name\\": \\"on_success\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The destination for successful invocations.\\",
+                \\"default\\": \\"- no destination\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+                  \\"name\\": \\"aws_cdk.aws_lambda.IDestination\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.AliasOptions.retry_attempts\\",
+                \\"name\\": \\"retry_attempts\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The maximum number of times to retry when the function returns an error.\\\\n\\\\nMinimum: 0\\\\nMaximum: 2\\",
+                \\"default\\": \\"2\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Union[int, float]\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.AliasOptions.additional_versions\\",
+                \\"name\\": \\"additional_versions\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Additional versions with individual weights this alias points to.\\\\n\\\\nIndividual additional version weights specified here should add up to\\\\n(less than) one. All remaining weight is routed to the default\\\\nversion.\\\\n\\\\nFor example, the config is\\\\n\\\\n    version: \\\\\\"1\\\\\\"\\\\n    additionalVersions: [{ version: \\\\\\"2\\\\\\", weight: 0.05 }]\\\\n\\\\nThen 5% of traffic will be routed to function version 2, while\\\\nthe remaining 95% of traffic will be routed to function version 1.\\",
+                \\"default\\": \\"No additional versions\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.List[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"fqn\\": \\"@aws-cdk/aws-lambda.VersionWeight\\",
+                      \\"name\\": \\"aws_cdk.aws_lambda.VersionWeight\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.AliasOptions.description\\",
+                \\"name\\": \\"description\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Description for the alias.\\",
+                \\"default\\": \\"No description\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.AliasOptions.provisioned_concurrent_executions\\",
+                \\"name\\": \\"provisioned_concurrent_executions\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Specifies a provisioned concurrency configuration for a function's alias.\\",
+                \\"default\\": \\"No provisioned concurrency\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Union[int, float]\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.add_event_source\\",
+            \\"name\\": \\"add_event_source\\",
+            \\"snippet\\": \\"\`\`\`python\\\\ndef add_event_source(\\\\n  source: IEventSource\\\\n)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"aws_cdk.experimental.EdgeFunction.source\\",
+                \\"name\\": \\"source\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.IEventSource\\",
+                  \\"name\\": \\"aws_cdk.aws_lambda.IEventSource\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.add_event_source_mapping\\",
+            \\"name\\": \\"add_event_source_mapping\\",
+            \\"snippet\\": \\"\`\`\`python\\\\ndef add_event_source_mapping(\\\\n  id: str,\\\\n  batch_size: typing.Union[int, float] = None,\\\\n  bisect_batch_on_error: bool = None,\\\\n  enabled: bool = None,\\\\n  event_source_arn: str = None,\\\\n  kafka_bootstrap_servers: typing.List[str] = None,\\\\n  kafka_topic: str = None,\\\\n  max_batching_window: Duration = None,\\\\n  max_record_age: Duration = None,\\\\n  on_failure: IEventSourceDlq = None,\\\\n  parallelization_factor: typing.Union[int, float] = None,\\\\n  report_batch_item_failures: bool = None,\\\\n  retry_attempts: typing.Union[int, float] = None,\\\\n  source_access_configurations: typing.List[SourceAccessConfiguration] = None,\\\\n  starting_position: StartingPosition = None,\\\\n  tumbling_window: Duration = None\\\\n)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"aws_cdk.experimental.EdgeFunction.id\\",
+                \\"name\\": \\"id\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.batch_size\\",
+                \\"name\\": \\"batch_size\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The largest number of records that AWS Lambda will retrieve from your event source at the time of invoking your function.\\\\n\\\\nYour function receives an\\\\nevent with all the retrieved records.\\\\n\\\\nValid Range: Minimum value of 1. Maximum value of 10000.\\",
+                \\"default\\": \\"- Amazon Kinesis, Amazon DynamoDB, and Amazon MSK is 100 records.\\\\nBoth the default and maximum for Amazon SQS are 10 messages.\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Union[int, float]\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.bisect_batch_on_error\\",
+                \\"name\\": \\"bisect_batch_on_error\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"If the function returns an error, split the batch in two and retry.\\",
+                \\"default\\": \\"false\\",
+                \\"type\\": {
+                  \\"name\\": \\"bool\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.enabled\\",
+                \\"name\\": \\"enabled\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Set to false to disable the event source upon creation.\\",
+                \\"default\\": \\"true\\",
+                \\"type\\": {
+                  \\"name\\": \\"bool\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.event_source_arn\\",
+                \\"name\\": \\"event_source_arn\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The Amazon Resource Name (ARN) of the event source.\\\\n\\\\nAny record added to\\\\nthis stream can invoke the Lambda function.\\",
+                \\"default\\": \\"- not set if using a self managed Kafka cluster, throws an error otherwise\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.kafka_bootstrap_servers\\",
+                \\"name\\": \\"kafka_bootstrap_servers\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"A list of host and port pairs that are the addresses of the Kafka brokers in a self managed \\\\\\"bootstrap\\\\\\" Kafka cluster that a Kafka client connects to initially to bootstrap itself.\\\\n\\\\nThey are in the format \`abc.example.com:9096\`.\\",
+                \\"default\\": \\"- none\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.List[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"name\\": \\"str\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.kafka_topic\\",
+                \\"name\\": \\"kafka_topic\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The name of the Kafka topic.\\",
+                \\"default\\": \\"- no topic\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.max_batching_window\\",
+                \\"name\\": \\"max_batching_window\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The maximum amount of time to gather records before invoking the function.\\\\n\\\\nMaximum of Duration.minutes(5)\\",
+                \\"default\\": \\"Duration.seconds(0)\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                  \\"name\\": \\"aws_cdk.core.Duration\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.max_record_age\\",
+                \\"name\\": \\"max_record_age\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The maximum age of a record that Lambda sends to a function for processing.\\\\n\\\\nValid Range:\\\\n* Minimum value of 60 seconds\\\\n* Maximum value of 7 days\\",
+                \\"default\\": \\"- infinite or until the record expires.\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                  \\"name\\": \\"aws_cdk.core.Duration\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.on_failure\\",
+                \\"name\\": \\"on_failure\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"An Amazon SQS queue or Amazon SNS topic destination for discarded records.\\",
+                \\"default\\": \\"discarded records are ignored\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.IEventSourceDlq\\",
+                  \\"name\\": \\"aws_cdk.aws_lambda.IEventSourceDlq\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.parallelization_factor\\",
+                \\"name\\": \\"parallelization_factor\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The number of batches to process from each shard concurrently.\\\\n\\\\nValid Range:\\\\n* Minimum value of 1\\\\n* Maximum value of 10\\",
+                \\"default\\": \\"1\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Union[int, float]\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.report_batch_item_failures\\",
+                \\"name\\": \\"report_batch_item_failures\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Allow functions to return partially successful responses for a batch of records.\\",
+                \\"default\\": \\"false\\",
+                \\"type\\": {
+                  \\"name\\": \\"bool\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.retry_attempts\\",
+                \\"name\\": \\"retry_attempts\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The maximum number of times to retry when the function returns an error.\\\\n\\\\nSet to \`undefined\` if you want lambda to keep retrying infinitely or until\\\\nthe record expires.\\\\n\\\\nValid Range:\\\\n* Minimum value of 0\\\\n* Maximum value of 10000\\",
+                \\"default\\": \\"- infinite or until the record expires.\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Union[int, float]\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.source_access_configurations\\",
+                \\"name\\": \\"source_access_configurations\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Specific settings like the authentication protocol or the VPC components to secure access to your event source.\\",
+                \\"default\\": \\"- none\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.List[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"fqn\\": \\"@aws-cdk/aws-lambda.SourceAccessConfiguration\\",
+                      \\"name\\": \\"aws_cdk.aws_lambda.SourceAccessConfiguration\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.starting_position\\",
+                \\"name\\": \\"starting_position\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The position in the DynamoDB, Kinesis or MSK stream where AWS Lambda should start reading.\\",
+                \\"default\\": \\"- Required for Amazon Kinesis, Amazon DynamoDB, and Amazon MSK Streams sources.\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.StartingPosition\\",
+                  \\"name\\": \\"aws_cdk.aws_lambda.StartingPosition\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventSourceMappingOptions.tumbling_window\\",
+                \\"name\\": \\"tumbling_window\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The size of the tumbling windows to group records sent to DynamoDB or Kinesis.\\",
+                \\"default\\": \\"- None\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                  \\"name\\": \\"aws_cdk.core.Duration\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.add_permission\\",
+            \\"name\\": \\"add_permission\\",
+            \\"snippet\\": \\"\`\`\`python\\\\ndef add_permission(\\\\n  id: str,\\\\n  principal: IPrincipal,\\\\n  action: str = None,\\\\n  event_source_token: str = None,\\\\n  scope: Construct = None,\\\\n  source_account: str = None,\\\\n  source_arn: str = None\\\\n)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"aws_cdk.experimental.EdgeFunction.id\\",
+                \\"name\\": \\"id\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.Permission.principal\\",
+                \\"name\\": \\"principal\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The entity for which you are granting permission to invoke the Lambda function.\\\\n\\\\nThis entity can be any valid AWS service principal, such as\\\\ns3.amazonaws.com or sns.amazonaws.com, or, if you are granting\\\\ncross-account permission, an AWS account ID. For example, you might want\\\\nto allow a custom application in another AWS account to push events to\\\\nLambda by invoking your function.\\\\n\\\\nThe principal can be either an AccountPrincipal or a ServicePrincipal.\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-iam.IPrincipal\\",
+                  \\"name\\": \\"aws_cdk.aws_iam.IPrincipal\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.Permission.action\\",
+                \\"name\\": \\"action\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The Lambda actions that you want to allow in this statement.\\\\n\\\\nFor example,\\\\nyou can specify lambda:CreateFunction to specify a certain action, or use\\\\na wildcard (\`\`lambda:*\`\`) to grant permission to all Lambda actions. For a\\\\nlist of actions, see Actions and Condition Context Keys for AWS Lambda in\\\\nthe IAM User Guide.\\",
+                \\"default\\": \\"'lambda:InvokeFunction'\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.Permission.event_source_token\\",
+                \\"name\\": \\"event_source_token\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"A unique token that must be supplied by the principal invoking the function.\\",
+                \\"default\\": \\"The caller would not need to present a token.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.Permission.scope\\",
+                \\"name\\": \\"scope\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The scope to which the permission constructs be attached.\\\\n\\\\nThe default is\\\\nthe Lambda function construct itself, but this would need to be different\\\\nin cases such as cross-stack references where the Permissions would need\\\\nto sit closer to the consumer of this permission (i.e., the caller).\\",
+                \\"default\\": \\"- The instance of lambda.IFunction\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/core.Construct\\",
+                  \\"name\\": \\"aws_cdk.core.Construct\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.Permission.source_account\\",
+                \\"name\\": \\"source_account\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The AWS account ID (without hyphens) of the source owner.\\\\n\\\\nFor example, if\\\\nyou specify an S3 bucket in the SourceArn property, this value is the\\\\nbucket owner's account ID. You can use this property to ensure that all\\\\nsource principals are owned by a specific account.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.Permission.source_arn\\",
+                \\"name\\": \\"source_arn\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The ARN of a resource that is invoking your function.\\\\n\\\\nWhen granting\\\\nAmazon Simple Storage Service (Amazon S3) permission to invoke your\\\\nfunction, specify this property with the bucket ARN as its value. This\\\\nensures that events generated only from the specified bucket, not just\\\\nany bucket from any AWS account that creates a mapping to your function,\\\\ncan invoke the function.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.add_to_role_policy\\",
+            \\"name\\": \\"add_to_role_policy\\",
+            \\"snippet\\": \\"\`\`\`python\\\\ndef add_to_role_policy(\\\\n  statement: PolicyStatement\\\\n)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"aws_cdk.experimental.EdgeFunction.statement\\",
+                \\"name\\": \\"statement\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-iam.PolicyStatement\\",
+                  \\"name\\": \\"aws_cdk.aws_iam.PolicyStatement\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.configure_async_invoke\\",
+            \\"name\\": \\"configure_async_invoke\\",
+            \\"snippet\\": \\"\`\`\`python\\\\ndef configure_async_invoke(\\\\n  max_event_age: Duration = None,\\\\n  on_failure: IDestination = None,\\\\n  on_success: IDestination = None,\\\\n  retry_attempts: typing.Union[int, float] = None\\\\n)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventInvokeConfigOptions.max_event_age\\",
+                \\"name\\": \\"max_event_age\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The maximum age of a request that Lambda sends to a function for processing.\\\\n\\\\nMinimum: 60 seconds\\\\nMaximum: 6 hours\\",
+                \\"default\\": \\"Duration.hours(6)\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                  \\"name\\": \\"aws_cdk.core.Duration\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventInvokeConfigOptions.on_failure\\",
+                \\"name\\": \\"on_failure\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The destination for failed invocations.\\",
+                \\"default\\": \\"- no destination\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+                  \\"name\\": \\"aws_cdk.aws_lambda.IDestination\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventInvokeConfigOptions.on_success\\",
+                \\"name\\": \\"on_success\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The destination for successful invocations.\\",
+                \\"default\\": \\"- no destination\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+                  \\"name\\": \\"aws_cdk.aws_lambda.IDestination\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_lambda.EventInvokeConfigOptions.retry_attempts\\",
+                \\"name\\": \\"retry_attempts\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The maximum number of times to retry when the function returns an error.\\\\n\\\\nMinimum: 0\\\\nMaximum: 2\\",
+                \\"default\\": \\"2\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Union[int, float]\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.grant_invoke\\",
+            \\"name\\": \\"grant_invoke\\",
+            \\"snippet\\": \\"\`\`\`python\\\\ndef grant_invoke(\\\\n  identity: IGrantable\\\\n)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"aws_cdk.experimental.EdgeFunction.identity\\",
+                \\"name\\": \\"identity\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-iam.IGrantable\\",
+                  \\"name\\": \\"aws_cdk.aws_iam.IGrantable\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.metric\\",
+            \\"name\\": \\"metric\\",
+            \\"snippet\\": \\"\`\`\`python\\\\ndef metric(\\\\n  metric_name: str,\\\\n  account: str = None,\\\\n  color: str = None,\\\\n  dimensions: typing.Mapping[typing.Any] = None,\\\\n  dimensions_map: typing.Mapping[str] = None,\\\\n  label: str = None,\\\\n  period: Duration = None,\\\\n  region: str = None,\\\\n  statistic: str = None,\\\\n  unit: Unit = None\\\\n)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"aws_cdk.experimental.EdgeFunction.metric_name\\",
+                \\"name\\": \\"metric_name\\",
+                \\"optional\\": false,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.account\\",
+                \\"name\\": \\"account\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Account which this metric comes from.\\",
+                \\"default\\": \\"- Deployment account.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.color\\",
+                \\"name\\": \\"color\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The hex color code, prefixed with '#' (e.g. '#00ff00'), to use when this metric is rendered on a graph. The \`Color\` class has a set of standard colors that can be used here.\\",
+                \\"default\\": \\"- Automatic color\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.dimensions\\",
+                \\"name\\": \\"dimensions\\",
+                \\"optional\\": true,
+                \\"deprecated\\": true,
+                \\"deprecationReason\\": \\"Use 'dimensionsMap' instead.\\",
+                \\"docs\\": \\"Dimensions of the metric.\\",
+                \\"default\\": \\"- No dimensions.\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Mapping[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"name\\": \\"typing.Any\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.dimensions_map\\",
+                \\"name\\": \\"dimensions_map\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Dimensions of the metric.\\",
+                \\"default\\": \\"- No dimensions.\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Mapping[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"name\\": \\"str\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.label\\",
+                \\"name\\": \\"label\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Label for this metric when added to a Graph in a Dashboard.\\",
+                \\"default\\": \\"- No label\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.period\\",
+                \\"name\\": \\"period\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The period over which the specified statistic is applied.\\",
+                \\"default\\": \\"Duration.minutes(5)\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                  \\"name\\": \\"aws_cdk.core.Duration\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.region\\",
+                \\"name\\": \\"region\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Region which this metric comes from.\\",
+                \\"default\\": \\"- Deployment region.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.statistic\\",
+                \\"name\\": \\"statistic\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"What function to use for aggregating.\\\\n\\\\nCan be one of the following:\\\\n\\\\n- \\\\\\"Minimum\\\\\\" | \\\\\\"min\\\\\\"\\\\n- \\\\\\"Maximum\\\\\\" | \\\\\\"max\\\\\\"\\\\n- \\\\\\"Average\\\\\\" | \\\\\\"avg\\\\\\"\\\\n- \\\\\\"Sum\\\\\\" | \\\\\\"sum\\\\\\"\\\\n- \\\\\\"SampleCount | \\\\\\"n\\\\\\"\\\\n- \\\\\\"pNN.NN\\\\\\"\\",
+                \\"default\\": \\"Average\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.unit\\",
+                \\"name\\": \\"unit\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Unit used to filter the metric stream.\\\\n\\\\nOnly refer to datums emitted to the metric stream with the given unit and\\\\nignore all others. Only useful when datums are being emitted to the same\\\\nmetric stream under different units.\\\\n\\\\nThe default is to use all matric datums in the stream, regardless of unit,\\\\nwhich is recommended in nearly all cases.\\\\n\\\\nCloudWatch does not honor this property for graphs.\\",
+                \\"default\\": \\"- All metric datums in the given metric stream\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.Unit\\",
+                  \\"name\\": \\"aws_cdk.aws_cloudwatch.Unit\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.metric_duration\\",
+            \\"name\\": \\"metric_duration\\",
+            \\"snippet\\": \\"\`\`\`python\\\\ndef metric_duration(\\\\n  account: str = None,\\\\n  color: str = None,\\\\n  dimensions: typing.Mapping[typing.Any] = None,\\\\n  dimensions_map: typing.Mapping[str] = None,\\\\n  label: str = None,\\\\n  period: Duration = None,\\\\n  region: str = None,\\\\n  statistic: str = None,\\\\n  unit: Unit = None\\\\n)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.account\\",
+                \\"name\\": \\"account\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Account which this metric comes from.\\",
+                \\"default\\": \\"- Deployment account.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.color\\",
+                \\"name\\": \\"color\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The hex color code, prefixed with '#' (e.g. '#00ff00'), to use when this metric is rendered on a graph. The \`Color\` class has a set of standard colors that can be used here.\\",
+                \\"default\\": \\"- Automatic color\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.dimensions\\",
+                \\"name\\": \\"dimensions\\",
+                \\"optional\\": true,
+                \\"deprecated\\": true,
+                \\"deprecationReason\\": \\"Use 'dimensionsMap' instead.\\",
+                \\"docs\\": \\"Dimensions of the metric.\\",
+                \\"default\\": \\"- No dimensions.\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Mapping[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"name\\": \\"typing.Any\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.dimensions_map\\",
+                \\"name\\": \\"dimensions_map\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Dimensions of the metric.\\",
+                \\"default\\": \\"- No dimensions.\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Mapping[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"name\\": \\"str\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.label\\",
+                \\"name\\": \\"label\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Label for this metric when added to a Graph in a Dashboard.\\",
+                \\"default\\": \\"- No label\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.period\\",
+                \\"name\\": \\"period\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The period over which the specified statistic is applied.\\",
+                \\"default\\": \\"Duration.minutes(5)\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                  \\"name\\": \\"aws_cdk.core.Duration\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.region\\",
+                \\"name\\": \\"region\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Region which this metric comes from.\\",
+                \\"default\\": \\"- Deployment region.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.statistic\\",
+                \\"name\\": \\"statistic\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"What function to use for aggregating.\\\\n\\\\nCan be one of the following:\\\\n\\\\n- \\\\\\"Minimum\\\\\\" | \\\\\\"min\\\\\\"\\\\n- \\\\\\"Maximum\\\\\\" | \\\\\\"max\\\\\\"\\\\n- \\\\\\"Average\\\\\\" | \\\\\\"avg\\\\\\"\\\\n- \\\\\\"Sum\\\\\\" | \\\\\\"sum\\\\\\"\\\\n- \\\\\\"SampleCount | \\\\\\"n\\\\\\"\\\\n- \\\\\\"pNN.NN\\\\\\"\\",
+                \\"default\\": \\"Average\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.unit\\",
+                \\"name\\": \\"unit\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Unit used to filter the metric stream.\\\\n\\\\nOnly refer to datums emitted to the metric stream with the given unit and\\\\nignore all others. Only useful when datums are being emitted to the same\\\\nmetric stream under different units.\\\\n\\\\nThe default is to use all matric datums in the stream, regardless of unit,\\\\nwhich is recommended in nearly all cases.\\\\n\\\\nCloudWatch does not honor this property for graphs.\\",
+                \\"default\\": \\"- All metric datums in the given metric stream\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.Unit\\",
+                  \\"name\\": \\"aws_cdk.aws_cloudwatch.Unit\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.metric_errors\\",
+            \\"name\\": \\"metric_errors\\",
+            \\"snippet\\": \\"\`\`\`python\\\\ndef metric_errors(\\\\n  account: str = None,\\\\n  color: str = None,\\\\n  dimensions: typing.Mapping[typing.Any] = None,\\\\n  dimensions_map: typing.Mapping[str] = None,\\\\n  label: str = None,\\\\n  period: Duration = None,\\\\n  region: str = None,\\\\n  statistic: str = None,\\\\n  unit: Unit = None\\\\n)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.account\\",
+                \\"name\\": \\"account\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Account which this metric comes from.\\",
+                \\"default\\": \\"- Deployment account.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.color\\",
+                \\"name\\": \\"color\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The hex color code, prefixed with '#' (e.g. '#00ff00'), to use when this metric is rendered on a graph. The \`Color\` class has a set of standard colors that can be used here.\\",
+                \\"default\\": \\"- Automatic color\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.dimensions\\",
+                \\"name\\": \\"dimensions\\",
+                \\"optional\\": true,
+                \\"deprecated\\": true,
+                \\"deprecationReason\\": \\"Use 'dimensionsMap' instead.\\",
+                \\"docs\\": \\"Dimensions of the metric.\\",
+                \\"default\\": \\"- No dimensions.\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Mapping[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"name\\": \\"typing.Any\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.dimensions_map\\",
+                \\"name\\": \\"dimensions_map\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Dimensions of the metric.\\",
+                \\"default\\": \\"- No dimensions.\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Mapping[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"name\\": \\"str\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.label\\",
+                \\"name\\": \\"label\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Label for this metric when added to a Graph in a Dashboard.\\",
+                \\"default\\": \\"- No label\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.period\\",
+                \\"name\\": \\"period\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The period over which the specified statistic is applied.\\",
+                \\"default\\": \\"Duration.minutes(5)\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                  \\"name\\": \\"aws_cdk.core.Duration\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.region\\",
+                \\"name\\": \\"region\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Region which this metric comes from.\\",
+                \\"default\\": \\"- Deployment region.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.statistic\\",
+                \\"name\\": \\"statistic\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"What function to use for aggregating.\\\\n\\\\nCan be one of the following:\\\\n\\\\n- \\\\\\"Minimum\\\\\\" | \\\\\\"min\\\\\\"\\\\n- \\\\\\"Maximum\\\\\\" | \\\\\\"max\\\\\\"\\\\n- \\\\\\"Average\\\\\\" | \\\\\\"avg\\\\\\"\\\\n- \\\\\\"Sum\\\\\\" | \\\\\\"sum\\\\\\"\\\\n- \\\\\\"SampleCount | \\\\\\"n\\\\\\"\\\\n- \\\\\\"pNN.NN\\\\\\"\\",
+                \\"default\\": \\"Average\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.unit\\",
+                \\"name\\": \\"unit\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Unit used to filter the metric stream.\\\\n\\\\nOnly refer to datums emitted to the metric stream with the given unit and\\\\nignore all others. Only useful when datums are being emitted to the same\\\\nmetric stream under different units.\\\\n\\\\nThe default is to use all matric datums in the stream, regardless of unit,\\\\nwhich is recommended in nearly all cases.\\\\n\\\\nCloudWatch does not honor this property for graphs.\\",
+                \\"default\\": \\"- All metric datums in the given metric stream\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.Unit\\",
+                  \\"name\\": \\"aws_cdk.aws_cloudwatch.Unit\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.metric_invocations\\",
+            \\"name\\": \\"metric_invocations\\",
+            \\"snippet\\": \\"\`\`\`python\\\\ndef metric_invocations(\\\\n  account: str = None,\\\\n  color: str = None,\\\\n  dimensions: typing.Mapping[typing.Any] = None,\\\\n  dimensions_map: typing.Mapping[str] = None,\\\\n  label: str = None,\\\\n  period: Duration = None,\\\\n  region: str = None,\\\\n  statistic: str = None,\\\\n  unit: Unit = None\\\\n)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.account\\",
+                \\"name\\": \\"account\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Account which this metric comes from.\\",
+                \\"default\\": \\"- Deployment account.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.color\\",
+                \\"name\\": \\"color\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The hex color code, prefixed with '#' (e.g. '#00ff00'), to use when this metric is rendered on a graph. The \`Color\` class has a set of standard colors that can be used here.\\",
+                \\"default\\": \\"- Automatic color\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.dimensions\\",
+                \\"name\\": \\"dimensions\\",
+                \\"optional\\": true,
+                \\"deprecated\\": true,
+                \\"deprecationReason\\": \\"Use 'dimensionsMap' instead.\\",
+                \\"docs\\": \\"Dimensions of the metric.\\",
+                \\"default\\": \\"- No dimensions.\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Mapping[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"name\\": \\"typing.Any\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.dimensions_map\\",
+                \\"name\\": \\"dimensions_map\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Dimensions of the metric.\\",
+                \\"default\\": \\"- No dimensions.\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Mapping[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"name\\": \\"str\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.label\\",
+                \\"name\\": \\"label\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Label for this metric when added to a Graph in a Dashboard.\\",
+                \\"default\\": \\"- No label\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.period\\",
+                \\"name\\": \\"period\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The period over which the specified statistic is applied.\\",
+                \\"default\\": \\"Duration.minutes(5)\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                  \\"name\\": \\"aws_cdk.core.Duration\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.region\\",
+                \\"name\\": \\"region\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Region which this metric comes from.\\",
+                \\"default\\": \\"- Deployment region.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.statistic\\",
+                \\"name\\": \\"statistic\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"What function to use for aggregating.\\\\n\\\\nCan be one of the following:\\\\n\\\\n- \\\\\\"Minimum\\\\\\" | \\\\\\"min\\\\\\"\\\\n- \\\\\\"Maximum\\\\\\" | \\\\\\"max\\\\\\"\\\\n- \\\\\\"Average\\\\\\" | \\\\\\"avg\\\\\\"\\\\n- \\\\\\"Sum\\\\\\" | \\\\\\"sum\\\\\\"\\\\n- \\\\\\"SampleCount | \\\\\\"n\\\\\\"\\\\n- \\\\\\"pNN.NN\\\\\\"\\",
+                \\"default\\": \\"Average\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.unit\\",
+                \\"name\\": \\"unit\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Unit used to filter the metric stream.\\\\n\\\\nOnly refer to datums emitted to the metric stream with the given unit and\\\\nignore all others. Only useful when datums are being emitted to the same\\\\nmetric stream under different units.\\\\n\\\\nThe default is to use all matric datums in the stream, regardless of unit,\\\\nwhich is recommended in nearly all cases.\\\\n\\\\nCloudWatch does not honor this property for graphs.\\",
+                \\"default\\": \\"- All metric datums in the given metric stream\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.Unit\\",
+                  \\"name\\": \\"aws_cdk.aws_cloudwatch.Unit\\"
+                }
+              }
+            ]
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.metric_throttles\\",
+            \\"name\\": \\"metric_throttles\\",
+            \\"snippet\\": \\"\`\`\`python\\\\ndef metric_throttles(\\\\n  account: str = None,\\\\n  color: str = None,\\\\n  dimensions: typing.Mapping[typing.Any] = None,\\\\n  dimensions_map: typing.Mapping[str] = None,\\\\n  label: str = None,\\\\n  period: Duration = None,\\\\n  region: str = None,\\\\n  statistic: str = None,\\\\n  unit: Unit = None\\\\n)\\\\n\`\`\`\\\\n\\",
+            \\"parameters\\": [
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.account\\",
+                \\"name\\": \\"account\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Account which this metric comes from.\\",
+                \\"default\\": \\"- Deployment account.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.color\\",
+                \\"name\\": \\"color\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The hex color code, prefixed with '#' (e.g. '#00ff00'), to use when this metric is rendered on a graph. The \`Color\` class has a set of standard colors that can be used here.\\",
+                \\"default\\": \\"- Automatic color\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.dimensions\\",
+                \\"name\\": \\"dimensions\\",
+                \\"optional\\": true,
+                \\"deprecated\\": true,
+                \\"deprecationReason\\": \\"Use 'dimensionsMap' instead.\\",
+                \\"docs\\": \\"Dimensions of the metric.\\",
+                \\"default\\": \\"- No dimensions.\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Mapping[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"name\\": \\"typing.Any\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.dimensions_map\\",
+                \\"name\\": \\"dimensions_map\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Dimensions of the metric.\\",
+                \\"default\\": \\"- No dimensions.\\",
+                \\"type\\": {
+                  \\"name\\": \\"typing.Mapping[%]\\",
+                  \\"types\\": [
+                    {
+                      \\"name\\": \\"str\\"
+                    }
+                  ]
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.label\\",
+                \\"name\\": \\"label\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Label for this metric when added to a Graph in a Dashboard.\\",
+                \\"default\\": \\"- No label\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.period\\",
+                \\"name\\": \\"period\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"The period over which the specified statistic is applied.\\",
+                \\"default\\": \\"Duration.minutes(5)\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+                  \\"name\\": \\"aws_cdk.core.Duration\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.region\\",
+                \\"name\\": \\"region\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Region which this metric comes from.\\",
+                \\"default\\": \\"- Deployment region.\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.statistic\\",
+                \\"name\\": \\"statistic\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"What function to use for aggregating.\\\\n\\\\nCan be one of the following:\\\\n\\\\n- \\\\\\"Minimum\\\\\\" | \\\\\\"min\\\\\\"\\\\n- \\\\\\"Maximum\\\\\\" | \\\\\\"max\\\\\\"\\\\n- \\\\\\"Average\\\\\\" | \\\\\\"avg\\\\\\"\\\\n- \\\\\\"Sum\\\\\\" | \\\\\\"sum\\\\\\"\\\\n- \\\\\\"SampleCount | \\\\\\"n\\\\\\"\\\\n- \\\\\\"pNN.NN\\\\\\"\\",
+                \\"default\\": \\"Average\\",
+                \\"type\\": {
+                  \\"name\\": \\"str\\"
+                }
+              },
+              {
+                \\"id\\": \\"aws_cdk.aws_cloudwatch.MetricOptions.unit\\",
+                \\"name\\": \\"unit\\",
+                \\"optional\\": true,
+                \\"deprecated\\": false,
+                \\"docs\\": \\"Unit used to filter the metric stream.\\\\n\\\\nOnly refer to datums emitted to the metric stream with the given unit and\\\\nignore all others. Only useful when datums are being emitted to the same\\\\nmetric stream under different units.\\\\n\\\\nThe default is to use all matric datums in the stream, regardless of unit,\\\\nwhich is recommended in nearly all cases.\\\\n\\\\nCloudWatch does not honor this property for graphs.\\",
+                \\"default\\": \\"- All metric datums in the given metric stream\\",
+                \\"type\\": {
+                  \\"fqn\\": \\"@aws-cdk/aws-cloudwatch.Unit\\",
+                  \\"name\\": \\"aws_cdk.aws_cloudwatch.Unit\\"
+                }
+              }
+            ]
+          }
+        ],
+        \\"staticFunctions\\": [],
+        \\"properties\\": [
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.connections\\",
+            \\"name\\": \\"connections\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Not supported.\\\\n\\\\nConnections are only applicable to VPC-enabled functions.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-ec2.Connections\\",
+              \\"name\\": \\"aws_cdk.aws_ec2.Connections\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.current_version\\",
+            \\"name\\": \\"current_version\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Convenience method to make \`EdgeFunction\` conform to the same interface as \`Function\`.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IVersion\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.IVersion\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.edge_arn\\",
+            \\"name\\": \\"edge_arn\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The ARN of the version for Lambda@Edge.\\",
+            \\"type\\": {
+              \\"name\\": \\"str\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.function_arn\\",
+            \\"name\\": \\"function_arn\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The ARN of the function.\\",
+            \\"type\\": {
+              \\"name\\": \\"str\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.function_name\\",
+            \\"name\\": \\"function_name\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The name of the function.\\",
+            \\"type\\": {
+              \\"name\\": \\"str\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.grant_principal\\",
+            \\"name\\": \\"grant_principal\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The principal to grant permissions to.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-iam.IPrincipal\\",
+              \\"name\\": \\"aws_cdk.aws_iam.IPrincipal\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.is_bound_to_vpc\\",
+            \\"name\\": \\"is_bound_to_vpc\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Whether or not this Lambda function was bound to a VPC.\\\\n\\\\nIf this is is \`false\`, trying to access the \`connections\` object will fail.\\",
+            \\"type\\": {
+              \\"name\\": \\"bool\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.lambda\\",
+            \\"name\\": \\"lambda\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The underlying AWS Lambda function.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IFunction\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.IFunction\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.latest_version\\",
+            \\"name\\": \\"latest_version\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The \`$LATEST\` version of this function.\\\\n\\\\nNote that this is reference to a non-specific AWS Lambda version, which\\\\nmeans the function this version refers to can return different results in\\\\ndifferent invocations.\\\\n\\\\nTo obtain a reference to an explicit version which references the current\\\\nfunction configuration, use \`lambdaFunction.currentVersion\` instead.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IVersion\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.IVersion\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.permissions_node\\",
+            \\"name\\": \\"permissions_node\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The construct node where permissions are attached.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/core.ConstructNode\\",
+              \\"name\\": \\"aws_cdk.core.ConstructNode\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.version\\",
+            \\"name\\": \\"version\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The most recently deployed version of this function.\\",
+            \\"type\\": {
+              \\"name\\": \\"str\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunction.role\\",
+            \\"name\\": \\"role\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The IAM role associated with this function.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+              \\"name\\": \\"aws_cdk.aws_iam.IRole\\"
+            }
+          }
+        ],
+        \\"constants\\": []
+      }
+    ],
+    \\"classes\\": [],
+    \\"structs\\": [
+      {
+        \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps\\",
+        \\"name\\": \\"EdgeFunctionProps\\",
+        \\"docs\\": \\"Properties for creating a Lambda@Edge function.\\",
+        \\"initializer\\": \\"\`\`\`python\\\\nfrom aws_cdk import aws_cloudfront\\\\n\\\\nexperimental.EdgeFunctionProps(\\\\n  max_event_age: Duration = None,\\\\n  on_failure: IDestination = None,\\\\n  on_success: IDestination = None,\\\\n  retry_attempts: typing.Union[int, float] = None,\\\\n  allow_all_outbound: bool = None,\\\\n  allow_public_subnet: bool = None,\\\\n  architectures: typing.List[Architecture] = None,\\\\n  code_signing_config: ICodeSigningConfig = None,\\\\n  current_version_options: VersionOptions = None,\\\\n  dead_letter_queue: IQueue = None,\\\\n  dead_letter_queue_enabled: bool = None,\\\\n  description: str = None,\\\\n  environment: typing.Mapping[str] = None,\\\\n  environment_encryption: IKey = None,\\\\n  events: typing.List[IEventSource] = None,\\\\n  filesystem: FileSystem = None,\\\\n  function_name: str = None,\\\\n  initial_policy: typing.List[PolicyStatement] = None,\\\\n  insights_version: LambdaInsightsVersion = None,\\\\n  layers: typing.List[ILayerVersion] = None,\\\\n  log_retention: RetentionDays = None,\\\\n  log_retention_retry_options: LogRetentionRetryOptions = None,\\\\n  log_retention_role: IRole = None,\\\\n  memory_size: typing.Union[int, float] = None,\\\\n  profiling: bool = None,\\\\n  profiling_group: IProfilingGroup = None,\\\\n  reserved_concurrent_executions: typing.Union[int, float] = None,\\\\n  role: IRole = None,\\\\n  security_group: ISecurityGroup = None,\\\\n  security_groups: typing.List[ISecurityGroup] = None,\\\\n  timeout: Duration = None,\\\\n  tracing: Tracing = None,\\\\n  vpc: IVpc = None,\\\\n  vpc_subnets: SubnetSelection = None,\\\\n  code: Code,\\\\n  handler: str,\\\\n  runtime: Runtime,\\\\n  stack_id: str = None\\\\n)\\\\n\`\`\`\\\\n\\",
+        \\"properties\\": [
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.max_event_age\\",
+            \\"name\\": \\"max_event_age\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The maximum age of a request that Lambda sends to a function for processing.\\\\n\\\\nMinimum: 60 seconds\\\\nMaximum: 6 hours\\",
+            \\"default\\": \\"Duration.hours(6)\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+              \\"name\\": \\"aws_cdk.core.Duration\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.on_failure\\",
+            \\"name\\": \\"on_failure\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The destination for failed invocations.\\",
+            \\"default\\": \\"- no destination\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.IDestination\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.on_success\\",
+            \\"name\\": \\"on_success\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The destination for successful invocations.\\",
+            \\"default\\": \\"- no destination\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.IDestination\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.IDestination\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.retry_attempts\\",
+            \\"name\\": \\"retry_attempts\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The maximum number of times to retry when the function returns an error.\\\\n\\\\nMinimum: 0\\\\nMaximum: 2\\",
+            \\"default\\": \\"2\\",
+            \\"type\\": {
+              \\"name\\": \\"typing.Union[int, float]\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.allow_all_outbound\\",
+            \\"name\\": \\"allow_all_outbound\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Whether to allow the Lambda to send all network traffic.\\\\n\\\\nIf set to false, you must individually add traffic rules to allow the\\\\nLambda to connect to network targets.\\",
+            \\"default\\": \\"true\\",
+            \\"type\\": {
+              \\"name\\": \\"bool\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.allow_public_subnet\\",
+            \\"name\\": \\"allow_public_subnet\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Lambda Functions in a public subnet can NOT access the internet.\\\\n\\\\nUse this property to acknowledge this limitation and still place the function in a public subnet.\\",
+            \\"default\\": \\"false\\",
+            \\"type\\": {
+              \\"name\\": \\"bool\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.architectures\\",
+            \\"name\\": \\"architectures\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The system architectures compatible with this lambda function.\\",
+            \\"default\\": \\"[Architecture.X86_64]\\",
+            \\"type\\": {
+              \\"name\\": \\"typing.List[%]\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.Architecture\\",
+                  \\"name\\": \\"aws_cdk.aws_lambda.Architecture\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.code_signing_config\\",
+            \\"name\\": \\"code_signing_config\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Code signing config associated with this function.\\",
+            \\"default\\": \\"- Not Sign the Code\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.ICodeSigningConfig\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.ICodeSigningConfig\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.current_version_options\\",
+            \\"name\\": \\"current_version_options\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Options for the \`lambda.Version\` resource automatically created by the \`fn.currentVersion\` method.\\",
+            \\"default\\": \\"- default options as described in \`VersionOptions\`\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.VersionOptions\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.VersionOptions\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.dead_letter_queue\\",
+            \\"name\\": \\"dead_letter_queue\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The SQS queue to use if DLQ is enabled.\\",
+            \\"default\\": \\"- SQS queue with 14 day retention period if \`deadLetterQueueEnabled\` is \`true\`\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-sqs.IQueue\\",
+              \\"name\\": \\"aws_cdk.aws_sqs.IQueue\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.dead_letter_queue_enabled\\",
+            \\"name\\": \\"dead_letter_queue_enabled\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Enabled DLQ.\\\\n\\\\nIf \`deadLetterQueue\` is undefined,\\\\nan SQS queue with default options will be defined for your Function.\\",
+            \\"default\\": \\"- false unless \`deadLetterQueue\` is set, which implies DLQ is enabled.\\",
+            \\"type\\": {
+              \\"name\\": \\"bool\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.description\\",
+            \\"name\\": \\"description\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"A description of the function.\\",
+            \\"default\\": \\"- No description.\\",
+            \\"type\\": {
+              \\"name\\": \\"str\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.environment\\",
+            \\"name\\": \\"environment\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Key-value pairs that Lambda caches and makes available for your Lambda functions.\\\\n\\\\nUse environment variables to apply configuration changes, such\\\\nas test and production environment configurations, without changing your\\\\nLambda function source code.\\",
+            \\"default\\": \\"- No environment variables.\\",
+            \\"type\\": {
+              \\"name\\": \\"typing.Mapping[%]\\",
+              \\"types\\": [
+                {
+                  \\"name\\": \\"str\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.environment_encryption\\",
+            \\"name\\": \\"environment_encryption\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The AWS KMS key that's used to encrypt your function's environment variables.\\",
+            \\"default\\": \\"- AWS Lambda creates and uses an AWS managed customer master key (CMK).\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-kms.IKey\\",
+              \\"name\\": \\"aws_cdk.aws_kms.IKey\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.events\\",
+            \\"name\\": \\"events\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Event sources for this function.\\\\n\\\\nYou can also add event sources using \`addEventSource\`.\\",
+            \\"default\\": \\"- No event sources.\\",
+            \\"type\\": {
+              \\"name\\": \\"typing.List[%]\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.IEventSource\\",
+                  \\"name\\": \\"aws_cdk.aws_lambda.IEventSource\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.filesystem\\",
+            \\"name\\": \\"filesystem\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The filesystem configuration for the lambda function.\\",
+            \\"default\\": \\"- will not mount any filesystem\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.FileSystem\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.FileSystem\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.function_name\\",
+            \\"name\\": \\"function_name\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"A name for the function.\\",
+            \\"default\\": \\"- AWS CloudFormation generates a unique physical ID and uses that\\\\nID for the function's name. For more information, see Name Type.\\",
+            \\"type\\": {
+              \\"name\\": \\"str\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.initial_policy\\",
+            \\"name\\": \\"initial_policy\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Initial policy statements to add to the created Lambda Role.\\\\n\\\\nYou can call \`addToRolePolicy\` to the created lambda to add statements post creation.\\",
+            \\"default\\": \\"- No policy statements are added to the created Lambda role.\\",
+            \\"type\\": {
+              \\"name\\": \\"typing.List[%]\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-iam.PolicyStatement\\",
+                  \\"name\\": \\"aws_cdk.aws_iam.PolicyStatement\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.insights_version\\",
+            \\"name\\": \\"insights_version\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Specify the version of CloudWatch Lambda insights to use for monitoring.\\",
+            \\"default\\": \\"- No Lambda Insights\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.LambdaInsightsVersion\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.LambdaInsightsVersion\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.layers\\",
+            \\"name\\": \\"layers\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"A list of layers to add to the function's execution environment.\\\\n\\\\nYou can configure your Lambda function to pull in\\\\nadditional code during initialization in the form of layers. Layers are packages of libraries or other dependencies\\\\nthat can be used by multiple functions.\\",
+            \\"default\\": \\"- No layers.\\",
+            \\"type\\": {
+              \\"name\\": \\"typing.List[%]\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-lambda.ILayerVersion\\",
+                  \\"name\\": \\"aws_cdk.aws_lambda.ILayerVersion\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.log_retention\\",
+            \\"name\\": \\"log_retention\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The number of days log events are kept in CloudWatch Logs.\\\\n\\\\nWhen updating\\\\nthis property, unsetting it doesn't remove the log retention policy. To\\\\nremove the retention policy, set the value to \`INFINITE\`.\\",
+            \\"default\\": \\"logs.RetentionDays.INFINITE\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-logs.RetentionDays\\",
+              \\"name\\": \\"aws_cdk.aws_logs.RetentionDays\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.log_retention_retry_options\\",
+            \\"name\\": \\"log_retention_retry_options\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"When log retention is specified, a custom resource attempts to create the CloudWatch log group.\\\\n\\\\nThese options control the retry policy when interacting with CloudWatch APIs.\\",
+            \\"default\\": \\"- Default AWS SDK retry options.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.LogRetentionRetryOptions\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.LogRetentionRetryOptions\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.log_retention_role\\",
+            \\"name\\": \\"log_retention_role\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The IAM role for the Lambda function associated with the custom resource that sets the retention policy.\\",
+            \\"default\\": \\"- A new role is created.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+              \\"name\\": \\"aws_cdk.aws_iam.IRole\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.memory_size\\",
+            \\"name\\": \\"memory_size\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The amount of memory, in MB, that is allocated to your Lambda function.\\\\n\\\\nLambda uses this value to proportionally allocate the amount of CPU\\\\npower. For more information, see Resource Model in the AWS Lambda\\\\nDeveloper Guide.\\",
+            \\"default\\": \\"128\\",
+            \\"type\\": {
+              \\"name\\": \\"typing.Union[int, float]\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.profiling\\",
+            \\"name\\": \\"profiling\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Enable profiling.\\",
+            \\"default\\": \\"- No profiling.\\",
+            \\"type\\": {
+              \\"name\\": \\"bool\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.profiling_group\\",
+            \\"name\\": \\"profiling_group\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Profiling Group.\\",
+            \\"default\\": \\"- A new profiling group will be created if \`profiling\` is set.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-codeguruprofiler.IProfilingGroup\\",
+              \\"name\\": \\"aws_cdk.aws_codeguruprofiler.IProfilingGroup\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.reserved_concurrent_executions\\",
+            \\"name\\": \\"reserved_concurrent_executions\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The maximum of concurrent executions you want to reserve for the function.\\",
+            \\"default\\": \\"- No specific limit - account limit.\\",
+            \\"type\\": {
+              \\"name\\": \\"typing.Union[int, float]\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.role\\",
+            \\"name\\": \\"role\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Lambda execution role.\\\\n\\\\nThis is the role that will be assumed by the function upon execution.\\\\nIt controls the permissions that the function will have. The Role must\\\\nbe assumable by the 'lambda.amazonaws.com' service principal.\\\\n\\\\nThe default Role automatically has permissions granted for Lambda execution. If you\\\\nprovide a Role, you must add the relevant AWS managed policies yourself.\\\\n\\\\nThe relevant managed policies are \\\\\\"service-role/AWSLambdaBasicExecutionRole\\\\\\" and\\\\n\\\\\\"service-role/AWSLambdaVPCAccessExecutionRole\\\\\\".\\",
+            \\"default\\": \\"- A unique role will be generated for this lambda function.\\\\nBoth supplied and generated roles can always be changed by calling \`addToRolePolicy\`.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-iam.IRole\\",
+              \\"name\\": \\"aws_cdk.aws_iam.IRole\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.security_group\\",
+            \\"name\\": \\"security_group\\",
+            \\"optional\\": true,
+            \\"deprecated\\": true,
+            \\"deprecationReason\\": \\"- This property is deprecated, use securityGroups instead\\",
+            \\"docs\\": \\"What security group to associate with the Lambda's network interfaces. This property is being deprecated, consider using securityGroups instead.\\\\n\\\\nOnly used if 'vpc' is supplied.\\\\n\\\\nUse securityGroups property instead.\\\\nFunction constructor will throw an error if both are specified.\\",
+            \\"default\\": \\"- If the function is placed within a VPC and a security group is\\\\nnot specified, either by this or securityGroups prop, a dedicated security\\\\ngroup will be created for this function.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-ec2.ISecurityGroup\\",
+              \\"name\\": \\"aws_cdk.aws_ec2.ISecurityGroup\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.security_groups\\",
+            \\"name\\": \\"security_groups\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The list of security groups to associate with the Lambda's network interfaces.\\\\n\\\\nOnly used if 'vpc' is supplied.\\",
+            \\"default\\": \\"- If the function is placed within a VPC and a security group is\\\\nnot specified, either by this or securityGroup prop, a dedicated security\\\\ngroup will be created for this function.\\",
+            \\"type\\": {
+              \\"name\\": \\"typing.List[%]\\",
+              \\"types\\": [
+                {
+                  \\"fqn\\": \\"@aws-cdk/aws-ec2.ISecurityGroup\\",
+                  \\"name\\": \\"aws_cdk.aws_ec2.ISecurityGroup\\"
+                }
+              ]
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.timeout\\",
+            \\"name\\": \\"timeout\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The function execution time (in seconds) after which Lambda terminates the function.\\\\n\\\\nBecause the execution time affects cost, set this value\\\\nbased on the function's expected execution time.\\",
+            \\"default\\": \\"Duration.seconds(3)\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/core.Duration\\",
+              \\"name\\": \\"aws_cdk.core.Duration\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.tracing\\",
+            \\"name\\": \\"tracing\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Enable AWS X-Ray Tracing for Lambda Function.\\",
+            \\"default\\": \\"Tracing.Disabled\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.Tracing\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.Tracing\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.vpc\\",
+            \\"name\\": \\"vpc\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"VPC network to place Lambda network interfaces.\\\\n\\\\nSpecify this if the Lambda function needs to access resources in a VPC.\\",
+            \\"default\\": \\"- Function is not placed within a VPC.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-ec2.IVpc\\",
+              \\"name\\": \\"aws_cdk.aws_ec2.IVpc\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.vpc_subnets\\",
+            \\"name\\": \\"vpc_subnets\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"Where to place the network interfaces within the VPC.\\\\n\\\\nOnly used if 'vpc' is supplied. Note: internet access for Lambdas\\\\nrequires a NAT gateway, so picking Public subnets is not allowed.\\",
+            \\"default\\": \\"- the Vpc default strategy if not specified\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-ec2.SubnetSelection\\",
+              \\"name\\": \\"aws_cdk.aws_ec2.SubnetSelection\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.code\\",
+            \\"name\\": \\"code\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The source code of your Lambda function.\\\\n\\\\nYou can point to a file in an\\\\nAmazon Simple Storage Service (Amazon S3) bucket or specify your source\\\\ncode as inline text.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.Code\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.Code\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.handler\\",
+            \\"name\\": \\"handler\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The name of the method within your code that Lambda calls to execute your function.\\\\n\\\\nThe format includes the file name. It can also include\\\\nnamespaces and other qualifiers, depending on the runtime.\\\\nFor more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.\\\\n\\\\nUse \`Handler.FROM_IMAGE\` when defining a function from a Docker image.\\\\n\\\\nNOTE: If you specify your source code as inline text by specifying the\\\\nZipFile property within the Code property, specify index.function_name as\\\\nthe handler.\\",
+            \\"type\\": {
+              \\"name\\": \\"str\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.runtime\\",
+            \\"name\\": \\"runtime\\",
+            \\"optional\\": false,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The runtime environment for the Lambda function that you are uploading.\\\\n\\\\nFor valid values, see the Runtime property in the AWS Lambda Developer\\\\nGuide.\\\\n\\\\nUse \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.\\",
+            \\"type\\": {
+              \\"fqn\\": \\"@aws-cdk/aws-lambda.Runtime\\",
+              \\"name\\": \\"aws_cdk.aws_lambda.Runtime\\"
+            }
+          },
+          {
+            \\"id\\": \\"aws_cdk.experimental.EdgeFunctionProps.stack_id\\",
+            \\"name\\": \\"stack_id\\",
+            \\"optional\\": true,
+            \\"deprecated\\": false,
+            \\"docs\\": \\"The stack ID of Lambda@Edge function.\\",
+            \\"default\\": \\"- \`edge-lambda-stack-\${region}\`\\",
+            \\"type\\": {
+              \\"name\\": \\"str\\"
+            }
+          }
+        ]
+      }
+    ],
+    \\"interfaces\\": [],
+    \\"enums\\": []
+  }
+}"
+`;
+
+exports[`submodules without an explicit name python markdown 1`] = `
 "
 # API Reference <a name=\\"API Reference\\"></a>
 

--- a/test/docgen/transpile/transpile.test.ts
+++ b/test/docgen/transpile/transpile.test.ts
@@ -38,7 +38,7 @@ describe('submodules without an explicit name', () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-cloudfront', Assemblies.AWSCDK_1_126_0, {
       language: Language.JAVA,
     });
-    const markdown = docs.render({ submodule: 'experimental' });
+    const markdown = docs.toMarkdown({ submodule: 'experimental' });
     expect(markdown.render()).toMatchSnapshot();
   });
 
@@ -46,7 +46,7 @@ describe('submodules without an explicit name', () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-cloudfront', Assemblies.AWSCDK_1_126_0, {
       language: Language.PYTHON,
     });
-    const markdown = docs.render({ submodule: 'experimental' });
+    const markdown = docs.toMarkdown({ submodule: 'experimental' });
     expect(markdown.render()).toMatchSnapshot();
   });
 
@@ -54,7 +54,7 @@ describe('submodules without an explicit name', () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-cloudfront', Assemblies.AWSCDK_1_126_0, {
       language: Language.CSHARP,
     });
-    const markdown = docs.render({ submodule: 'experimental' });
+    const markdown = docs.toMarkdown({ submodule: 'experimental' });
     expect(markdown.render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/transpile/transpile.test.ts
+++ b/test/docgen/transpile/transpile.test.ts
@@ -34,7 +34,7 @@ describe('language', () => {
 
 describe('submodules without an explicit name', () => {
 
-  test('java', async () => {
+  test('java markdown', async () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-cloudfront', Assemblies.AWSCDK_1_126_0, {
       language: Language.JAVA,
     });
@@ -42,7 +42,15 @@ describe('submodules without an explicit name', () => {
     expect(markdown.render()).toMatchSnapshot();
   });
 
-  test('python', async () => {
+  test('java json', async () => {
+    const docs = await Documentation.forAssembly('@aws-cdk/aws-cloudfront', Assemblies.AWSCDK_1_126_0, {
+      language: Language.JAVA,
+    });
+    const json = docs.toJson({ submodule: 'experimental' });
+    expect(json.render()).toMatchSnapshot();
+  });
+
+  test('python markdown', async () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-cloudfront', Assemblies.AWSCDK_1_126_0, {
       language: Language.PYTHON,
     });
@@ -50,11 +58,27 @@ describe('submodules without an explicit name', () => {
     expect(markdown.render()).toMatchSnapshot();
   });
 
-  test('csharp', async () => {
+  test('python json', async () => {
+    const docs = await Documentation.forAssembly('@aws-cdk/aws-cloudfront', Assemblies.AWSCDK_1_126_0, {
+      language: Language.PYTHON,
+    });
+    const json = docs.toJson({ submodule: 'experimental' });
+    expect(json.render()).toMatchSnapshot();
+  });
+
+  test('csharp markdown', async () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-cloudfront', Assemblies.AWSCDK_1_126_0, {
       language: Language.CSHARP,
     });
     const markdown = docs.toMarkdown({ submodule: 'experimental' });
     expect(markdown.render()).toMatchSnapshot();
+  });
+
+  test('csharp json', async () => {
+    const docs = await Documentation.forAssembly('@aws-cdk/aws-cloudfront', Assemblies.AWSCDK_1_126_0, {
+      language: Language.CSHARP,
+    });
+    const json = docs.toJson({ submodule: 'experimental' });
+    expect(json.render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/__snapshots__/class.test.ts.snap
+++ b/test/docgen/view/__snapshots__/class.test.ts.snap
@@ -1,6 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csharp snapshot 1`] = `
+exports[`csharp json snapshot 1`] = `
+Object {
+  "constants": Array [],
+  "docs": "Authorization token to access private ECR repositories in the current environment via Docker CLI.",
+  "id": "Amazon.CDK.AWS.ECR.AuthorizationToken",
+  "initializer": undefined,
+  "instanceMethods": Array [],
+  "interfaces": Array [],
+  "name": "AuthorizationToken",
+  "properties": Array [],
+  "staticFunctions": Array [
+    Object {
+      "id": "Amazon.CDK.AWS.ECR.AuthorizationToken.Initializer",
+      "name": "GrantRead",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "Amazon.CDK.AWS.ECR.AuthorizationToken.Grantee",
+          "name": "Grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "Amazon.CDK.AWS.IAM.IGrantable",
+          },
+        },
+      ],
+      "snippet": "\`\`\`csharp
+using Amazon.CDK.AWS.ECR;
+
+AuthorizationToken.GrantRead(IGrantable Grantee);
+\`\`\`
+",
+    },
+  ],
+}
+`;
+
+exports[`csharp markdown snapshot 1`] = `
 " AuthorizationToken <a name=\\"Amazon.CDK.AWS.ECR.AuthorizationToken\\"></a>
 
 Authorization token to access private ECR repositories in the current environment via Docker CLI.
@@ -28,7 +68,47 @@ AuthorizationToken.GrantRead(IGrantable Grantee);
 "
 `;
 
-exports[`java snapshot 1`] = `
+exports[`java json snapshot 1`] = `
+Object {
+  "constants": Array [],
+  "docs": "Authorization token to access private ECR repositories in the current environment via Docker CLI.",
+  "id": "software.amazon.awscdk.services.ecr.AuthorizationToken",
+  "initializer": undefined,
+  "instanceMethods": Array [],
+  "interfaces": Array [],
+  "name": "AuthorizationToken",
+  "properties": Array [],
+  "staticFunctions": Array [
+    Object {
+      "id": "software.amazon.awscdk.services.ecr.AuthorizationToken.Initializer",
+      "name": "grantRead",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "software.amazon.awscdk.services.ecr.AuthorizationToken.grantee",
+          "name": "grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "software.amazon.awscdk.services.iam.IGrantable",
+          },
+        },
+      ],
+      "snippet": "\`\`\`java
+import software.amazon.awscdk.services.ecr.AuthorizationToken;
+
+AuthorizationToken.grantRead(IGrantable grantee)
+\`\`\`
+",
+    },
+  ],
+}
+`;
+
+exports[`java markdown snapshot 1`] = `
 " AuthorizationToken <a name=\\"software.amazon.awscdk.services.ecr.AuthorizationToken\\"></a>
 
 Authorization token to access private ECR repositories in the current environment via Docker CLI.
@@ -86,7 +166,47 @@ aws_cdk.aws_ecr.AuthorizationToken.grant_read(
 "
 `;
 
-exports[`typescript snapshot 1`] = `
+exports[`typescript json snapshot 1`] = `
+Object {
+  "constants": Array [],
+  "docs": "Authorization token to access private ECR repositories in the current environment via Docker CLI.",
+  "id": "@aws-cdk/aws-ecr.AuthorizationToken",
+  "initializer": undefined,
+  "instanceMethods": Array [],
+  "interfaces": Array [],
+  "name": "AuthorizationToken",
+  "properties": Array [],
+  "staticFunctions": Array [
+    Object {
+      "id": "@aws-cdk/aws-ecr.AuthorizationToken.Initializer",
+      "name": "grantRead",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "@aws-cdk/aws-ecr.AuthorizationToken.grantee",
+          "name": "grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "@aws-cdk/aws-iam.IGrantable",
+          },
+        },
+      ],
+      "snippet": "\`\`\`typescript
+import { AuthorizationToken } from '@aws-cdk/aws-ecr'
+
+AuthorizationToken.grantRead(grantee: IGrantable)
+\`\`\`
+",
+    },
+  ],
+}
+`;
+
+exports[`typescript markdown snapshot 1`] = `
 " AuthorizationToken <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken\\"></a>
 
 Authorization token to access private ECR repositories in the current environment via Docker CLI.

--- a/test/docgen/view/__snapshots__/enum.test.ts.snap
+++ b/test/docgen/view/__snapshots__/enum.test.ts.snap
@@ -1,6 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csharp snapshot 1`] = `
+exports[`csharp json snapshot 1`] = `
+Object {
+  "docs": "The tag mutability setting for your repository.",
+  "members": Array [
+    Object {
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "allow image tags to be overwritten.",
+      "id": "Amazon.CDK.AWS.ECR.TagMutability.MUTABLE",
+      "name": "MUTABLE",
+    },
+    Object {
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "all image tags within the repository will be immutable which will prevent them from being overwritten.",
+      "id": "Amazon.CDK.AWS.ECR.TagMutability.IMMUTABLE",
+      "name": "IMMUTABLE",
+    },
+  ],
+  "name": "TagMutability",
+}
+`;
+
+exports[`csharp markdown snapshot 1`] = `
 " TagMutability <a name=\\"TagMutability\\"></a>
 
 The tag mutability setting for your repository.
@@ -21,7 +44,30 @@ all image tags within the repository will be immutable which will prevent them f
 "
 `;
 
-exports[`java snapshot 1`] = `
+exports[`java json snapshot 1`] = `
+Object {
+  "docs": "The tag mutability setting for your repository.",
+  "members": Array [
+    Object {
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "allow image tags to be overwritten.",
+      "id": "software.amazon.awscdk.services.ecr.TagMutability.MUTABLE",
+      "name": "MUTABLE",
+    },
+    Object {
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "all image tags within the repository will be immutable which will prevent them from being overwritten.",
+      "id": "software.amazon.awscdk.services.ecr.TagMutability.IMMUTABLE",
+      "name": "IMMUTABLE",
+    },
+  ],
+  "name": "TagMutability",
+}
+`;
+
+exports[`java markdown snapshot 1`] = `
 " TagMutability <a name=\\"TagMutability\\"></a>
 
 The tag mutability setting for your repository.
@@ -63,7 +109,30 @@ all image tags within the repository will be immutable which will prevent them f
 "
 `;
 
-exports[`typescript snapshot 1`] = `
+exports[`typescript json snapshot 1`] = `
+Object {
+  "docs": "The tag mutability setting for your repository.",
+  "members": Array [
+    Object {
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "allow image tags to be overwritten.",
+      "id": "@aws-cdk/aws-ecr.TagMutability.MUTABLE",
+      "name": "MUTABLE",
+    },
+    Object {
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "all image tags within the repository will be immutable which will prevent them from being overwritten.",
+      "id": "@aws-cdk/aws-ecr.TagMutability.IMMUTABLE",
+      "name": "IMMUTABLE",
+    },
+  ],
+  "name": "TagMutability",
+}
+`;
+
+exports[`typescript markdown snapshot 1`] = `
 " TagMutability <a name=\\"TagMutability\\"></a>
 
 The tag mutability setting for your repository.

--- a/test/docgen/view/__snapshots__/initializer.test.ts.snap
+++ b/test/docgen/view/__snapshots__/initializer.test.ts.snap
@@ -1,6 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csharp snapshot 1`] = `
+exports[`csharp json snapshot 1`] = `
+Object {
+  "id": "Amazon.CDK.AWS.ECR.CfnPublicRepository.Initializer",
+  "parameters": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- scope in which this resource is defined.",
+      "id": "Amazon.CDK.AWS.ECR.CfnPublicRepository.Scope",
+      "name": "Scope",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.Construct",
+        "name": "Amazon.CDK.Construct",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- scoped id of the resource.",
+      "id": "Amazon.CDK.AWS.ECR.CfnPublicRepository.Id",
+      "name": "Id",
+      "optional": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- resource properties.",
+      "id": "Amazon.CDK.AWS.ECR.CfnPublicRepository.Props",
+      "name": "Props",
+      "optional": true,
+      "type": Object {
+        "fqn": "@aws-cdk/aws-ecr.CfnPublicRepositoryProps",
+        "name": "Amazon.CDK.AWS.ECR.CfnPublicRepositoryProps",
+      },
+    },
+  ],
+  "snippet": "\`\`\`csharp
+using Amazon.CDK.AWS.ECR;
+
+new CfnPublicRepository(Construct Scope, string Id, CfnPublicRepositoryProps Props = null);
+\`\`\`
+",
+}
+`;
+
+exports[`csharp markdown snapshot 1`] = `
 " Initializers <a name=\\"Amazon.CDK.AWS.ECR.CfnPublicRepository.Initializer\\"></a>
 
 \`\`\`csharp
@@ -35,7 +87,105 @@ resource properties.
 "
 `;
 
-exports[`java snapshot 1`] = `
+exports[`java json snapshot 1`] = `
+Object {
+  "id": "software.amazon.awscdk.services.ecr.CfnPublicRepository.Initializer",
+  "parameters": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- scope in which this resource is defined.",
+      "id": "software.amazon.awscdk.services.ecr.CfnPublicRepository.scope",
+      "name": "scope",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.Construct",
+        "name": "software.amazon.awscdk.core.Construct",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- scoped id of the resource.",
+      "id": "software.amazon.awscdk.services.ecr.CfnPublicRepository.id",
+      "name": "id",
+      "optional": false,
+      "type": Object {
+        "name": "java.lang.String",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryCatalogData\`.",
+      "id": "software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.repositoryCatalogData",
+      "name": "repositoryCatalogData",
+      "optional": true,
+      "type": Object {
+        "name": "java.lang.Object",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryName\`.",
+      "id": "software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.repositoryName",
+      "name": "repositoryName",
+      "optional": true,
+      "type": Object {
+        "name": "java.lang.String",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryPolicyText\`.",
+      "id": "software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.repositoryPolicyText",
+      "name": "repositoryPolicyText",
+      "optional": true,
+      "type": Object {
+        "name": "java.lang.Object",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.Tags\`.",
+      "id": "software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.tags",
+      "name": "tags",
+      "optional": true,
+      "type": Object {
+        "name": "java.util.List<%>",
+        "types": Array [
+          Object {
+            "fqn": "@aws-cdk/core.CfnTag",
+            "name": "software.amazon.awscdk.core.CfnTag",
+          },
+        ],
+      },
+    },
+  ],
+  "snippet": "\`\`\`java
+import software.amazon.awscdk.services.ecr.CfnPublicRepository;
+
+CfnPublicRepository.Builder.create(Construct scope, java.lang.String id)
+//  .repositoryCatalogData(java.lang.Object)
+//  .repositoryName(java.lang.String)
+//  .repositoryPolicyText(java.lang.Object)
+//  .tags(java.util.List<CfnTag>)
+    .build();
+\`\`\`
+",
+}
+`;
+
+exports[`java markdown snapshot 1`] = `
 " Initializers <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.Initializer\\"></a>
 
 \`\`\`java
@@ -107,7 +257,107 @@ scoped id of the resource.
 "
 `;
 
-exports[`python snapshot 1`] = `
+exports[`python json snapshot 1`] = `
+Object {
+  "id": "aws_cdk.aws_ecr.CfnPublicRepository.Initializer",
+  "parameters": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- scope in which this resource is defined.",
+      "id": "aws_cdk.aws_ecr.CfnPublicRepository.scope",
+      "name": "scope",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.Construct",
+        "name": "aws_cdk.core.Construct",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- scoped id of the resource.",
+      "id": "aws_cdk.aws_ecr.CfnPublicRepository.id",
+      "name": "id",
+      "optional": false,
+      "type": Object {
+        "name": "str",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryCatalogData\`.",
+      "id": "aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_catalog_data",
+      "name": "repository_catalog_data",
+      "optional": true,
+      "type": Object {
+        "name": "typing.Any",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryName\`.",
+      "id": "aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_name",
+      "name": "repository_name",
+      "optional": true,
+      "type": Object {
+        "name": "str",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryPolicyText\`.",
+      "id": "aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_policy_text",
+      "name": "repository_policy_text",
+      "optional": true,
+      "type": Object {
+        "name": "typing.Any",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.Tags\`.",
+      "id": "aws_cdk.aws_ecr.CfnPublicRepositoryProps.tags",
+      "name": "tags",
+      "optional": true,
+      "type": Object {
+        "name": "typing.List[%]",
+        "types": Array [
+          Object {
+            "fqn": "@aws-cdk/core.CfnTag",
+            "name": "aws_cdk.core.CfnTag",
+          },
+        ],
+      },
+    },
+  ],
+  "snippet": "\`\`\`python
+import aws_cdk.aws_ecr
+
+aws_cdk.aws_ecr.CfnPublicRepository(
+  scope: Construct,
+  id: str,
+  repository_catalog_data: typing.Any = None,
+  repository_name: str = None,
+  repository_policy_text: typing.Any = None,
+  tags: typing.List[CfnTag] = None
+)
+\`\`\`
+",
+}
+`;
+
+exports[`python markdown snapshot 1`] = `
 " Initializers <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.Initializer\\"></a>
 
 \`\`\`python
@@ -181,7 +431,59 @@ scoped id of the resource.
 "
 `;
 
-exports[`typescript snapshot 1`] = `
+exports[`typescript json snapshot 1`] = `
+Object {
+  "id": "@aws-cdk/aws-ecr.CfnPublicRepository.Initializer",
+  "parameters": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- scope in which this resource is defined.",
+      "id": "@aws-cdk/aws-ecr.CfnPublicRepository.scope",
+      "name": "scope",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.Construct",
+        "name": "@aws-cdk/core.Construct",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- scoped id of the resource.",
+      "id": "@aws-cdk/aws-ecr.CfnPublicRepository.id",
+      "name": "id",
+      "optional": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- resource properties.",
+      "id": "@aws-cdk/aws-ecr.CfnPublicRepository.props",
+      "name": "props",
+      "optional": true,
+      "type": Object {
+        "fqn": "@aws-cdk/aws-ecr.CfnPublicRepositoryProps",
+        "name": "@aws-cdk/aws-ecr.CfnPublicRepositoryProps",
+      },
+    },
+  ],
+  "snippet": "\`\`\`typescript
+import { CfnPublicRepository } from '@aws-cdk/aws-ecr'
+
+new CfnPublicRepository(scope: Construct, id: string, props?: CfnPublicRepositoryProps)
+\`\`\`
+",
+}
+`;
+
+exports[`typescript markdown snapshot 1`] = `
 " Initializers <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.Initializer\\"></a>
 
 \`\`\`typescript

--- a/test/docgen/view/__snapshots__/instance-method.test.ts.snap
+++ b/test/docgen/view/__snapshots__/instance-method.test.ts.snap
@@ -1,6 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csharp snapshot 1`] = `
+exports[`csharp json snapshot 1`] = `
+Object {
+  "id": "Amazon.CDK.AWS.ECR.CfnPublicRepository.Inspect",
+  "name": "Inspect",
+  "parameters": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- tree inspector to collect and process attributes.",
+      "id": "Amazon.CDK.AWS.ECR.CfnPublicRepository.Inspector",
+      "name": "Inspector",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.TreeInspector",
+        "name": "Amazon.CDK.TreeInspector",
+      },
+    },
+  ],
+  "snippet": "\`\`\`csharp
+private Inspect(TreeInspector Inspector)
+\`\`\`
+",
+}
+`;
+
+exports[`csharp markdown snapshot 1`] = `
 " \`Inspect\` <a name=\\"Amazon.CDK.AWS.ECR.CfnPublicRepository.Inspect\\"></a>
 
 \`\`\`csharp
@@ -17,7 +43,33 @@ tree inspector to collect and process attributes.
 "
 `;
 
-exports[`java snapshot 1`] = `
+exports[`java json snapshot 1`] = `
+Object {
+  "id": "software.amazon.awscdk.services.ecr.CfnPublicRepository.inspect",
+  "name": "inspect",
+  "parameters": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- tree inspector to collect and process attributes.",
+      "id": "software.amazon.awscdk.services.ecr.CfnPublicRepository.inspector",
+      "name": "inspector",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.TreeInspector",
+        "name": "software.amazon.awscdk.core.TreeInspector",
+      },
+    },
+  ],
+  "snippet": "\`\`\`java
+public inspect(TreeInspector inspector)
+\`\`\`
+",
+}
+`;
+
+exports[`java markdown snapshot 1`] = `
 " \`inspect\` <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepository.inspect\\"></a>
 
 \`\`\`java
@@ -34,7 +86,35 @@ tree inspector to collect and process attributes.
 "
 `;
 
-exports[`python snapshot 1`] = `
+exports[`python json snapshot 1`] = `
+Object {
+  "id": "aws_cdk.aws_ecr.CfnPublicRepository.inspect",
+  "name": "inspect",
+  "parameters": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- tree inspector to collect and process attributes.",
+      "id": "aws_cdk.aws_ecr.CfnPublicRepository.inspector",
+      "name": "inspector",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.TreeInspector",
+        "name": "aws_cdk.core.TreeInspector",
+      },
+    },
+  ],
+  "snippet": "\`\`\`python
+def inspect(
+  inspector: TreeInspector
+)
+\`\`\`
+",
+}
+`;
+
+exports[`python markdown snapshot 1`] = `
 " \`inspect\` <a name=\\"aws_cdk.aws_ecr.CfnPublicRepository.inspect\\"></a>
 
 \`\`\`python
@@ -53,7 +133,33 @@ tree inspector to collect and process attributes.
 "
 `;
 
-exports[`typescript snapshot 1`] = `
+exports[`typescript json snapshot 1`] = `
+Object {
+  "id": "@aws-cdk/aws-ecr.CfnPublicRepository.inspect",
+  "name": "inspect",
+  "parameters": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "- tree inspector to collect and process attributes.",
+      "id": "@aws-cdk/aws-ecr.CfnPublicRepository.inspector",
+      "name": "inspector",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.TreeInspector",
+        "name": "@aws-cdk/core.TreeInspector",
+      },
+    },
+  ],
+  "snippet": "\`\`\`typescript
+public inspect(inspector: TreeInspector)
+\`\`\`
+",
+}
+`;
+
+exports[`typescript markdown snapshot 1`] = `
 " \`inspect\` <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepository.inspect\\"></a>
 
 \`\`\`typescript

--- a/test/docgen/view/__snapshots__/interface.test.ts.snap
+++ b/test/docgen/view/__snapshots__/interface.test.ts.snap
@@ -1,6 +1,410 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csharp snapshot 1`] = `
+exports[`csharp json snapshot 1`] = `
+Object {
+  "docs": "Represents an ECR repository.",
+  "id": "Amazon.CDK.AWS.ECR.IRepository",
+  "implementations": Array [
+    Object {
+      "fqn": "@aws-cdk/aws-ecr.Repository",
+      "name": "Amazon.CDK.AWS.ECR.Repository",
+    },
+    Object {
+      "fqn": "@aws-cdk/aws-ecr.RepositoryBase",
+      "name": "Amazon.CDK.AWS.ECR.RepositoryBase",
+    },
+    Object {
+      "fqn": "@aws-cdk/aws-ecr.IRepository",
+      "name": "Amazon.CDK.AWS.ECR.IRepository",
+    },
+  ],
+  "instanceMethods": Array [
+    Object {
+      "id": "Amazon.CDK.AWS.ECR.IRepository.AddToResourcePolicy",
+      "name": "AddToResourcePolicy",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Statement",
+          "name": "Statement",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.PolicyStatement",
+            "name": "Amazon.CDK.AWS.IAM.PolicyStatement",
+          },
+        },
+      ],
+      "snippet": "\`\`\`csharp
+private AddToResourcePolicy(PolicyStatement Statement)
+\`\`\`
+",
+    },
+    Object {
+      "id": "Amazon.CDK.AWS.ECR.IRepository.Grant",
+      "name": "Grant",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Grantee",
+          "name": "Grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "Amazon.CDK.AWS.IAM.IGrantable",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Actions",
+          "name": "Actions",
+          "optional": false,
+          "type": Object {
+            "name": "string",
+          },
+        },
+      ],
+      "snippet": "\`\`\`csharp
+private Grant(IGrantable Grantee, string Actions)
+\`\`\`
+",
+    },
+    Object {
+      "id": "Amazon.CDK.AWS.ECR.IRepository.GrantPull",
+      "name": "GrantPull",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Grantee",
+          "name": "Grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "Amazon.CDK.AWS.IAM.IGrantable",
+          },
+        },
+      ],
+      "snippet": "\`\`\`csharp
+private GrantPull(IGrantable Grantee)
+\`\`\`
+",
+    },
+    Object {
+      "id": "Amazon.CDK.AWS.ECR.IRepository.GrantPullPush",
+      "name": "GrantPullPush",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Grantee",
+          "name": "Grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "Amazon.CDK.AWS.IAM.IGrantable",
+          },
+        },
+      ],
+      "snippet": "\`\`\`csharp
+private GrantPullPush(IGrantable Grantee)
+\`\`\`
+",
+    },
+    Object {
+      "id": "Amazon.CDK.AWS.ECR.IRepository.OnCloudTrailEvent",
+      "name": "OnCloudTrailEvent",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The id of the rule.",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Id",
+          "name": "Id",
+          "optional": false,
+          "type": Object {
+            "name": "string",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Options for adding the rule.",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Options",
+          "name": "Options",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.OnEventOptions",
+            "name": "Amazon.CDK.AWS.Events.OnEventOptions",
+          },
+        },
+      ],
+      "snippet": "\`\`\`csharp
+private OnCloudTrailEvent(string Id, OnEventOptions Options = null)
+\`\`\`
+",
+    },
+    Object {
+      "id": "Amazon.CDK.AWS.ECR.IRepository.OnCloudTrailImagePushed",
+      "name": "OnCloudTrailImagePushed",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The id of the rule.",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Id",
+          "name": "Id",
+          "optional": false,
+          "type": Object {
+            "name": "string",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Options for adding the rule.",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Options",
+          "name": "Options",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions",
+            "name": "Amazon.CDK.AWS.ECR.OnCloudTrailImagePushedOptions",
+          },
+        },
+      ],
+      "snippet": "\`\`\`csharp
+private OnCloudTrailImagePushed(string Id, OnCloudTrailImagePushedOptions Options = null)
+\`\`\`
+",
+    },
+    Object {
+      "id": "Amazon.CDK.AWS.ECR.IRepository.OnEvent",
+      "name": "OnEvent",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Id",
+          "name": "Id",
+          "optional": false,
+          "type": Object {
+            "name": "string",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Options",
+          "name": "Options",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.OnEventOptions",
+            "name": "Amazon.CDK.AWS.Events.OnEventOptions",
+          },
+        },
+      ],
+      "snippet": "\`\`\`csharp
+private OnEvent(string Id, OnEventOptions Options = null)
+\`\`\`
+",
+    },
+    Object {
+      "id": "Amazon.CDK.AWS.ECR.IRepository.OnImageScanCompleted",
+      "name": "OnImageScanCompleted",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The id of the rule.",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Id",
+          "name": "Id",
+          "optional": false,
+          "type": Object {
+            "name": "string",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Options for adding the rule.",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Options",
+          "name": "Options",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-ecr.OnImageScanCompletedOptions",
+            "name": "Amazon.CDK.AWS.ECR.OnImageScanCompletedOptions",
+          },
+        },
+      ],
+      "snippet": "\`\`\`csharp
+private OnImageScanCompleted(string Id, OnImageScanCompletedOptions Options = null)
+\`\`\`
+",
+    },
+    Object {
+      "id": "Amazon.CDK.AWS.ECR.IRepository.RepositoryUriForDigest",
+      "name": "RepositoryUriForDigest",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Image digest to use (tools usually default to the image with the \\"latest\\" tag if omitted).",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Digest",
+          "name": "Digest",
+          "optional": true,
+          "type": Object {
+            "name": "string",
+          },
+        },
+      ],
+      "snippet": "\`\`\`csharp
+private RepositoryUriForDigest(string Digest = null)
+\`\`\`
+",
+    },
+    Object {
+      "id": "Amazon.CDK.AWS.ECR.IRepository.RepositoryUriForTag",
+      "name": "RepositoryUriForTag",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Image tag to use (tools usually default to \\"latest\\" if omitted).",
+          "id": "Amazon.CDK.AWS.ECR.IRepository.Tag",
+          "name": "Tag",
+          "optional": true,
+          "type": Object {
+            "name": "string",
+          },
+        },
+      ],
+      "snippet": "\`\`\`csharp
+private RepositoryUriForTag(string Tag = null)
+\`\`\`
+",
+    },
+  ],
+  "interfaces": Array [
+    Object {
+      "fqn": "@aws-cdk/core.IResource",
+      "name": "Amazon.CDK.IResource",
+    },
+  ],
+  "name": "IRepository",
+  "properties": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The construct tree node for this construct.",
+      "id": "Amazon.CDK.AWS.ECR.IRepository.Node",
+      "name": "Node",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.ConstructNode",
+        "name": "Amazon.CDK.ConstructNode",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.",
+      "id": "Amazon.CDK.AWS.ECR.IRepository.Env",
+      "name": "Env",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.ResourceEnvironment",
+        "name": "Amazon.CDK.ResourceEnvironment",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The stack in which this resource is defined.",
+      "id": "Amazon.CDK.AWS.ECR.IRepository.Stack",
+      "name": "Stack",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.Stack",
+        "name": "Amazon.CDK.Stack",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The ARN of the repository.",
+      "id": "Amazon.CDK.AWS.ECR.IRepository.RepositoryArn",
+      "name": "RepositoryArn",
+      "optional": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The name of the repository.",
+      "id": "Amazon.CDK.AWS.ECR.IRepository.RepositoryName",
+      "name": "RepositoryName",
+      "optional": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The URI of this repository (represents the latest image):.
+
+ACCOUNT.dkr.ecr.REGION.amazonaws.com/REPOSITORY",
+      "id": "Amazon.CDK.AWS.ECR.IRepository.RepositoryUri",
+      "name": "RepositoryUri",
+      "optional": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+  ],
+}
+`;
+
+exports[`csharp markdown snapshot 1`] = `
 " IRepository <a name=\\"Amazon.CDK.AWS.ECR.IRepository\\"></a>
 
 - *Extends:* [\`Amazon.CDK.IResource\`](#Amazon.CDK.IResource)
@@ -262,7 +666,417 @@ ACCOUNT.dkr.ecr.REGION.amazonaws.com/REPOSITORY
 "
 `;
 
-exports[`java snapshot 1`] = `
+exports[`java json snapshot 1`] = `
+Object {
+  "docs": "Represents an ECR repository.",
+  "id": "software.amazon.awscdk.services.ecr.IRepository",
+  "implementations": Array [
+    Object {
+      "fqn": "@aws-cdk/aws-ecr.Repository",
+      "name": "software.amazon.awscdk.services.ecr.Repository",
+    },
+    Object {
+      "fqn": "@aws-cdk/aws-ecr.RepositoryBase",
+      "name": "software.amazon.awscdk.services.ecr.RepositoryBase",
+    },
+    Object {
+      "fqn": "@aws-cdk/aws-ecr.IRepository",
+      "name": "software.amazon.awscdk.services.ecr.IRepository",
+    },
+  ],
+  "instanceMethods": Array [
+    Object {
+      "id": "software.amazon.awscdk.services.ecr.IRepository.addToResourcePolicy",
+      "name": "addToResourcePolicy",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.statement",
+          "name": "statement",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.PolicyStatement",
+            "name": "software.amazon.awscdk.services.iam.PolicyStatement",
+          },
+        },
+      ],
+      "snippet": "\`\`\`java
+public addToResourcePolicy(PolicyStatement statement)
+\`\`\`
+",
+    },
+    Object {
+      "id": "software.amazon.awscdk.services.ecr.IRepository.grant",
+      "name": "grant",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.grantee",
+          "name": "grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "software.amazon.awscdk.services.iam.IGrantable",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.actions",
+          "name": "actions",
+          "optional": false,
+          "type": Object {
+            "name": "java.lang.String",
+          },
+        },
+      ],
+      "snippet": "\`\`\`java
+public grant(IGrantable grantee, java.lang.String actions)
+\`\`\`
+",
+    },
+    Object {
+      "id": "software.amazon.awscdk.services.ecr.IRepository.grantPull",
+      "name": "grantPull",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.grantee",
+          "name": "grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "software.amazon.awscdk.services.iam.IGrantable",
+          },
+        },
+      ],
+      "snippet": "\`\`\`java
+public grantPull(IGrantable grantee)
+\`\`\`
+",
+    },
+    Object {
+      "id": "software.amazon.awscdk.services.ecr.IRepository.grantPullPush",
+      "name": "grantPullPush",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.grantee",
+          "name": "grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "software.amazon.awscdk.services.iam.IGrantable",
+          },
+        },
+      ],
+      "snippet": "\`\`\`java
+public grantPullPush(IGrantable grantee)
+\`\`\`
+",
+    },
+    Object {
+      "id": "software.amazon.awscdk.services.ecr.IRepository.onCloudTrailEvent",
+      "name": "onCloudTrailEvent",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The id of the rule.",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.id",
+          "name": "id",
+          "optional": false,
+          "type": Object {
+            "name": "java.lang.String",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Options for adding the rule.",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.options",
+          "name": "options",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.OnEventOptions",
+            "name": "software.amazon.awscdk.services.events.OnEventOptions",
+          },
+        },
+      ],
+      "snippet": "\`\`\`java
+public onCloudTrailEvent(java.lang.String id)
+public onCloudTrailEvent(java.lang.String id, OnEventOptions options)
+\`\`\`
+",
+    },
+    Object {
+      "id": "software.amazon.awscdk.services.ecr.IRepository.onCloudTrailImagePushed",
+      "name": "onCloudTrailImagePushed",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The id of the rule.",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.id",
+          "name": "id",
+          "optional": false,
+          "type": Object {
+            "name": "java.lang.String",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Options for adding the rule.",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.options",
+          "name": "options",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions",
+            "name": "software.amazon.awscdk.services.ecr.OnCloudTrailImagePushedOptions",
+          },
+        },
+      ],
+      "snippet": "\`\`\`java
+public onCloudTrailImagePushed(java.lang.String id)
+public onCloudTrailImagePushed(java.lang.String id, OnCloudTrailImagePushedOptions options)
+\`\`\`
+",
+    },
+    Object {
+      "id": "software.amazon.awscdk.services.ecr.IRepository.onEvent",
+      "name": "onEvent",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.id",
+          "name": "id",
+          "optional": false,
+          "type": Object {
+            "name": "java.lang.String",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.options",
+          "name": "options",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.OnEventOptions",
+            "name": "software.amazon.awscdk.services.events.OnEventOptions",
+          },
+        },
+      ],
+      "snippet": "\`\`\`java
+public onEvent(java.lang.String id)
+public onEvent(java.lang.String id, OnEventOptions options)
+\`\`\`
+",
+    },
+    Object {
+      "id": "software.amazon.awscdk.services.ecr.IRepository.onImageScanCompleted",
+      "name": "onImageScanCompleted",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The id of the rule.",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.id",
+          "name": "id",
+          "optional": false,
+          "type": Object {
+            "name": "java.lang.String",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Options for adding the rule.",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.options",
+          "name": "options",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-ecr.OnImageScanCompletedOptions",
+            "name": "software.amazon.awscdk.services.ecr.OnImageScanCompletedOptions",
+          },
+        },
+      ],
+      "snippet": "\`\`\`java
+public onImageScanCompleted(java.lang.String id)
+public onImageScanCompleted(java.lang.String id, OnImageScanCompletedOptions options)
+\`\`\`
+",
+    },
+    Object {
+      "id": "software.amazon.awscdk.services.ecr.IRepository.repositoryUriForDigest",
+      "name": "repositoryUriForDigest",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Image digest to use (tools usually default to the image with the \\"latest\\" tag if omitted).",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.digest",
+          "name": "digest",
+          "optional": true,
+          "type": Object {
+            "name": "java.lang.String",
+          },
+        },
+      ],
+      "snippet": "\`\`\`java
+public repositoryUriForDigest()
+public repositoryUriForDigest(java.lang.String digest)
+\`\`\`
+",
+    },
+    Object {
+      "id": "software.amazon.awscdk.services.ecr.IRepository.repositoryUriForTag",
+      "name": "repositoryUriForTag",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Image tag to use (tools usually default to \\"latest\\" if omitted).",
+          "id": "software.amazon.awscdk.services.ecr.IRepository.tag",
+          "name": "tag",
+          "optional": true,
+          "type": Object {
+            "name": "java.lang.String",
+          },
+        },
+      ],
+      "snippet": "\`\`\`java
+public repositoryUriForTag()
+public repositoryUriForTag(java.lang.String tag)
+\`\`\`
+",
+    },
+  ],
+  "interfaces": Array [
+    Object {
+      "fqn": "@aws-cdk/core.IResource",
+      "name": "software.amazon.awscdk.core.IResource",
+    },
+  ],
+  "name": "IRepository",
+  "properties": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The construct tree node for this construct.",
+      "id": "software.amazon.awscdk.services.ecr.IRepository.node",
+      "name": "node",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.ConstructNode",
+        "name": "software.amazon.awscdk.core.ConstructNode",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.",
+      "id": "software.amazon.awscdk.services.ecr.IRepository.env",
+      "name": "env",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.ResourceEnvironment",
+        "name": "software.amazon.awscdk.core.ResourceEnvironment",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The stack in which this resource is defined.",
+      "id": "software.amazon.awscdk.services.ecr.IRepository.stack",
+      "name": "stack",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.Stack",
+        "name": "software.amazon.awscdk.core.Stack",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The ARN of the repository.",
+      "id": "software.amazon.awscdk.services.ecr.IRepository.repositoryArn",
+      "name": "repositoryArn",
+      "optional": false,
+      "type": Object {
+        "name": "java.lang.String",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The name of the repository.",
+      "id": "software.amazon.awscdk.services.ecr.IRepository.repositoryName",
+      "name": "repositoryName",
+      "optional": false,
+      "type": Object {
+        "name": "java.lang.String",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The URI of this repository (represents the latest image):.
+
+ACCOUNT.dkr.ecr.REGION.amazonaws.com/REPOSITORY",
+      "id": "software.amazon.awscdk.services.ecr.IRepository.repositoryUri",
+      "name": "repositoryUri",
+      "optional": false,
+      "type": Object {
+        "name": "java.lang.String",
+      },
+    },
+  ],
+}
+`;
+
+exports[`java markdown snapshot 1`] = `
 " IRepository <a name=\\"software.amazon.awscdk.services.ecr.IRepository\\"></a>
 
 - *Extends:* [\`software.amazon.awscdk.core.IResource\`](#software.amazon.awscdk.core.IResource)
@@ -530,7 +1344,645 @@ ACCOUNT.dkr.ecr.REGION.amazonaws.com/REPOSITORY
 "
 `;
 
-exports[`python snapshot 1`] = `
+exports[`python json snapshot 1`] = `
+Object {
+  "docs": "Represents an ECR repository.",
+  "id": "aws_cdk.aws_ecr.IRepository",
+  "implementations": Array [
+    Object {
+      "fqn": "@aws-cdk/aws-ecr.Repository",
+      "name": "aws_cdk.aws_ecr.Repository",
+    },
+    Object {
+      "fqn": "@aws-cdk/aws-ecr.RepositoryBase",
+      "name": "aws_cdk.aws_ecr.RepositoryBase",
+    },
+    Object {
+      "fqn": "@aws-cdk/aws-ecr.IRepository",
+      "name": "aws_cdk.aws_ecr.IRepository",
+    },
+  ],
+  "instanceMethods": Array [
+    Object {
+      "id": "aws_cdk.aws_ecr.IRepository.add_to_resource_policy",
+      "name": "add_to_resource_policy",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "aws_cdk.aws_ecr.IRepository.statement",
+          "name": "statement",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.PolicyStatement",
+            "name": "aws_cdk.aws_iam.PolicyStatement",
+          },
+        },
+      ],
+      "snippet": "\`\`\`python
+def add_to_resource_policy(
+  statement: PolicyStatement
+)
+\`\`\`
+",
+    },
+    Object {
+      "id": "aws_cdk.aws_ecr.IRepository.grant",
+      "name": "grant",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "aws_cdk.aws_ecr.IRepository.grantee",
+          "name": "grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "aws_cdk.aws_iam.IGrantable",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "aws_cdk.aws_ecr.IRepository.actions",
+          "name": "actions",
+          "optional": false,
+          "type": Object {
+            "name": "str",
+          },
+        },
+      ],
+      "snippet": "\`\`\`python
+def grant(
+  grantee: IGrantable,
+  actions: str
+)
+\`\`\`
+",
+    },
+    Object {
+      "id": "aws_cdk.aws_ecr.IRepository.grant_pull",
+      "name": "grant_pull",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "aws_cdk.aws_ecr.IRepository.grantee",
+          "name": "grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "aws_cdk.aws_iam.IGrantable",
+          },
+        },
+      ],
+      "snippet": "\`\`\`python
+def grant_pull(
+  grantee: IGrantable
+)
+\`\`\`
+",
+    },
+    Object {
+      "id": "aws_cdk.aws_ecr.IRepository.grant_pull_push",
+      "name": "grant_pull_push",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "aws_cdk.aws_ecr.IRepository.grantee",
+          "name": "grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "aws_cdk.aws_iam.IGrantable",
+          },
+        },
+      ],
+      "snippet": "\`\`\`python
+def grant_pull_push(
+  grantee: IGrantable
+)
+\`\`\`
+",
+    },
+    Object {
+      "id": "aws_cdk.aws_ecr.IRepository.on_cloud_trail_event",
+      "name": "on_cloud_trail_event",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The id of the rule.",
+          "id": "aws_cdk.aws_ecr.IRepository.id",
+          "name": "id",
+          "optional": false,
+          "type": Object {
+            "name": "str",
+          },
+        },
+        Object {
+          "default": "- No description",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "A description of the rule's purpose.",
+          "id": "aws_cdk.aws_events.OnEventOptions.description",
+          "name": "description",
+          "optional": true,
+          "type": Object {
+            "name": "str",
+          },
+        },
+        Object {
+          "default": "- No additional filtering based on an event pattern.",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Additional restrictions for the event to route to the specified target.
+
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.",
+          "id": "aws_cdk.aws_events.OnEventOptions.event_pattern",
+          "name": "event_pattern",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.EventPattern",
+            "name": "aws_cdk.aws_events.EventPattern",
+          },
+        },
+        Object {
+          "default": "AWS CloudFormation generates a unique physical ID.",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "A name for the rule.",
+          "id": "aws_cdk.aws_events.OnEventOptions.rule_name",
+          "name": "rule_name",
+          "optional": true,
+          "type": Object {
+            "name": "str",
+          },
+        },
+        Object {
+          "default": "- No target is added to the rule. Use \`addTarget()\` to add a target.",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The target to register for the event.",
+          "id": "aws_cdk.aws_events.OnEventOptions.target",
+          "name": "target",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.IRuleTarget",
+            "name": "aws_cdk.aws_events.IRuleTarget",
+          },
+        },
+      ],
+      "snippet": "\`\`\`python
+def on_cloud_trail_event(
+  id: str,
+  description: str = None,
+  event_pattern: EventPattern = None,
+  rule_name: str = None,
+  target: IRuleTarget = None
+)
+\`\`\`
+",
+    },
+    Object {
+      "id": "aws_cdk.aws_ecr.IRepository.on_cloud_trail_image_pushed",
+      "name": "on_cloud_trail_image_pushed",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The id of the rule.",
+          "id": "aws_cdk.aws_ecr.IRepository.id",
+          "name": "id",
+          "optional": false,
+          "type": Object {
+            "name": "str",
+          },
+        },
+        Object {
+          "default": "- No description",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "A description of the rule's purpose.",
+          "id": "aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.description",
+          "name": "description",
+          "optional": true,
+          "type": Object {
+            "name": "str",
+          },
+        },
+        Object {
+          "default": "- No additional filtering based on an event pattern.",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Additional restrictions for the event to route to the specified target.
+
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.",
+          "id": "aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.event_pattern",
+          "name": "event_pattern",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.EventPattern",
+            "name": "aws_cdk.aws_events.EventPattern",
+          },
+        },
+        Object {
+          "default": "AWS CloudFormation generates a unique physical ID.",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "A name for the rule.",
+          "id": "aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.rule_name",
+          "name": "rule_name",
+          "optional": true,
+          "type": Object {
+            "name": "str",
+          },
+        },
+        Object {
+          "default": "- No target is added to the rule. Use \`addTarget()\` to add a target.",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The target to register for the event.",
+          "id": "aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.target",
+          "name": "target",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.IRuleTarget",
+            "name": "aws_cdk.aws_events.IRuleTarget",
+          },
+        },
+        Object {
+          "default": "- Watch changes to all tags",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Only watch changes to this image tag.",
+          "id": "aws_cdk.aws_ecr.OnCloudTrailImagePushedOptions.image_tag",
+          "name": "image_tag",
+          "optional": true,
+          "type": Object {
+            "name": "str",
+          },
+        },
+      ],
+      "snippet": "\`\`\`python
+def on_cloud_trail_image_pushed(
+  id: str,
+  description: str = None,
+  event_pattern: EventPattern = None,
+  rule_name: str = None,
+  target: IRuleTarget = None,
+  image_tag: str = None
+)
+\`\`\`
+",
+    },
+    Object {
+      "id": "aws_cdk.aws_ecr.IRepository.on_event",
+      "name": "on_event",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "aws_cdk.aws_ecr.IRepository.id",
+          "name": "id",
+          "optional": false,
+          "type": Object {
+            "name": "str",
+          },
+        },
+        Object {
+          "default": "- No description",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "A description of the rule's purpose.",
+          "id": "aws_cdk.aws_events.OnEventOptions.description",
+          "name": "description",
+          "optional": true,
+          "type": Object {
+            "name": "str",
+          },
+        },
+        Object {
+          "default": "- No additional filtering based on an event pattern.",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Additional restrictions for the event to route to the specified target.
+
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.",
+          "id": "aws_cdk.aws_events.OnEventOptions.event_pattern",
+          "name": "event_pattern",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.EventPattern",
+            "name": "aws_cdk.aws_events.EventPattern",
+          },
+        },
+        Object {
+          "default": "AWS CloudFormation generates a unique physical ID.",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "A name for the rule.",
+          "id": "aws_cdk.aws_events.OnEventOptions.rule_name",
+          "name": "rule_name",
+          "optional": true,
+          "type": Object {
+            "name": "str",
+          },
+        },
+        Object {
+          "default": "- No target is added to the rule. Use \`addTarget()\` to add a target.",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The target to register for the event.",
+          "id": "aws_cdk.aws_events.OnEventOptions.target",
+          "name": "target",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.IRuleTarget",
+            "name": "aws_cdk.aws_events.IRuleTarget",
+          },
+        },
+      ],
+      "snippet": "\`\`\`python
+def on_event(
+  id: str,
+  description: str = None,
+  event_pattern: EventPattern = None,
+  rule_name: str = None,
+  target: IRuleTarget = None
+)
+\`\`\`
+",
+    },
+    Object {
+      "id": "aws_cdk.aws_ecr.IRepository.on_image_scan_completed",
+      "name": "on_image_scan_completed",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The id of the rule.",
+          "id": "aws_cdk.aws_ecr.IRepository.id",
+          "name": "id",
+          "optional": false,
+          "type": Object {
+            "name": "str",
+          },
+        },
+        Object {
+          "default": "- No description",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "A description of the rule's purpose.",
+          "id": "aws_cdk.aws_ecr.OnImageScanCompletedOptions.description",
+          "name": "description",
+          "optional": true,
+          "type": Object {
+            "name": "str",
+          },
+        },
+        Object {
+          "default": "- No additional filtering based on an event pattern.",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Additional restrictions for the event to route to the specified target.
+
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.",
+          "id": "aws_cdk.aws_ecr.OnImageScanCompletedOptions.event_pattern",
+          "name": "event_pattern",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.EventPattern",
+            "name": "aws_cdk.aws_events.EventPattern",
+          },
+        },
+        Object {
+          "default": "AWS CloudFormation generates a unique physical ID.",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "A name for the rule.",
+          "id": "aws_cdk.aws_ecr.OnImageScanCompletedOptions.rule_name",
+          "name": "rule_name",
+          "optional": true,
+          "type": Object {
+            "name": "str",
+          },
+        },
+        Object {
+          "default": "- No target is added to the rule. Use \`addTarget()\` to add a target.",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The target to register for the event.",
+          "id": "aws_cdk.aws_ecr.OnImageScanCompletedOptions.target",
+          "name": "target",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.IRuleTarget",
+            "name": "aws_cdk.aws_events.IRuleTarget",
+          },
+        },
+        Object {
+          "default": "- Watch the changes to the repository with all image tags",
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Only watch changes to the image tags spedified.
+
+Leave it undefined to watch the full repository.",
+          "id": "aws_cdk.aws_ecr.OnImageScanCompletedOptions.image_tags",
+          "name": "image_tags",
+          "optional": true,
+          "type": Object {
+            "name": "typing.List[%]",
+            "types": Array [
+              Object {
+                "name": "str",
+              },
+            ],
+          },
+        },
+      ],
+      "snippet": "\`\`\`python
+def on_image_scan_completed(
+  id: str,
+  description: str = None,
+  event_pattern: EventPattern = None,
+  rule_name: str = None,
+  target: IRuleTarget = None,
+  image_tags: typing.List[str] = None
+)
+\`\`\`
+",
+    },
+    Object {
+      "id": "aws_cdk.aws_ecr.IRepository.repository_uri_for_digest",
+      "name": "repository_uri_for_digest",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Image digest to use (tools usually default to the image with the \\"latest\\" tag if omitted).",
+          "id": "aws_cdk.aws_ecr.IRepository.digest",
+          "name": "digest",
+          "optional": true,
+          "type": Object {
+            "name": "str",
+          },
+        },
+      ],
+      "snippet": "\`\`\`python
+def repository_uri_for_digest(
+  digest: str = None
+)
+\`\`\`
+",
+    },
+    Object {
+      "id": "aws_cdk.aws_ecr.IRepository.repository_uri_for_tag",
+      "name": "repository_uri_for_tag",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Image tag to use (tools usually default to \\"latest\\" if omitted).",
+          "id": "aws_cdk.aws_ecr.IRepository.tag",
+          "name": "tag",
+          "optional": true,
+          "type": Object {
+            "name": "str",
+          },
+        },
+      ],
+      "snippet": "\`\`\`python
+def repository_uri_for_tag(
+  tag: str = None
+)
+\`\`\`
+",
+    },
+  ],
+  "interfaces": Array [
+    Object {
+      "fqn": "@aws-cdk/core.IResource",
+      "name": "aws_cdk.core.IResource",
+    },
+  ],
+  "name": "IRepository",
+  "properties": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The construct tree node for this construct.",
+      "id": "aws_cdk.aws_ecr.IRepository.node",
+      "name": "node",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.ConstructNode",
+        "name": "aws_cdk.core.ConstructNode",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.",
+      "id": "aws_cdk.aws_ecr.IRepository.env",
+      "name": "env",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.ResourceEnvironment",
+        "name": "aws_cdk.core.ResourceEnvironment",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The stack in which this resource is defined.",
+      "id": "aws_cdk.aws_ecr.IRepository.stack",
+      "name": "stack",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.Stack",
+        "name": "aws_cdk.core.Stack",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The ARN of the repository.",
+      "id": "aws_cdk.aws_ecr.IRepository.repository_arn",
+      "name": "repository_arn",
+      "optional": false,
+      "type": Object {
+        "name": "str",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The name of the repository.",
+      "id": "aws_cdk.aws_ecr.IRepository.repository_name",
+      "name": "repository_name",
+      "optional": false,
+      "type": Object {
+        "name": "str",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The URI of this repository (represents the latest image):.
+
+ACCOUNT.dkr.ecr.REGION.amazonaws.com/REPOSITORY",
+      "id": "aws_cdk.aws_ecr.IRepository.repository_uri",
+      "name": "repository_uri",
+      "optional": false,
+      "type": Object {
+        "name": "str",
+      },
+    },
+  ],
+}
+`;
+
+exports[`python markdown snapshot 1`] = `
 " IRepository <a name=\\"aws_cdk.aws_ecr.IRepository\\"></a>
 
 - *Extends:* [\`aws_cdk.core.IResource\`](#aws_cdk.core.IResource)
@@ -989,7 +2441,411 @@ ACCOUNT.dkr.ecr.REGION.amazonaws.com/REPOSITORY
 "
 `;
 
-exports[`typescript snapshot 1`] = `
+exports[`typescript json snapshot 1`] = `
+Object {
+  "docs": "Represents an ECR repository.",
+  "id": "@aws-cdk/aws-ecr.IRepository",
+  "implementations": Array [
+    Object {
+      "fqn": "@aws-cdk/aws-ecr.Repository",
+      "name": "@aws-cdk/aws-ecr.Repository",
+    },
+    Object {
+      "fqn": "@aws-cdk/aws-ecr.RepositoryBase",
+      "name": "@aws-cdk/aws-ecr.RepositoryBase",
+    },
+    Object {
+      "fqn": "@aws-cdk/aws-ecr.IRepository",
+      "name": "@aws-cdk/aws-ecr.IRepository",
+    },
+  ],
+  "instanceMethods": Array [
+    Object {
+      "id": "@aws-cdk/aws-ecr.IRepository.addToResourcePolicy",
+      "name": "addToResourcePolicy",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "@aws-cdk/aws-ecr.IRepository.statement",
+          "name": "statement",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.PolicyStatement",
+            "name": "@aws-cdk/aws-iam.PolicyStatement",
+          },
+        },
+      ],
+      "snippet": "\`\`\`typescript
+public addToResourcePolicy(statement: PolicyStatement)
+\`\`\`
+",
+    },
+    Object {
+      "id": "@aws-cdk/aws-ecr.IRepository.grant",
+      "name": "grant",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "@aws-cdk/aws-ecr.IRepository.grantee",
+          "name": "grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "@aws-cdk/aws-iam.IGrantable",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "@aws-cdk/aws-ecr.IRepository.actions",
+          "name": "actions",
+          "optional": false,
+          "type": Object {
+            "name": "string",
+          },
+        },
+      ],
+      "snippet": "\`\`\`typescript
+public grant(grantee: IGrantable, actions: string)
+\`\`\`
+",
+    },
+    Object {
+      "id": "@aws-cdk/aws-ecr.IRepository.grantPull",
+      "name": "grantPull",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "@aws-cdk/aws-ecr.IRepository.grantee",
+          "name": "grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "@aws-cdk/aws-iam.IGrantable",
+          },
+        },
+      ],
+      "snippet": "\`\`\`typescript
+public grantPull(grantee: IGrantable)
+\`\`\`
+",
+    },
+    Object {
+      "id": "@aws-cdk/aws-ecr.IRepository.grantPullPush",
+      "name": "grantPullPush",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "@aws-cdk/aws-ecr.IRepository.grantee",
+          "name": "grantee",
+          "optional": false,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-iam.IGrantable",
+            "name": "@aws-cdk/aws-iam.IGrantable",
+          },
+        },
+      ],
+      "snippet": "\`\`\`typescript
+public grantPullPush(grantee: IGrantable)
+\`\`\`
+",
+    },
+    Object {
+      "id": "@aws-cdk/aws-ecr.IRepository.onCloudTrailEvent",
+      "name": "onCloudTrailEvent",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The id of the rule.",
+          "id": "@aws-cdk/aws-ecr.IRepository.id",
+          "name": "id",
+          "optional": false,
+          "type": Object {
+            "name": "string",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Options for adding the rule.",
+          "id": "@aws-cdk/aws-ecr.IRepository.options",
+          "name": "options",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.OnEventOptions",
+            "name": "@aws-cdk/aws-events.OnEventOptions",
+          },
+        },
+      ],
+      "snippet": "\`\`\`typescript
+public onCloudTrailEvent(id: string, options?: OnEventOptions)
+\`\`\`
+",
+    },
+    Object {
+      "id": "@aws-cdk/aws-ecr.IRepository.onCloudTrailImagePushed",
+      "name": "onCloudTrailImagePushed",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The id of the rule.",
+          "id": "@aws-cdk/aws-ecr.IRepository.id",
+          "name": "id",
+          "optional": false,
+          "type": Object {
+            "name": "string",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Options for adding the rule.",
+          "id": "@aws-cdk/aws-ecr.IRepository.options",
+          "name": "options",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions",
+            "name": "@aws-cdk/aws-ecr.OnCloudTrailImagePushedOptions",
+          },
+        },
+      ],
+      "snippet": "\`\`\`typescript
+public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOptions)
+\`\`\`
+",
+    },
+    Object {
+      "id": "@aws-cdk/aws-ecr.IRepository.onEvent",
+      "name": "onEvent",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "@aws-cdk/aws-ecr.IRepository.id",
+          "name": "id",
+          "optional": false,
+          "type": Object {
+            "name": "string",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "",
+          "id": "@aws-cdk/aws-ecr.IRepository.options",
+          "name": "options",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-events.OnEventOptions",
+            "name": "@aws-cdk/aws-events.OnEventOptions",
+          },
+        },
+      ],
+      "snippet": "\`\`\`typescript
+public onEvent(id: string, options?: OnEventOptions)
+\`\`\`
+",
+    },
+    Object {
+      "id": "@aws-cdk/aws-ecr.IRepository.onImageScanCompleted",
+      "name": "onImageScanCompleted",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "The id of the rule.",
+          "id": "@aws-cdk/aws-ecr.IRepository.id",
+          "name": "id",
+          "optional": false,
+          "type": Object {
+            "name": "string",
+          },
+        },
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Options for adding the rule.",
+          "id": "@aws-cdk/aws-ecr.IRepository.options",
+          "name": "options",
+          "optional": true,
+          "type": Object {
+            "fqn": "@aws-cdk/aws-ecr.OnImageScanCompletedOptions",
+            "name": "@aws-cdk/aws-ecr.OnImageScanCompletedOptions",
+          },
+        },
+      ],
+      "snippet": "\`\`\`typescript
+public onImageScanCompleted(id: string, options?: OnImageScanCompletedOptions)
+\`\`\`
+",
+    },
+    Object {
+      "id": "@aws-cdk/aws-ecr.IRepository.repositoryUriForDigest",
+      "name": "repositoryUriForDigest",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Image digest to use (tools usually default to the image with the \\"latest\\" tag if omitted).",
+          "id": "@aws-cdk/aws-ecr.IRepository.digest",
+          "name": "digest",
+          "optional": true,
+          "type": Object {
+            "name": "string",
+          },
+        },
+      ],
+      "snippet": "\`\`\`typescript
+public repositoryUriForDigest(digest?: string)
+\`\`\`
+",
+    },
+    Object {
+      "id": "@aws-cdk/aws-ecr.IRepository.repositoryUriForTag",
+      "name": "repositoryUriForTag",
+      "parameters": Array [
+        Object {
+          "default": undefined,
+          "deprecated": false,
+          "deprecationReason": undefined,
+          "docs": "Image tag to use (tools usually default to \\"latest\\" if omitted).",
+          "id": "@aws-cdk/aws-ecr.IRepository.tag",
+          "name": "tag",
+          "optional": true,
+          "type": Object {
+            "name": "string",
+          },
+        },
+      ],
+      "snippet": "\`\`\`typescript
+public repositoryUriForTag(tag?: string)
+\`\`\`
+",
+    },
+  ],
+  "interfaces": Array [
+    Object {
+      "fqn": "@aws-cdk/core.IResource",
+      "name": "@aws-cdk/core.IResource",
+    },
+  ],
+  "name": "IRepository",
+  "properties": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The construct tree node for this construct.",
+      "id": "@aws-cdk/aws-ecr.IRepository.node",
+      "name": "node",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.ConstructNode",
+        "name": "@aws-cdk/core.ConstructNode",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.",
+      "id": "@aws-cdk/aws-ecr.IRepository.env",
+      "name": "env",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.ResourceEnvironment",
+        "name": "@aws-cdk/core.ResourceEnvironment",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The stack in which this resource is defined.",
+      "id": "@aws-cdk/aws-ecr.IRepository.stack",
+      "name": "stack",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/core.Stack",
+        "name": "@aws-cdk/core.Stack",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The ARN of the repository.",
+      "id": "@aws-cdk/aws-ecr.IRepository.repositoryArn",
+      "name": "repositoryArn",
+      "optional": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The name of the repository.",
+      "id": "@aws-cdk/aws-ecr.IRepository.repositoryName",
+      "name": "repositoryName",
+      "optional": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "The URI of this repository (represents the latest image):.
+
+ACCOUNT.dkr.ecr.REGION.amazonaws.com/REPOSITORY",
+      "id": "@aws-cdk/aws-ecr.IRepository.repositoryUri",
+      "name": "repositoryUri",
+      "optional": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+  ],
+}
+`;
+
+exports[`typescript markdown snapshot 1`] = `
 " IRepository <a name=\\"@aws-cdk/aws-ecr.IRepository\\"></a>
 
 - *Extends:* [\`@aws-cdk/core.IResource\`](#@aws-cdk/core.IResource)

--- a/test/docgen/view/__snapshots__/parameter.test.ts.snap
+++ b/test/docgen/view/__snapshots__/parameter.test.ts.snap
@@ -1,6 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csharp snapshot 1`] = `
+exports[`csharp json snapshot 1`] = `
+Object {
+  "default": undefined,
+  "deprecated": false,
+  "deprecationReason": undefined,
+  "docs": "",
+  "id": "Amazon.CDK.AWS.ECR.AuthorizationToken.Grantee",
+  "name": "Grantee",
+  "optional": false,
+  "type": Object {
+    "fqn": "@aws-cdk/aws-iam.IGrantable",
+    "name": "Amazon.CDK.AWS.IAM.IGrantable",
+  },
+}
+`;
+
+exports[`csharp markdown snapshot 1`] = `
 " \`Grantee\`<sup>Required</sup> <a name=\\"Amazon.CDK.AWS.ECR.AuthorizationToken.parameter.Grantee\\"></a>
 
 - *Type:* [\`Amazon.CDK.AWS.IAM.IGrantable\`](#Amazon.CDK.AWS.IAM.IGrantable)
@@ -9,7 +25,23 @@ exports[`csharp snapshot 1`] = `
 "
 `;
 
-exports[`java snapshot 1`] = `
+exports[`java json snapshot 1`] = `
+Object {
+  "default": undefined,
+  "deprecated": false,
+  "deprecationReason": undefined,
+  "docs": "",
+  "id": "software.amazon.awscdk.services.ecr.AuthorizationToken.grantee",
+  "name": "grantee",
+  "optional": false,
+  "type": Object {
+    "fqn": "@aws-cdk/aws-iam.IGrantable",
+    "name": "software.amazon.awscdk.services.iam.IGrantable",
+  },
+}
+`;
+
+exports[`java markdown snapshot 1`] = `
 " \`grantee\`<sup>Required</sup> <a name=\\"software.amazon.awscdk.services.ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`software.amazon.awscdk.services.iam.IGrantable\`](#software.amazon.awscdk.services.iam.IGrantable)
@@ -18,7 +50,23 @@ exports[`java snapshot 1`] = `
 "
 `;
 
-exports[`python snapshot 1`] = `
+exports[`python json snapshot 1`] = `
+Object {
+  "default": undefined,
+  "deprecated": false,
+  "deprecationReason": undefined,
+  "docs": "",
+  "id": "aws_cdk.aws_ecr.AuthorizationToken.grantee",
+  "name": "grantee",
+  "optional": false,
+  "type": Object {
+    "fqn": "@aws-cdk/aws-iam.IGrantable",
+    "name": "aws_cdk.aws_iam.IGrantable",
+  },
+}
+`;
+
+exports[`python markdown snapshot 1`] = `
 " \`grantee\`<sup>Required</sup> <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`aws_cdk.aws_iam.IGrantable\`](#aws_cdk.aws_iam.IGrantable)
@@ -27,7 +75,23 @@ exports[`python snapshot 1`] = `
 "
 `;
 
-exports[`typescript snapshot 1`] = `
+exports[`typescript json snapshot 1`] = `
+Object {
+  "default": undefined,
+  "deprecated": false,
+  "deprecationReason": undefined,
+  "docs": "",
+  "id": "@aws-cdk/aws-ecr.AuthorizationToken.grantee",
+  "name": "grantee",
+  "optional": false,
+  "type": Object {
+    "fqn": "@aws-cdk/aws-iam.IGrantable",
+    "name": "@aws-cdk/aws-iam.IGrantable",
+  },
+}
+`;
+
+exports[`typescript markdown snapshot 1`] = `
 " \`grantee\`<sup>Required</sup> <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken.parameter.grantee\\"></a>
 
 - *Type:* [\`@aws-cdk/aws-iam.IGrantable\`](#@aws-cdk/aws-iam.IGrantable)

--- a/test/docgen/view/__snapshots__/property.test.ts.snap
+++ b/test/docgen/view/__snapshots__/property.test.ts.snap
@@ -1,6 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csharp snapshot 1`] = `
+exports[`csharp json snapshot 1`] = `
+Object {
+  "default": undefined,
+  "deprecated": false,
+  "deprecationReason": undefined,
+  "docs": "\`AWS::ECR::PublicRepository.RepositoryCatalogData\`.",
+  "id": "Amazon.CDK.AWS.ECR.CfnPublicRepositoryProps.RepositoryCatalogData",
+  "name": "RepositoryCatalogData",
+  "optional": true,
+  "type": Object {
+    "name": "object",
+  },
+}
+`;
+
+exports[`csharp markdown snapshot 1`] = `
 " \`RepositoryCatalogData\`<sup>Optional</sup> <a name=\\"Amazon.CDK.AWS.ECR.CfnPublicRepositoryProps.property.RepositoryCatalogData\\"></a>
 
 \`\`\`csharp
@@ -17,7 +32,22 @@ public object RepositoryCatalogData { get; set; }
 "
 `;
 
-exports[`java snapshot 1`] = `
+exports[`java json snapshot 1`] = `
+Object {
+  "default": undefined,
+  "deprecated": false,
+  "deprecationReason": undefined,
+  "docs": "\`AWS::ECR::PublicRepository.RepositoryCatalogData\`.",
+  "id": "software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.repositoryCatalogData",
+  "name": "repositoryCatalogData",
+  "optional": true,
+  "type": Object {
+    "name": "java.lang.Object",
+  },
+}
+`;
+
+exports[`java markdown snapshot 1`] = `
 " \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 \`\`\`java
@@ -34,7 +64,22 @@ public java.lang.Object getRepositoryCatalogData();
 "
 `;
 
-exports[`python snapshot 1`] = `
+exports[`python json snapshot 1`] = `
+Object {
+  "default": undefined,
+  "deprecated": false,
+  "deprecationReason": undefined,
+  "docs": "\`AWS::ECR::PublicRepository.RepositoryCatalogData\`.",
+  "id": "aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_catalog_data",
+  "name": "repository_catalog_data",
+  "optional": true,
+  "type": Object {
+    "name": "typing.Any",
+  },
+}
+`;
+
+exports[`python markdown snapshot 1`] = `
 " \`repository_catalog_data\`<sup>Optional</sup> <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps.property.repository_catalog_data\\"></a>
 
 \`\`\`python
@@ -51,7 +96,22 @@ repository_catalog_data: typing.Any
 "
 `;
 
-exports[`typescript snapshot 1`] = `
+exports[`typescript json snapshot 1`] = `
+Object {
+  "default": undefined,
+  "deprecated": false,
+  "deprecationReason": undefined,
+  "docs": "\`AWS::ECR::PublicRepository.RepositoryCatalogData\`.",
+  "id": "@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryCatalogData",
+  "name": "repositoryCatalogData",
+  "optional": true,
+  "type": Object {
+    "name": "any",
+  },
+}
+`;
+
+exports[`typescript markdown snapshot 1`] = `
 " \`repositoryCatalogData\`<sup>Optional</sup> <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps.property.repositoryCatalogData\\"></a>
 
 \`\`\`typescript

--- a/test/docgen/view/__snapshots__/static-function.test.ts.snap
+++ b/test/docgen/view/__snapshots__/static-function.test.ts.snap
@@ -1,6 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csharp snapshot 1`] = `
+exports[`csharp json snapshot 1`] = `
+Object {
+  "id": "Amazon.CDK.AWS.ECR.AuthorizationToken.Initializer",
+  "name": "GrantRead",
+  "parameters": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "",
+      "id": "Amazon.CDK.AWS.ECR.AuthorizationToken.Grantee",
+      "name": "Grantee",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/aws-iam.IGrantable",
+        "name": "Amazon.CDK.AWS.IAM.IGrantable",
+      },
+    },
+  ],
+  "snippet": "\`\`\`csharp
+using Amazon.CDK.AWS.ECR;
+
+AuthorizationToken.GrantRead(IGrantable Grantee);
+\`\`\`
+",
+}
+`;
+
+exports[`csharp markdown snapshot 1`] = `
 " \`GrantRead\` <a name=\\"Amazon.CDK.AWS.ECR.AuthorizationToken.GrantRead\\"></a>
 
 \`\`\`csharp
@@ -17,7 +45,35 @@ AuthorizationToken.GrantRead(IGrantable Grantee);
 "
 `;
 
-exports[`java snapshot 1`] = `
+exports[`java json snapshot 1`] = `
+Object {
+  "id": "software.amazon.awscdk.services.ecr.AuthorizationToken.Initializer",
+  "name": "grantRead",
+  "parameters": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "",
+      "id": "software.amazon.awscdk.services.ecr.AuthorizationToken.grantee",
+      "name": "grantee",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/aws-iam.IGrantable",
+        "name": "software.amazon.awscdk.services.iam.IGrantable",
+      },
+    },
+  ],
+  "snippet": "\`\`\`java
+import software.amazon.awscdk.services.ecr.AuthorizationToken;
+
+AuthorizationToken.grantRead(IGrantable grantee)
+\`\`\`
+",
+}
+`;
+
+exports[`java markdown snapshot 1`] = `
 " \`grantRead\` <a name=\\"software.amazon.awscdk.services.ecr.AuthorizationToken.grantRead\\"></a>
 
 \`\`\`java
@@ -34,7 +90,37 @@ AuthorizationToken.grantRead(IGrantable grantee)
 "
 `;
 
-exports[`python snapshot 1`] = `
+exports[`python json snapshot 1`] = `
+Object {
+  "id": "aws_cdk.aws_ecr.AuthorizationToken.Initializer",
+  "name": "grant_read",
+  "parameters": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "",
+      "id": "aws_cdk.aws_ecr.AuthorizationToken.grantee",
+      "name": "grantee",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/aws-iam.IGrantable",
+        "name": "aws_cdk.aws_iam.IGrantable",
+      },
+    },
+  ],
+  "snippet": "\`\`\`python
+import aws_cdk.aws_ecr
+
+aws_cdk.aws_ecr.AuthorizationToken.grant_read(
+  grantee: IGrantable
+)
+\`\`\`
+",
+}
+`;
+
+exports[`python markdown snapshot 1`] = `
 " \`grant_read\` <a name=\\"aws_cdk.aws_ecr.AuthorizationToken.grant_read\\"></a>
 
 \`\`\`python
@@ -53,7 +139,35 @@ aws_cdk.aws_ecr.AuthorizationToken.grant_read(
 "
 `;
 
-exports[`typescript snapshot 1`] = `
+exports[`typescript json snapshot 1`] = `
+Object {
+  "id": "@aws-cdk/aws-ecr.AuthorizationToken.Initializer",
+  "name": "grantRead",
+  "parameters": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "",
+      "id": "@aws-cdk/aws-ecr.AuthorizationToken.grantee",
+      "name": "grantee",
+      "optional": false,
+      "type": Object {
+        "fqn": "@aws-cdk/aws-iam.IGrantable",
+        "name": "@aws-cdk/aws-iam.IGrantable",
+      },
+    },
+  ],
+  "snippet": "\`\`\`typescript
+import { AuthorizationToken } from '@aws-cdk/aws-ecr'
+
+AuthorizationToken.grantRead(grantee: IGrantable)
+\`\`\`
+",
+}
+`;
+
+exports[`typescript markdown snapshot 1`] = `
 " \`grantRead\` <a name=\\"@aws-cdk/aws-ecr.AuthorizationToken.grantRead\\"></a>
 
 \`\`\`typescript

--- a/test/docgen/view/__snapshots__/struct.test.ts.snap
+++ b/test/docgen/view/__snapshots__/struct.test.ts.snap
@@ -1,6 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csharp snapshot 1`] = `
+exports[`csharp json snapshot 1`] = `
+Object {
+  "docs": "Properties for defining a \`AWS::ECR::PublicRepository\`.",
+  "id": "Amazon.CDK.AWS.ECR.CfnPublicRepositoryProps",
+  "initializer": "\`\`\`csharp
+using Amazon.CDK.AWS.ECR;
+
+new CfnPublicRepositoryProps {
+    object RepositoryCatalogData = null,
+    string RepositoryName = null,
+    object RepositoryPolicyText = null,
+    CfnTag[] Tags = null
+};
+\`\`\`
+",
+  "name": "CfnPublicRepositoryProps",
+  "properties": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryCatalogData\`.",
+      "id": "Amazon.CDK.AWS.ECR.CfnPublicRepositoryProps.RepositoryCatalogData",
+      "name": "RepositoryCatalogData",
+      "optional": true,
+      "type": Object {
+        "name": "object",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryName\`.",
+      "id": "Amazon.CDK.AWS.ECR.CfnPublicRepositoryProps.RepositoryName",
+      "name": "RepositoryName",
+      "optional": true,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryPolicyText\`.",
+      "id": "Amazon.CDK.AWS.ECR.CfnPublicRepositoryProps.RepositoryPolicyText",
+      "name": "RepositoryPolicyText",
+      "optional": true,
+      "type": Object {
+        "name": "object",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.Tags\`.",
+      "id": "Amazon.CDK.AWS.ECR.CfnPublicRepositoryProps.Tags",
+      "name": "Tags",
+      "optional": true,
+      "type": Object {
+        "name": "%[]",
+        "types": Array [
+          Object {
+            "fqn": "@aws-cdk/core.CfnTag",
+            "name": "Amazon.CDK.CfnTag",
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`csharp markdown snapshot 1`] = `
 " CfnPublicRepositoryProps <a name=\\"Amazon.CDK.AWS.ECR.CfnPublicRepositoryProps\\"></a>
 
 Properties for defining a \`AWS::ECR::PublicRepository\`.
@@ -78,7 +153,82 @@ public CfnTag[] Tags { get; set; }
 "
 `;
 
-exports[`java snapshot 1`] = `
+exports[`java json snapshot 1`] = `
+Object {
+  "docs": "Properties for defining a \`AWS::ECR::PublicRepository\`.",
+  "id": "software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps",
+  "initializer": "\`\`\`java
+import software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps;
+
+CfnPublicRepositoryProps.builder()
+//  .repositoryCatalogData(java.lang.Object)
+//  .repositoryName(java.lang.String)
+//  .repositoryPolicyText(java.lang.Object)
+//  .tags(java.util.List<CfnTag>)
+    .build();
+\`\`\`
+",
+  "name": "CfnPublicRepositoryProps",
+  "properties": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryCatalogData\`.",
+      "id": "software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.repositoryCatalogData",
+      "name": "repositoryCatalogData",
+      "optional": true,
+      "type": Object {
+        "name": "java.lang.Object",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryName\`.",
+      "id": "software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.repositoryName",
+      "name": "repositoryName",
+      "optional": true,
+      "type": Object {
+        "name": "java.lang.String",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryPolicyText\`.",
+      "id": "software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.repositoryPolicyText",
+      "name": "repositoryPolicyText",
+      "optional": true,
+      "type": Object {
+        "name": "java.lang.Object",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.Tags\`.",
+      "id": "software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps.tags",
+      "name": "tags",
+      "optional": true,
+      "type": Object {
+        "name": "java.util.List<%>",
+        "types": Array [
+          Object {
+            "fqn": "@aws-cdk/core.CfnTag",
+            "name": "software.amazon.awscdk.core.CfnTag",
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`java markdown snapshot 1`] = `
 " CfnPublicRepositoryProps <a name=\\"software.amazon.awscdk.services.ecr.CfnPublicRepositoryProps\\"></a>
 
 Properties for defining a \`AWS::ECR::PublicRepository\`.
@@ -156,7 +306,82 @@ public java.util.List<CfnTag> getTags();
 "
 `;
 
-exports[`python snapshot 1`] = `
+exports[`python json snapshot 1`] = `
+Object {
+  "docs": "Properties for defining a \`AWS::ECR::PublicRepository\`.",
+  "id": "aws_cdk.aws_ecr.CfnPublicRepositoryProps",
+  "initializer": "\`\`\`python
+import aws_cdk.aws_ecr
+
+aws_cdk.aws_ecr.CfnPublicRepositoryProps(
+  repository_catalog_data: typing.Any = None,
+  repository_name: str = None,
+  repository_policy_text: typing.Any = None,
+  tags: typing.List[CfnTag] = None
+)
+\`\`\`
+",
+  "name": "CfnPublicRepositoryProps",
+  "properties": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryCatalogData\`.",
+      "id": "aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_catalog_data",
+      "name": "repository_catalog_data",
+      "optional": true,
+      "type": Object {
+        "name": "typing.Any",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryName\`.",
+      "id": "aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_name",
+      "name": "repository_name",
+      "optional": true,
+      "type": Object {
+        "name": "str",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryPolicyText\`.",
+      "id": "aws_cdk.aws_ecr.CfnPublicRepositoryProps.repository_policy_text",
+      "name": "repository_policy_text",
+      "optional": true,
+      "type": Object {
+        "name": "typing.Any",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.Tags\`.",
+      "id": "aws_cdk.aws_ecr.CfnPublicRepositoryProps.tags",
+      "name": "tags",
+      "optional": true,
+      "type": Object {
+        "name": "typing.List[%]",
+        "types": Array [
+          Object {
+            "fqn": "@aws-cdk/core.CfnTag",
+            "name": "aws_cdk.core.CfnTag",
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`python markdown snapshot 1`] = `
 " CfnPublicRepositoryProps <a name=\\"aws_cdk.aws_ecr.CfnPublicRepositoryProps\\"></a>
 
 Properties for defining a \`AWS::ECR::PublicRepository\`.
@@ -234,7 +459,77 @@ tags: typing.List[CfnTag]
 "
 `;
 
-exports[`typescript snapshot 1`] = `
+exports[`typescript json snapshot 1`] = `
+Object {
+  "docs": "Properties for defining a \`AWS::ECR::PublicRepository\`.",
+  "id": "@aws-cdk/aws-ecr.CfnPublicRepositoryProps",
+  "initializer": "\`\`\`typescript
+import { CfnPublicRepositoryProps } from '@aws-cdk/aws-ecr'
+
+const cfnPublicRepositoryProps: CfnPublicRepositoryProps = { ... }
+\`\`\`
+",
+  "name": "CfnPublicRepositoryProps",
+  "properties": Array [
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryCatalogData\`.",
+      "id": "@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryCatalogData",
+      "name": "repositoryCatalogData",
+      "optional": true,
+      "type": Object {
+        "name": "any",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryName\`.",
+      "id": "@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryName",
+      "name": "repositoryName",
+      "optional": true,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.RepositoryPolicyText\`.",
+      "id": "@aws-cdk/aws-ecr.CfnPublicRepositoryProps.repositoryPolicyText",
+      "name": "repositoryPolicyText",
+      "optional": true,
+      "type": Object {
+        "name": "any",
+      },
+    },
+    Object {
+      "default": undefined,
+      "deprecated": false,
+      "deprecationReason": undefined,
+      "docs": "\`AWS::ECR::PublicRepository.Tags\`.",
+      "id": "@aws-cdk/aws-ecr.CfnPublicRepositoryProps.tags",
+      "name": "tags",
+      "optional": true,
+      "type": Object {
+        "name": "%[]",
+        "types": Array [
+          Object {
+            "fqn": "@aws-cdk/core.CfnTag",
+            "name": "@aws-cdk/core.CfnTag",
+          },
+        ],
+      },
+    },
+  ],
+}
+`;
+
+exports[`typescript markdown snapshot 1`] = `
 " CfnPublicRepositoryProps <a name=\\"@aws-cdk/aws-ecr.CfnPublicRepositoryProps\\"></a>
 
 Properties for defining a \`AWS::ECR::PublicRepository\`.

--- a/test/docgen/view/class.test.ts
+++ b/test/docgen/view/class.test.ts
@@ -12,31 +12,31 @@ const assembly: reflect.Assembly = Assemblies.instance.withoutSubmodules;
 describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
-    const klass = new Class(transpile, assembly.classes[0], (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.toMarkdown().render()).toMatchSnapshot();
+    const klass = new Class(transpile, assembly.classes[0]);
+    expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
-    const klass = new Class(transpile, assembly.classes[0], (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.toMarkdown().render()).toMatchSnapshot();
+    const klass = new Class(transpile, assembly.classes[0]);
+    expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
-    const klass = new Class(transpile, assembly.classes[0], (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.toMarkdown().render()).toMatchSnapshot();
+    const klass = new Class(transpile, assembly.classes[0]);
+    expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
-    const klass = new Class(transpile, assembly.classes[0], (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.toMarkdown().render()).toMatchSnapshot();
+    const klass = new Class(transpile, assembly.classes[0]);
+    expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/class.test.ts
+++ b/test/docgen/view/class.test.ts
@@ -19,24 +19,39 @@ describe('python', () => {
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const klass = new Class(transpile, assembly.classes[0]);
     expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const klass = new Class(transpile, assembly.classes[0]);
+    expect(klass.toJson()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const klass = new Class(transpile, assembly.classes[0]);
     expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const klass = new Class(transpile, assembly.classes[0]);
+    expect(klass.toJson()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const klass = new Class(transpile, assembly.classes[0]);
     expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const klass = new Class(transpile, assembly.classes[0]);
+    expect(klass.toJson()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/class.test.ts
+++ b/test/docgen/view/class.test.ts
@@ -13,7 +13,7 @@ describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
     const klass = new Class(transpile, assembly.classes[0], (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.render().render()).toMatchSnapshot();
+    expect(klass.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -21,7 +21,7 @@ describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
     const klass = new Class(transpile, assembly.classes[0], (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.render().render()).toMatchSnapshot();
+    expect(klass.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -29,7 +29,7 @@ describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
     const klass = new Class(transpile, assembly.classes[0], (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.render().render()).toMatchSnapshot();
+    expect(klass.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -37,6 +37,6 @@ describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
     const klass = new Class(transpile, assembly.classes[0], (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.render().render()).toMatchSnapshot();
+    expect(klass.toMarkdown().render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/documentation.test.ts
+++ b/test/docgen/view/documentation.test.ts
@@ -37,7 +37,7 @@ test('custom link formatter', async () => {
   const docs = await Documentation.forPackage('@aws-cdk/aws-ecr@1.106.0', {
     language: Language.PYTHON,
   });
-  const markdown = docs.render({ linkFormatter: (t: TranspiledType) => `#custom-${t.fqn}` });
+  const markdown = docs.toMarkdown({ linkFormatter: (t: TranspiledType) => `#custom-${t.fqn}` });
   expect(markdown.render()).toMatchSnapshot();
 });
 
@@ -61,7 +61,7 @@ test('package installation does not run lifecycle hooks', async () => {
 
   // this should succeed because the failure script should be ignored
   const docs = await Documentation.forPackage(path.join(workdir, 'dist', 'js', `${libraryName}@0.0.0.jsii.tgz`), { name: libraryName });
-  const markdown = docs.render();
+  const markdown = docs.toMarkdown();
   expect(markdown.render()).toMatchSnapshot();
 });
 
@@ -70,7 +70,7 @@ describe('python', () => {
     const docs = await Documentation.forPackage('@aws-cdk/aws-ecr@1.106.0', {
       language: Language.PYTHON,
     });
-    const markdown = docs.render();
+    const markdown = docs.toMarkdown();
     expect(markdown.render()).toMatchSnapshot();
   });
 
@@ -78,7 +78,7 @@ describe('python', () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-ecr', Assemblies.AWSCDK_1_106_0, {
       language: Language.PYTHON,
     });
-    const markdown = docs.render();
+    const markdown = docs.toMarkdown();
     expect(markdown.render()).toMatchSnapshot();
   });
 
@@ -86,7 +86,7 @@ describe('python', () => {
     const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0, {
       language: Language.PYTHON,
     });
-    const markdown = docs.render({ submodule: 'aws_eks' });
+    const markdown = docs.toMarkdown({ submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
   });
 });
@@ -94,19 +94,19 @@ describe('python', () => {
 describe('typescript', () => {
   test('for package', async () => {
     const docs = await Documentation.forPackage('@aws-cdk/aws-ecr@1.106.0');
-    const markdown = docs.render();
+    const markdown = docs.toMarkdown();
     expect(markdown.render()).toMatchSnapshot();
   });
 
   test('snapshot - single module', async () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-ecr', Assemblies.AWSCDK_1_106_0);
-    const markdown = docs.render();
+    const markdown = docs.toMarkdown();
     expect(markdown.render()).toMatchSnapshot();
   });
 
   test('snapshot - submodules', async () => {
     const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0);
-    const markdown = docs.render({ submodule: 'aws_eks' });
+    const markdown = docs.toMarkdown({ submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
   });
 });
@@ -116,7 +116,7 @@ describe('java', () => {
     const docs = await Documentation.forPackage('@aws-cdk/aws-ecr@1.106.0', {
       language: Language.JAVA,
     });
-    const markdown = docs.render();
+    const markdown = docs.toMarkdown();
     expect(markdown.render()).toMatchSnapshot();
   });
 
@@ -124,7 +124,7 @@ describe('java', () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-ecr', Assemblies.AWSCDK_1_106_0, {
       language: Language.JAVA,
     });
-    const markdown = docs.render();
+    const markdown = docs.toMarkdown();
     expect(markdown.render()).toMatchSnapshot();
   });
 
@@ -132,7 +132,7 @@ describe('java', () => {
     const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0, {
       language: Language.JAVA,
     });
-    const markdown = docs.render({ submodule: 'aws_eks' });
+    const markdown = docs.toMarkdown({ submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
   });
 
@@ -140,7 +140,7 @@ describe('java', () => {
     const docs = await Documentation.forAssembly('monocdk', Assemblies.AWSCDK_1_106_0, {
       language: Language.JAVA,
     });
-    const markdown = docs.render({ submodule: 'aws_eks' });
+    const markdown = docs.toMarkdown({ submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
   });
 });
@@ -150,7 +150,7 @@ describe('csharp', () => {
     const docs = await Documentation.forPackage('@aws-cdk/aws-ecr@1.106.0', {
       language: Language.CSHARP,
     });
-    const markdown = docs.render();
+    const markdown = docs.toMarkdown();
     expect(markdown.render()).toMatchSnapshot();
   });
 
@@ -158,7 +158,7 @@ describe('csharp', () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-ecr', Assemblies.AWSCDK_1_106_0, {
       language: Language.CSHARP,
     });
-    const markdown = docs.render();
+    const markdown = docs.toMarkdown();
     expect(markdown.render()).toMatchSnapshot();
   });
 
@@ -166,7 +166,7 @@ describe('csharp', () => {
     const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0, {
       language: Language.CSHARP,
     });
-    const markdown = docs.render({ submodule: 'aws_eks' });
+    const markdown = docs.toMarkdown({ submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
   });
 
@@ -174,7 +174,7 @@ describe('csharp', () => {
     const docs = await Documentation.forAssembly('monocdk', Assemblies.AWSCDK_1_106_0, {
       language: Language.CSHARP,
     });
-    const markdown = docs.render({ submodule: 'aws_eks' });
+    const markdown = docs.toMarkdown({ submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/documentation.test.ts
+++ b/test/docgen/view/documentation.test.ts
@@ -74,7 +74,7 @@ describe('python', () => {
     expect(markdown.render()).toMatchSnapshot();
   });
 
-  test('snapshot - root module', async () => {
+  test('markdown snapshot - root module', async () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-ecr', Assemblies.AWSCDK_1_106_0, {
       language: Language.PYTHON,
     });
@@ -82,12 +82,28 @@ describe('python', () => {
     expect(markdown.render()).toMatchSnapshot();
   });
 
-  test('snapshot - submodules', async () => {
+  test('markdown snapshot - submodules', async () => {
     const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0, {
       language: Language.PYTHON,
     });
     const markdown = docs.toMarkdown({ submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
+  });
+
+  test('json snapshot - root module', async () => {
+    const docs = await Documentation.forAssembly('@aws-cdk/aws-ecr', Assemblies.AWSCDK_1_106_0, {
+      language: Language.PYTHON,
+    });
+    const json = docs.toJson();
+    expect(json.render()).toMatchSnapshot();
+  });
+
+  test('json snapshot - submodules', async () => {
+    const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0, {
+      language: Language.PYTHON,
+    });
+    const json = docs.toJson({ submodule: 'aws_eks' });
+    expect(json.render()).toMatchSnapshot();
   });
 });
 
@@ -98,16 +114,28 @@ describe('typescript', () => {
     expect(markdown.render()).toMatchSnapshot();
   });
 
-  test('snapshot - single module', async () => {
+  test('markdown snapshot - single module', async () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-ecr', Assemblies.AWSCDK_1_106_0);
     const markdown = docs.toMarkdown();
     expect(markdown.render()).toMatchSnapshot();
   });
 
-  test('snapshot - submodules', async () => {
+  test('markdown snapshot - submodules', async () => {
     const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0);
     const markdown = docs.toMarkdown({ submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
+  });
+
+  test('json snapshot - single module', async () => {
+    const docs = await Documentation.forAssembly('@aws-cdk/aws-ecr', Assemblies.AWSCDK_1_106_0);
+    const json = docs.toJson();
+    expect(json.render()).toMatchSnapshot();
+  });
+
+  test('json snapshot - submodules', async () => {
+    const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0);
+    const json = docs.toJson({ submodule: 'aws_eks' });
+    expect(json.render()).toMatchSnapshot();
   });
 });
 
@@ -120,7 +148,7 @@ describe('java', () => {
     expect(markdown.render()).toMatchSnapshot();
   });
 
-  test('snapshot - root module', async () => {
+  test('markdown snapshot - root module', async () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-ecr', Assemblies.AWSCDK_1_106_0, {
       language: Language.JAVA,
     });
@@ -128,7 +156,7 @@ describe('java', () => {
     expect(markdown.render()).toMatchSnapshot();
   });
 
-  test('snapshot - submodules', async () => {
+  test('markdown snapshot - submodules', async () => {
     const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0, {
       language: Language.JAVA,
     });
@@ -136,12 +164,36 @@ describe('java', () => {
     expect(markdown.render()).toMatchSnapshot();
   });
 
-  test('snapshot - submodules 2', async () => {
+  test('markdown snapshot - submodules 2', async () => {
     const docs = await Documentation.forAssembly('monocdk', Assemblies.AWSCDK_1_106_0, {
       language: Language.JAVA,
     });
     const markdown = docs.toMarkdown({ submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
+  });
+
+  test('json snapshot - root module', async () => {
+    const docs = await Documentation.forAssembly('@aws-cdk/aws-ecr', Assemblies.AWSCDK_1_106_0, {
+      language: Language.JAVA,
+    });
+    const json = docs.toJson();
+    expect(json.render()).toMatchSnapshot();
+  });
+
+  test('Json snapshot - submodules', async () => {
+    const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0, {
+      language: Language.JAVA,
+    });
+    const json = docs.toJson({ submodule: 'aws_eks' });
+    expect(json.render()).toMatchSnapshot();
+  });
+
+  test('json snapshot - submodules 2', async () => {
+    const docs = await Documentation.forAssembly('monocdk', Assemblies.AWSCDK_1_106_0, {
+      language: Language.JAVA,
+    });
+    const json = docs.toJson({ submodule: 'aws_eks' });
+    expect(json.render()).toMatchSnapshot();
   });
 });
 
@@ -154,7 +206,7 @@ describe('csharp', () => {
     expect(markdown.render()).toMatchSnapshot();
   });
 
-  test('snapshot - root module', async () => {
+  test('markdown snapshot - root module', async () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-ecr', Assemblies.AWSCDK_1_106_0, {
       language: Language.CSHARP,
     });
@@ -162,7 +214,7 @@ describe('csharp', () => {
     expect(markdown.render()).toMatchSnapshot();
   });
 
-  test('snapshot - submodules', async () => {
+  test('markdown snapshot - submodules', async () => {
     const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0, {
       language: Language.CSHARP,
     });
@@ -170,11 +222,35 @@ describe('csharp', () => {
     expect(markdown.render()).toMatchSnapshot();
   });
 
-  test('snapshot - submodules 2', async () => {
+  test('markdown snapshot - submodules 2', async () => {
     const docs = await Documentation.forAssembly('monocdk', Assemblies.AWSCDK_1_106_0, {
       language: Language.CSHARP,
     });
     const markdown = docs.toMarkdown({ submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
+  });
+
+  test('json snapshot - root module', async () => {
+    const docs = await Documentation.forAssembly('@aws-cdk/aws-ecr', Assemblies.AWSCDK_1_106_0, {
+      language: Language.CSHARP,
+    });
+    const json = docs.toJson();
+    expect(json.render()).toMatchSnapshot();
+  });
+
+  test('json snapshot - submodules', async () => {
+    const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0, {
+      language: Language.CSHARP,
+    });
+    const json = docs.toJson({ submodule: 'aws_eks' });
+    expect(json.render()).toMatchSnapshot();
+  });
+
+  test('json snapshot - submodules 2', async () => {
+    const docs = await Documentation.forAssembly('monocdk', Assemblies.AWSCDK_1_106_0, {
+      language: Language.CSHARP,
+    });
+    const json = docs.toJson({ submodule: 'aws_eks' });
+    expect(json.render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/enum.test.ts
+++ b/test/docgen/view/enum.test.ts
@@ -18,24 +18,39 @@ describe('python', () => {
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const enu = new Enum(transpile, assembly.enums[0]);
     expect(enu.toMarkdown().render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const enu = new Enum(transpile, assembly.enums[0]);
+    expect(enu.toJson()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const enu = new Enum(transpile, assembly.enums[0]);
     expect(enu.toMarkdown().render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const enu = new Enum(transpile, assembly.enums[0]);
+    expect(enu.toJson()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const enu = new Enum(transpile, assembly.enums[0]);
     expect(enu.toMarkdown().render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const enu = new Enum(transpile, assembly.enums[0]);
+    expect(enu.toJson()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/enum.test.ts
+++ b/test/docgen/view/enum.test.ts
@@ -12,7 +12,7 @@ describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
     const enu = new Enum(transpile, assembly.enums[0]);
-    expect(enu.render().render()).toMatchSnapshot();
+    expect(enu.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -20,7 +20,7 @@ describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
     const enu = new Enum(transpile, assembly.enums[0]);
-    expect(enu.render().render()).toMatchSnapshot();
+    expect(enu.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -28,7 +28,7 @@ describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
     const enu = new Enum(transpile, assembly.enums[0]);
-    expect(enu.render().render()).toMatchSnapshot();
+    expect(enu.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -36,6 +36,6 @@ describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
     const enu = new Enum(transpile, assembly.enums[0]);
-    expect(enu.render().render()).toMatchSnapshot();
+    expect(enu.toMarkdown().render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/initializer.test.ts
+++ b/test/docgen/view/initializer.test.ts
@@ -21,31 +21,31 @@ const findInitializer = (): reflect.Initializer => {
 describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
-    const initializer = new Initializer(transpile, findInitializer(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(initializer.toMarkdown().render()).toMatchSnapshot();
+    const initializer = new Initializer(transpile, findInitializer());
+    expect(initializer.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
-    const initializer = new Initializer(transpile, findInitializer(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(initializer.toMarkdown().render()).toMatchSnapshot();
+    const initializer = new Initializer(transpile, findInitializer());
+    expect(initializer.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
-    const initializer = new Initializer(transpile, findInitializer(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(initializer.toMarkdown().render()).toMatchSnapshot();
+    const initializer = new Initializer(transpile, findInitializer());
+    expect(initializer.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
-    const initializer = new Initializer(transpile, findInitializer(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(initializer.toMarkdown().render()).toMatchSnapshot();
+    const initializer = new Initializer(transpile, findInitializer());
+    expect(initializer.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/initializer.test.ts
+++ b/test/docgen/view/initializer.test.ts
@@ -22,7 +22,7 @@ describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
     const initializer = new Initializer(transpile, findInitializer(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(initializer.render().render()).toMatchSnapshot();
+    expect(initializer.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -30,7 +30,7 @@ describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
     const initializer = new Initializer(transpile, findInitializer(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(initializer.render().render()).toMatchSnapshot();
+    expect(initializer.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -38,7 +38,7 @@ describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
     const initializer = new Initializer(transpile, findInitializer(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(initializer.render().render()).toMatchSnapshot();
+    expect(initializer.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -46,6 +46,6 @@ describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
     const initializer = new Initializer(transpile, findInitializer(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(initializer.render().render()).toMatchSnapshot();
+    expect(initializer.toMarkdown().render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/initializer.test.ts
+++ b/test/docgen/view/initializer.test.ts
@@ -20,32 +20,52 @@ const findInitializer = (): reflect.Initializer => {
 
 describe('python', () => {
   const transpile = new PythonTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const initializer = new Initializer(transpile, findInitializer());
     expect(initializer.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const initializer = new Initializer(transpile, findInitializer());
+    expect(initializer.toJson()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const initializer = new Initializer(transpile, findInitializer());
     expect(initializer.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const initializer = new Initializer(transpile, findInitializer());
+    expect(initializer.toJson()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const initializer = new Initializer(transpile, findInitializer());
     expect(initializer.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const initializer = new Initializer(transpile, findInitializer());
+    expect(initializer.toJson()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const initializer = new Initializer(transpile, findInitializer());
     expect(initializer.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const initializer = new Initializer(transpile, findInitializer());
+    expect(initializer.toJson()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/instance-method.test.ts
+++ b/test/docgen/view/instance-method.test.ts
@@ -24,7 +24,7 @@ describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
     const instanceMethod = new InstanceMethod(transpile, findInstanceMethod(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(instanceMethod.render().render()).toMatchSnapshot();
+    expect(instanceMethod.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -32,7 +32,7 @@ describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
     const instanceMethod = new InstanceMethod(transpile, findInstanceMethod(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(instanceMethod.render().render()).toMatchSnapshot();
+    expect(instanceMethod.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -40,7 +40,7 @@ describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
     const instanceMethod = new InstanceMethod(transpile, findInstanceMethod(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(instanceMethod.render().render()).toMatchSnapshot();
+    expect(instanceMethod.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -48,6 +48,6 @@ describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
     const instanceMethod = new InstanceMethod(transpile, findInstanceMethod(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(instanceMethod.render().render()).toMatchSnapshot();
+    expect(instanceMethod.toMarkdown().render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/instance-method.test.ts
+++ b/test/docgen/view/instance-method.test.ts
@@ -23,31 +23,31 @@ const findInstanceMethod = (): reflect.Method => {
 describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
-    const instanceMethod = new InstanceMethod(transpile, findInstanceMethod(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(instanceMethod.toMarkdown().render()).toMatchSnapshot();
+    const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
+    expect(instanceMethod.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
-    const instanceMethod = new InstanceMethod(transpile, findInstanceMethod(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(instanceMethod.toMarkdown().render()).toMatchSnapshot();
+    const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
+    expect(instanceMethod.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
-    const instanceMethod = new InstanceMethod(transpile, findInstanceMethod(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(instanceMethod.toMarkdown().render()).toMatchSnapshot();
+    const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
+    expect(instanceMethod.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
-    const instanceMethod = new InstanceMethod(transpile, findInstanceMethod(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(instanceMethod.toMarkdown().render()).toMatchSnapshot();
+    const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
+    expect(instanceMethod.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/instance-method.test.ts
+++ b/test/docgen/view/instance-method.test.ts
@@ -22,32 +22,52 @@ const findInstanceMethod = (): reflect.Method => {
 
 describe('python', () => {
   const transpile = new PythonTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
     expect(instanceMethod.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
+    expect(instanceMethod.toJson()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
     expect(instanceMethod.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
+    expect(instanceMethod.toJson()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
     expect(instanceMethod.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
+    expect(instanceMethod.toJson()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
     expect(instanceMethod.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const instanceMethod = new InstanceMethod(transpile, findInstanceMethod());
+    expect(instanceMethod.toJson()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/interface.test.ts
+++ b/test/docgen/view/interface.test.ts
@@ -21,31 +21,31 @@ const findInterface = () => {
 describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
-    const klass = new Interface(transpile, findInterface(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.toMarkdown().render()).toMatchSnapshot();
+    const klass = new Interface(transpile, findInterface());
+    expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
-    const klass = new Interface(transpile, findInterface(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.toMarkdown().render()).toMatchSnapshot();
+    const klass = new Interface(transpile, findInterface());
+    expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
-    const klass = new Interface(transpile, findInterface(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.toMarkdown().render()).toMatchSnapshot();
+    const klass = new Interface(transpile, findInterface());
+    expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
-    const klass = new Interface(transpile, findInterface(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.toMarkdown().render()).toMatchSnapshot();
+    const klass = new Interface(transpile, findInterface());
+    expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/interface.test.ts
+++ b/test/docgen/view/interface.test.ts
@@ -22,7 +22,7 @@ describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
     const klass = new Interface(transpile, findInterface(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.render().render()).toMatchSnapshot();
+    expect(klass.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -30,7 +30,7 @@ describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
     const klass = new Interface(transpile, findInterface(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.render().render()).toMatchSnapshot();
+    expect(klass.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -38,7 +38,7 @@ describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
     const klass = new Interface(transpile, findInterface(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.render().render()).toMatchSnapshot();
+    expect(klass.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -46,6 +46,6 @@ describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
     const klass = new Interface(transpile, findInterface(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(klass.render().render()).toMatchSnapshot();
+    expect(klass.toMarkdown().render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/interface.test.ts
+++ b/test/docgen/view/interface.test.ts
@@ -20,32 +20,52 @@ const findInterface = () => {
 
 describe('python', () => {
   const transpile = new PythonTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const klass = new Interface(transpile, findInterface());
     expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const klass = new Interface(transpile, findInterface());
+    expect(klass.toJson()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const klass = new Interface(transpile, findInterface());
     expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const klass = new Interface(transpile, findInterface());
+    expect(klass.toJson()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const klass = new Interface(transpile, findInterface());
     expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const klass = new Interface(transpile, findInterface());
+    expect(klass.toJson()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const klass = new Interface(transpile, findInterface());
     expect(klass.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const klass = new Interface(transpile, findInterface());
+    expect(klass.toJson()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/parameter.test.ts
+++ b/test/docgen/view/parameter.test.ts
@@ -24,7 +24,7 @@ describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
     const parameter = new Parameter(transpile, findParameter(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(parameter.render().render()).toMatchSnapshot();
+    expect(parameter.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -32,7 +32,7 @@ describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
     const parameter = new Parameter(transpile, findParameter(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(parameter.render().render()).toMatchSnapshot();
+    expect(parameter.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -40,7 +40,7 @@ describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
     const parameter = new Parameter(transpile, findParameter(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(parameter.render().render()).toMatchSnapshot();
+    expect(parameter.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -48,6 +48,6 @@ describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
     const parameter = new Parameter(transpile, findParameter(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(parameter.render().render()).toMatchSnapshot();
+    expect(parameter.toMarkdown().render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/parameter.test.ts
+++ b/test/docgen/view/parameter.test.ts
@@ -22,32 +22,52 @@ const findParameter = (): reflect.Parameter => {
 
 describe('python', () => {
   const transpile = new PythonTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const parameter = new Parameter(transpile, findParameter());
     expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const parameter = new Parameter(transpile, findParameter());
+    expect(parameter.toJson()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const parameter = new Parameter(transpile, findParameter());
     expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const parameter = new Parameter(transpile, findParameter());
+    expect(parameter.toJson()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const parameter = new Parameter(transpile, findParameter());
     expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const parameter = new Parameter(transpile, findParameter());
+    expect(parameter.toJson()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const parameter = new Parameter(transpile, findParameter());
     expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const parameter = new Parameter(transpile, findParameter());
+    expect(parameter.toJson()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/parameter.test.ts
+++ b/test/docgen/view/parameter.test.ts
@@ -23,31 +23,31 @@ const findParameter = (): reflect.Parameter => {
 describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
-    const parameter = new Parameter(transpile, findParameter(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(parameter.toMarkdown().render()).toMatchSnapshot();
+    const parameter = new Parameter(transpile, findParameter());
+    expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
-    const parameter = new Parameter(transpile, findParameter(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(parameter.toMarkdown().render()).toMatchSnapshot();
+    const parameter = new Parameter(transpile, findParameter());
+    expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
-    const parameter = new Parameter(transpile, findParameter(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(parameter.toMarkdown().render()).toMatchSnapshot();
+    const parameter = new Parameter(transpile, findParameter());
+    expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
-    const parameter = new Parameter(transpile, findParameter(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(parameter.toMarkdown().render()).toMatchSnapshot();
+    const parameter = new Parameter(transpile, findParameter());
+    expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/property.test.ts
+++ b/test/docgen/view/property.test.ts
@@ -17,7 +17,7 @@ describe('python', () => {
       assembly.system.interfaces[0].allProperties[0],
       (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(parameter.render().render()).toMatchSnapshot();
+    expect(parameter.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -29,7 +29,7 @@ describe('typescript', () => {
       assembly.system.interfaces[0].allProperties[0],
       (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(parameter.render().render()).toMatchSnapshot();
+    expect(parameter.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -41,7 +41,7 @@ describe('java', () => {
       assembly.system.interfaces[0].allProperties[0],
       (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(parameter.render().render()).toMatchSnapshot();
+    expect(parameter.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -53,6 +53,6 @@ describe('csharp', () => {
       assembly.system.interfaces[0].allProperties[0],
       (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(parameter.render().render()).toMatchSnapshot();
+    expect(parameter.toMarkdown().render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/property.test.ts
+++ b/test/docgen/view/property.test.ts
@@ -11,44 +11,76 @@ const assembly: reflect.Assembly = Assemblies.instance.withoutSubmodules;
 
 describe('python', () => {
   const transpile = new PythonTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const parameter = new Property(
       transpile,
       assembly.system.interfaces[0].allProperties[0],
     );
     expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const parameter = new Property(
+      transpile,
+      assembly.system.interfaces[0].allProperties[0],
+    );
+    expect(parameter.toJson()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const parameter = new Property(
       transpile,
       assembly.system.interfaces[0].allProperties[0],
     );
     expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const parameter = new Property(
+      transpile,
+      assembly.system.interfaces[0].allProperties[0],
+    );
+    expect(parameter.toJson()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const parameter = new Property(
       transpile,
       assembly.system.interfaces[0].allProperties[0],
     );
     expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
+
+  test('json snapshot', () => {
+    const parameter = new Property(
+      transpile,
+      assembly.system.interfaces[0].allProperties[0],
+    );
+    expect(parameter.toJson()).toMatchSnapshot();
+  });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const parameter = new Property(
       transpile,
       assembly.system.interfaces[0].allProperties[0],
     );
     expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const parameter = new Property(
+      transpile,
+      assembly.system.interfaces[0].allProperties[0],
+    );
+    expect(parameter.toJson()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/property.test.ts
+++ b/test/docgen/view/property.test.ts
@@ -15,9 +15,8 @@ describe('python', () => {
     const parameter = new Property(
       transpile,
       assembly.system.interfaces[0].allProperties[0],
-      (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(parameter.toMarkdown().render()).toMatchSnapshot();
+    expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
@@ -27,9 +26,8 @@ describe('typescript', () => {
     const parameter = new Property(
       transpile,
       assembly.system.interfaces[0].allProperties[0],
-      (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(parameter.toMarkdown().render()).toMatchSnapshot();
+    expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
@@ -39,9 +37,8 @@ describe('java', () => {
     const parameter = new Property(
       transpile,
       assembly.system.interfaces[0].allProperties[0],
-      (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(parameter.toMarkdown().render()).toMatchSnapshot();
+    expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
@@ -51,8 +48,7 @@ describe('csharp', () => {
     const parameter = new Property(
       transpile,
       assembly.system.interfaces[0].allProperties[0],
-      (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(parameter.toMarkdown().render()).toMatchSnapshot();
+    expect(parameter.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/static-function.test.ts
+++ b/test/docgen/view/static-function.test.ts
@@ -24,7 +24,7 @@ describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
     const staticFunction = new StaticFunction(transpile, findStaticFunction(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(staticFunction.render().render()).toMatchSnapshot();
+    expect(staticFunction.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -32,7 +32,7 @@ describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
     const staticFunction = new StaticFunction(transpile, findStaticFunction(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(staticFunction.render().render()).toMatchSnapshot();
+    expect(staticFunction.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -40,7 +40,7 @@ describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
     const staticFunction = new StaticFunction(transpile, findStaticFunction(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(staticFunction.render().render()).toMatchSnapshot();
+    expect(staticFunction.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -48,6 +48,6 @@ describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
     const staticFunction = new StaticFunction(transpile, findStaticFunction(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(staticFunction.render().render()).toMatchSnapshot();
+    expect(staticFunction.toMarkdown().render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/static-function.test.ts
+++ b/test/docgen/view/static-function.test.ts
@@ -23,31 +23,31 @@ const findStaticFunction = (): reflect.Method => {
 describe('python', () => {
   const transpile = new PythonTranspile();
   test('snapshot', () => {
-    const staticFunction = new StaticFunction(transpile, findStaticFunction(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(staticFunction.toMarkdown().render()).toMatchSnapshot();
+    const staticFunction = new StaticFunction(transpile, findStaticFunction());
+    expect(staticFunction.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
   test('snapshot', () => {
-    const staticFunction = new StaticFunction(transpile, findStaticFunction(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(staticFunction.toMarkdown().render()).toMatchSnapshot();
+    const staticFunction = new StaticFunction(transpile, findStaticFunction());
+    expect(staticFunction.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
   test('snapshot', () => {
-    const staticFunction = new StaticFunction(transpile, findStaticFunction(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(staticFunction.toMarkdown().render()).toMatchSnapshot();
+    const staticFunction = new StaticFunction(transpile, findStaticFunction());
+    expect(staticFunction.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
   test('snapshot', () => {
-    const staticFunction = new StaticFunction(transpile, findStaticFunction(), (t: TranspiledType) => `#${t.fqn}`);
-    expect(staticFunction.toMarkdown().render()).toMatchSnapshot();
+    const staticFunction = new StaticFunction(transpile, findStaticFunction());
+    expect(staticFunction.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/static-function.test.ts
+++ b/test/docgen/view/static-function.test.ts
@@ -22,32 +22,52 @@ const findStaticFunction = (): reflect.Method => {
 
 describe('python', () => {
   const transpile = new PythonTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const staticFunction = new StaticFunction(transpile, findStaticFunction());
     expect(staticFunction.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const staticFunction = new StaticFunction(transpile, findStaticFunction());
+    expect(staticFunction.toJson()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const staticFunction = new StaticFunction(transpile, findStaticFunction());
     expect(staticFunction.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const staticFunction = new StaticFunction(transpile, findStaticFunction());
+    expect(staticFunction.toJson()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const staticFunction = new StaticFunction(transpile, findStaticFunction());
     expect(staticFunction.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const staticFunction = new StaticFunction(transpile, findStaticFunction());
+    expect(staticFunction.toJson()).toMatchSnapshot();
   });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const staticFunction = new StaticFunction(transpile, findStaticFunction());
     expect(staticFunction.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const staticFunction = new StaticFunction(transpile, findStaticFunction());
+    expect(staticFunction.toJson()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/struct.test.ts
+++ b/test/docgen/view/struct.test.ts
@@ -11,44 +11,76 @@ const assembly: reflect.Assembly = Assemblies.instance.withoutSubmodules;
 
 describe('python', () => {
   const transpile = new PythonTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const struct = new Struct(
       transpile,
       assembly.system.interfaces.filter((i) => i.datatype)[0],
     );
     expect(struct.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const struct = new Struct(
+      transpile,
+      assembly.system.interfaces.filter((i) => i.datatype)[0],
+    );
+    expect(struct.toJson()).toMatchSnapshot();
   });
 });
 
 describe('typescript', () => {
   const transpile = new TypeScriptTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const struct = new Struct(
       transpile,
       assembly.system.interfaces.filter((i) => i.datatype)[0],
     );
     expect(struct.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const struct = new Struct(
+      transpile,
+      assembly.system.interfaces.filter((i) => i.datatype)[0],
+    );
+    expect(struct.toJson()).toMatchSnapshot();
   });
 });
 
 describe('java', () => {
   const transpile = new JavaTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const struct = new Struct(
       transpile,
       assembly.system.interfaces.filter((i) => i.datatype)[0],
     );
     expect(struct.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
+
+  test('json snapshot', () => {
+    const struct = new Struct(
+      transpile,
+      assembly.system.interfaces.filter((i) => i.datatype)[0],
+    );
+    expect(struct.toJson()).toMatchSnapshot();
+  });
 });
 
 describe('csharp', () => {
   const transpile = new CSharpTranspile();
-  test('snapshot', () => {
+  test('markdown snapshot', () => {
     const struct = new Struct(
       transpile,
       assembly.system.interfaces.filter((i) => i.datatype)[0],
     );
     expect(struct.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
+  });
+
+  test('json snapshot', () => {
+    const struct = new Struct(
+      transpile,
+      assembly.system.interfaces.filter((i) => i.datatype)[0],
+    );
+    expect(struct.toJson()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/struct.test.ts
+++ b/test/docgen/view/struct.test.ts
@@ -17,7 +17,7 @@ describe('python', () => {
       assembly.system.interfaces.filter((i) => i.datatype)[0],
       (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(struct.render().render()).toMatchSnapshot();
+    expect(struct.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -29,7 +29,7 @@ describe('typescript', () => {
       assembly.system.interfaces.filter((i) => i.datatype)[0],
       (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(struct.render().render()).toMatchSnapshot();
+    expect(struct.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -41,7 +41,7 @@ describe('java', () => {
       assembly.system.interfaces.filter((i) => i.datatype)[0],
       (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(struct.render().render()).toMatchSnapshot();
+    expect(struct.toMarkdown().render()).toMatchSnapshot();
   });
 });
 
@@ -53,6 +53,6 @@ describe('csharp', () => {
       assembly.system.interfaces.filter((i) => i.datatype)[0],
       (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(struct.render().render()).toMatchSnapshot();
+    expect(struct.toMarkdown().render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/struct.test.ts
+++ b/test/docgen/view/struct.test.ts
@@ -15,9 +15,8 @@ describe('python', () => {
     const struct = new Struct(
       transpile,
       assembly.system.interfaces.filter((i) => i.datatype)[0],
-      (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(struct.toMarkdown().render()).toMatchSnapshot();
+    expect(struct.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
@@ -27,9 +26,8 @@ describe('typescript', () => {
     const struct = new Struct(
       transpile,
       assembly.system.interfaces.filter((i) => i.datatype)[0],
-      (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(struct.toMarkdown().render()).toMatchSnapshot();
+    expect(struct.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
@@ -39,9 +37,8 @@ describe('java', () => {
     const struct = new Struct(
       transpile,
       assembly.system.interfaces.filter((i) => i.datatype)[0],
-      (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(struct.toMarkdown().render()).toMatchSnapshot();
+    expect(struct.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });
 
@@ -51,8 +48,7 @@ describe('csharp', () => {
     const struct = new Struct(
       transpile,
       assembly.system.interfaces.filter((i) => i.datatype)[0],
-      (t: TranspiledType) => `#${t.fqn}`,
     );
-    expect(struct.toMarkdown().render()).toMatchSnapshot();
+    expect(struct.toMarkdown((t: TranspiledType) => `#${t.fqn}`).render()).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Allows rendering language specific documentation to a JSON object in
addition to a markdown string. This allows the consumer more flexibility
to render the structure of the API reference as needed without
regenerating markdown documents.

Additionally removes the `linkFormatter` argument from the `ApiReference`
and type views constructors and moves it to be passed to the `toMarkdown`
method instead. This makes sense because link formatting is markdown
specific and is not needed for the markdown rendering. Additionally, a similar
feature may be useful on the json side in the future to format nested type strings.

BREAKING CHANGE: renames `Documentation.render` method to
`Documentation.toMarkdown`.