### PR TITLE
fix: export MarkdownRenderer and MarkdownFormattingOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ export { Documentation } from './docgen/view/documentation';
 export { Language } from './docgen/transpile/transpile';
 export { UnsupportedLanguageError } from './docgen/transpile/transpile';
 export { MarkdownDocument } from './docgen/render/markdown-doc';
+export * from './docgen/render/markdown-render';
 export * from './errors';
 export * from './docgen/schema';


### PR DESCRIPTION
There are two ways to generate markdown docs in `jsii-docgen@5`:

1. via `Documentation.toMarkdown` (which generates `API.json` in-memory and then converts it to markdown)
2. by taking a valid `API.json` (generated by `Documentation.toJson`) and passing the data to `MarkdownRenderer.fromSchema`

This PR fixes (2) is not being usable since the relevant classes/options are not exported.