### PR TITLE
chore: disable assembly validation

### DIFF
--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -256,7 +256,10 @@ export class Documentation {
     }
   }
 
-  private async languageSpecific(lang: Language, options: TransliterationOptions): Promise<{ assembly: reflect.Assembly; transpile: Transpile}> {
+  private async languageSpecific(
+    lang: Language,
+    options: Required<TransliterationOptions>,
+  ): Promise<{ assembly: reflect.Assembly; transpile: Transpile}> {
     const { rosettaTarget, transpile } = LANGUAGE_SPECIFIC[lang.toString()];
     return { assembly: await this.createAssembly(rosettaTarget, options), transpile };
   }
@@ -280,7 +283,10 @@ export class Documentation {
     return submodules[0];
   }
 
-  private async createAssembly(language: TargetLanguage | undefined, options: TransliterationOptions): Promise<reflect.Assembly> {
+  private async createAssembly(
+    language: TargetLanguage | undefined,
+    options: Required<TransliterationOptions>,
+  ): Promise<reflect.Assembly> {
 
     const cacheKey = `lang:${language ?? 'ts'}.loose:${options.loose}.validate:${options.validate}`;
     const cached = this.assembliesCache.get(cacheKey);


### PR DESCRIPTION
To improve performance, we change the default behavior to disable validating assemblies while loading them with `jsii-reflect`. This matches the behavior that already exists to skip assembly validations when we invoke `transliterateAssembly` from `jsii-rosetta`, as seen in this line here: https://github.com/aws/jsii/blob/309da85ba07c8ac884dcfb72fb0cbc0271364326/packages/jsii-rosetta/lib/commands/extract.ts#L89

Validation can be re-enabled via the `validate` flag.

When generating python docs for the root module of `aws-cdk-lib@2.8.0`, the time it took to generate on my development machine decreased from 30 seconds to 16 seconds.

Before flamegraph:
<img width="1405" alt="Screen Shot 2022-01-14 at 2 39 06 PM" src="https://user-images.githubusercontent.com/5008987/149594914-f99ef032-454c-4a23-839a-8012cb75d521.png">

After flamegraph:
<img width="1411" alt="Screen Shot 2022-01-14 at 2 39 40 PM" src="https://user-images.githubusercontent.com/5008987/149594938-7a467f2b-c8c9-4c20-bc2b-2b9b66f2551f.png">

