### PR TITLE
fix: header limit reached on some packages with examples

### DIFF
--- a/src/docgen/render/markdown-doc.ts
+++ b/src/docgen/render/markdown-doc.ts
@@ -124,10 +124,8 @@ export class MarkdownDocument {
       }
       const example = new MarkdownDocument({
         id: `${this.options.id}.example`,
-        header: {
-          title: 'Example',
-        },
       });
+      example.lines(MarkdownDocument.italic('Example'), '');
       example.code(language.toString(), docs.example);
       example.lines('');
       this.section(example);
@@ -174,15 +172,16 @@ export class MarkdownDocument {
   }
 
   public render(headerSize: number = 0): string {
-    if (headerSize > 6) {
-      // headers are mapped to `h1-h6` html elements.
-      // passed that, markdown just renders `#` signs.
-      // lets see if and when we'll hit this limit.
-      throw new Error('Unable to render markdown. Header limit (6) reached.');
-    }
-
     const content: string[] = [];
+
     if (this.header) {
+      if (headerSize > 6) {
+        // headers are mapped to `h1-h6` html elements.
+        // passed that, markdown just renders `#` signs.
+        // lets see if and when we'll hit this limit.
+        throw new Error('Unable to render markdown. Header limit (6) reached.');
+      }
+
       const heading = `${'#'.repeat(headerSize)} ${this.header}`;
 
       // temporary hack to avoid breaking Construct Hub

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -107,7 +107,7 @@ Adds a bucket notification event destination.
 
 > [https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
 
-###### Example <a name=\\"Example\\" id=\\"construct-library.submod1.GoodbyeBucket.addEventNotification.example\\"></a>
+*Example*
 
 \`\`\`typescript
    declare const myLambda: lambda.Function;
@@ -1048,7 +1048,7 @@ Adds a bucket notification event destination.
 
 > [https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
 
-###### Example <a name=\\"Example\\" id=\\"construct-library.GreeterBucket.addEventNotification.example\\"></a>
+*Example*
 
 \`\`\`typescript
    declare const myLambda: lambda.Function;
@@ -2273,7 +2273,7 @@ Adds a bucket notification event destination.
 
 > [https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
 
-###### Example <a name=\\"Example\\" id=\\"construct-library.submod1.GoodbyeBucket.addEventNotification.example\\"></a>
+*Example*
 
 \`\`\`python
    declare const myLambda: lambda.Function;
@@ -4072,7 +4072,7 @@ Adds a bucket notification event destination.
 
 > [https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
 
-###### Example <a name=\\"Example\\" id=\\"construct-library.GreeterBucket.addEventNotification.example\\"></a>
+*Example*
 
 \`\`\`python
    declare const myLambda: lambda.Function;
@@ -5609,7 +5609,7 @@ Adds a bucket notification event destination.
 
 > [https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
 
-###### Example <a name=\\"Example\\" id=\\"construct-library.GreeterBucket.addEventNotification.example\\"></a>
+*Example*
 
 \`\`\`typescript
    declare const myLambda: lambda.Function;
@@ -6561,7 +6561,7 @@ Adds a bucket notification event destination.
 
 > [https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
 
-###### Example <a name=\\"Example\\" id=\\"construct-library.submod1.GoodbyeBucket.addEventNotification.example\\"></a>
+*Example*
 
 \`\`\`typescript
    declare const myLambda: lambda.Function;

--- a/test/docgen/view/documentation.test.ts
+++ b/test/docgen/view/documentation.test.ts
@@ -204,3 +204,11 @@ test('performance on large modules', async () => {
   // the assertion here is simply finishing the rendering in time.
   await docs.toMarkdown({ language: Language.PYTHON, submodule: 'wafv2' });
 });
+
+test('does not reach headerSize limit for modules with method param examples', async () => {
+  // this module includes @example information for a method parameter
+  // at @aws-cdk/aws-apigateway.ProxyResource.addMethod.parameter.requestModels
+  const docs = await Documentation.forPackage('@aws-cdk/aws-apigateway@1.47.0');
+  // the assertion here is simply that the rendering succeeds
+  await docs.toMarkdown({ language: Language.PYTHON });
+});


### PR DESCRIPTION
On some packages, we are seeing an error where jsii-docgen throws an error

```Error: Unable to render markdown. Header limit (6) reached.
    at MarkdownDocument.render (/Volumes/workplace/jsii-docgen/lib/docgen/render/markdown-doc.js:105:19)
```

This is caused by the existence of examples on parameters of methods in some libraries. To see concretely the chain of header sizes, I found that for `@aws-cdk/aws-apigateway@1.47.0` it was trying to render:

```
# API Reference <a name="API Reference" id="api-reference"></a>

## Constructs <a name="Constructs" id="Constructs"></a>

### ProxyResource <a name="ProxyResource" id="@aws-cdk/aws-apigateway.ProxyResource"></a>

#### Methods <a name="Methods" id="Methods"></a>

##### `add_method` <a name="add_method" id="@aws-cdk/aws-apigateway.ProxyResource.addMethod"></a>

###### `request_models`<sup>Optional</sup> <a name="request_models" id="@aws-cdk/aws-apigateway.ProxyResource.addMethod.parameter.requestModels"></a>

####### Example <a name="Example" id="@aws-cdk/aws-apigateway.ProxyResource.addMethod.parameter.requestModels.example"></a>
```

Since H7 is not allowed, we change examples to be rendered without a header, and instead with the title "Example" italicized.