### PR TITLE
fix: language support validation is too shallow

### DIFF
--- a/src/docgen/transpile/transpile.ts
+++ b/src/docgen/transpile/transpile.ts
@@ -8,22 +8,22 @@ export class Language {
   /**
    * TypeScript.
    */
-  public static readonly TYPESCRIPT = new Language('typescript');
+  public static readonly TYPESCRIPT = new Language({ name: 'typescript', validator: () => true });
 
   /**
    * Python.
    */
-  public static readonly PYTHON = new Language('python');
+  public static readonly PYTHON = new Language({ name: 'python', validator: validatePythonConfig });
 
   /**
    * Java.
    */
-  public static readonly JAVA = new Language('java');
+  public static readonly JAVA = new Language({ name: 'java', validator: validateJavaConfig });
 
   /**
    * C#
    */
-  public static readonly CSHARP = new Language('csharp', 'dotnet');
+  public static readonly CSHARP = new Language({ name: 'csharp', targetName: 'dotnet', validator: validateDotNetConfig });
 
   /**
    * Transform a literal string to the `Language` object.
@@ -53,12 +53,50 @@ export class Language {
     return [Language.TYPESCRIPT, Language.PYTHON, Language.JAVA, Language.CSHARP];
   }
 
-  private constructor(public readonly name: string, public readonly targetName = name) {}
+  public readonly name: string;
+  public readonly targetName: string;
+  private readonly validator: (config: Record<string, unknown>) => boolean;
+
+  private constructor(
+    { name, targetName = name, validator }: {
+      name: string;
+      targetName?: string;
+      validator: (config: Record<string, unknown>) => boolean;
+    },
+  ) {
+    this.name = name;
+    this.targetName = targetName;
+    this.validator = validator;
+  }
+
+  public isValidConfiguration(config: Record<string, unknown> | undefined): boolean {
+    // TypeScript does not need configuration, all other languages do
+    if (config == null) {
+      return this === Language.TYPESCRIPT;
+    }
+
+    return this.validator(config);
+  }
 
   public toString() {
     return this.name;
   }
 
+}
+
+function validateDotNetConfig(config: Record<string, any>): boolean {
+  // See: https://aws.github.io/jsii/user-guides/lib-author/configuration/targets/dotnet/
+  return typeof config.namespace === 'string' && typeof config.packageId === 'string';
+}
+
+function validateJavaConfig(config: Record<string, any>): boolean {
+  // See: https://aws.github.io/jsii/user-guides/lib-author/configuration/targets/java/
+  return typeof config.package === 'string' && typeof config.maven?.groupId === 'string' && typeof config.maven?.artifactId === 'string';
+}
+
+function validatePythonConfig(config: Record<string, any>): boolean {
+  // See: https://aws.github.io/jsii/user-guides/lib-author/configuration/targets/python/
+  return typeof config.module === 'string' && typeof config.distName === 'string';
 }
 
 export class UnsupportedLanguageError extends Error {

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -210,7 +210,7 @@ export class Documentation {
       throw new Error(`Assembly ${assemblyFqn} does not have any targets defined`);
     }
 
-    const isSupported = language === Language.TYPESCRIPT || assembly.targets[language.targetName];
+    const isSupported = language === Language.TYPESCRIPT || language.isValidConfiguration(assembly.targets[language.targetName]);
 
     if (!isSupported) {
       throw new LanguageNotSupportedError(`Laguage ${language} is not supported for package ${assemblyFqn}`);

--- a/test/docgen/transpile/transpile.test.ts
+++ b/test/docgen/transpile/transpile.test.ts
@@ -8,18 +8,34 @@ describe('language', () => {
 
   test('typescript is supported', () => {
     expect(Language.fromString('typescript')).toEqual(Language.TYPESCRIPT);
+    // Allows undefined configuration
+    expect(Language.TYPESCRIPT.isValidConfiguration(undefined)).toBeTruthy();
+    // Allows random configuration
+    expect(Language.TYPESCRIPT.isValidConfiguration({ foo: 'bar' })).toBeTruthy();
   });
 
   test('python is supported', () => {
     expect(Language.fromString('python')).toEqual(Language.PYTHON);
+    // Disallows undefined configuration
+    expect(Language.PYTHON.isValidConfiguration(undefined)).toBeFalsy();
+    // Allows valid configuration
+    expect(Language.PYTHON.isValidConfiguration({ distName: 'bar', module: 'foo' })).toBeTruthy();
   });
 
   test('java is supported', () => {
     expect(Language.fromString('java')).toEqual(Language.JAVA);
+    // Disallows undefined configuration
+    expect(Language.JAVA.isValidConfiguration(undefined)).toBeFalsy();
+    // Allows valid configuration
+    expect(Language.JAVA.isValidConfiguration({ package: 'com.acme.package', maven: { groupId: 'group', artifactId: 'artifact' } })).toBeTruthy();
   });
 
   test('csharp is supported', () => {
     expect(Language.fromString('csharp')).toEqual(Language.CSHARP);
+    // Disallows undefined configuration
+    expect(Language.CSHARP.isValidConfiguration(undefined)).toBeFalsy();
+    // Allows valid configuration
+    expect(Language.CSHARP.isValidConfiguration({ namespace: 'Com.Acme.Package', packageId: 'AcmePackage' })).toBeTruthy();
   });
 
   test('throw error on unsupported language', () => {


### PR DESCRIPTION
The language support validation only checked for the presence of a
particular key under `jsii.targets`, however it failed to validate that
the contents of that key is valid, and did not throw a
`LanguageNotSupportedError`, instead letting `jsii-rosetta` throw a
generic error once it tried to use the missing configuration.

This adds in-depth checkers that, although they don't ensure the values
are valid, at least verifies they are present and of the expected type.