### PR TITLE
fix: remove newlines suppression for other fields than docs.defaults

### DIFF
--- a/src/docgen/render/markdown-doc.ts
+++ b/src/docgen/render/markdown-doc.ts
@@ -70,9 +70,14 @@ export class MarkdownDocument {
       sanitized = sanitized.substring(1, line.length).trim();
     }
 
-    sanitized = sanitized.replace(/\n/g, ' ');
-
     return sanitized;
+  }
+
+  /**
+   * Remove newlines from markdown.
+   */
+  public static removeNewlines(line: string): string {
+    return line.replace(/\n/g, ' ');
   }
 
   public static bold(text: string): string {

--- a/src/docgen/render/markdown-render.ts
+++ b/src/docgen/render/markdown-render.ts
@@ -539,7 +539,8 @@ export class MarkdownRenderer {
     };
 
     if (prop.default) {
-      metadata.Default = MarkdownDocument.sanitize(prop.default);
+      const sanitized = MarkdownDocument.sanitize(prop.default);
+      metadata.Default = MarkdownDocument.removeNewlines(sanitized);
     }
 
     for (const [key, value] of Object.entries(metadata)) {
@@ -589,7 +590,8 @@ export class MarkdownRenderer {
     };
 
     if (parameter.default) {
-      metadata.Default = MarkdownDocument.sanitize(parameter.default);
+      const sanitized = MarkdownDocument.sanitize(parameter.default);
+      metadata.Default = MarkdownDocument.removeNewlines(sanitized);
     }
 
     for (const [key, value] of Object.entries(metadata)) {

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -89,7 +89,13 @@ public applyRemovalPolicy(policy: RemovalPolicy): void
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"construct-library.submod1.GoodbyeBucket.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -138,7 +144,9 @@ The notification destination (Lambda, SNS Topic or SQS Queue).
 
 S3 object key filter rules to determine which objects trigger this event.
 
-Each filter must include a \`prefix\` and/or \`suffix\` that will be matched against the s3 object key. Refer to the S3 Developer Guide for details about allowed filter rules.
+Each filter must include a \`prefix\` and/or \`suffix\`
+that will be matched against the s3 object key. Refer to the S3 Developer Guide
+for details about allowed filter rules.
 
 ---
 
@@ -150,7 +158,8 @@ public addObjectCreatedNotification(dest: IBucketNotificationDestination, filter
 
 Subscribes a destination to receive notifications when an object is created in the bucket.
 
-This is identical to calling \`onEvent(EventType.OBJECT_CREATED)\`.
+This is identical to calling
+\`onEvent(EventType.OBJECT_CREATED)\`.
 
 ###### \`dest\`<sup>Required</sup> <a name=\\"dest\\" id=\\"construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification.parameter.dest\\"></a>
 
@@ -176,7 +185,8 @@ public addObjectRemovedNotification(dest: IBucketNotificationDestination, filter
 
 Subscribes a destination to receive notifications when an object is removed from the bucket.
 
-This is identical to calling \`onEvent(EventType.OBJECT_REMOVED)\`.
+This is identical to calling
+\`onEvent(EventType.OBJECT_REMOVED)\`.
 
 ###### \`dest\`<sup>Required</sup> <a name=\\"dest\\" id=\\"construct-library.submod1.GoodbyeBucket.addObjectRemovedNotification.parameter.dest\\"></a>
 
@@ -202,7 +212,11 @@ public addToResourcePolicy(permission: PolicyStatement): AddToResourcePolicyResu
 
 Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects.
 
-Note that the policy statement may or may not be added to the policy. For example, when an \`IBucket\` is created from an existing bucket, it's not possible to tell whether the bucket already has a policy attached, let alone to re-use that policy to add more statements to it. So it's safest to do nothing in these cases.
+Note that the policy statement may or may not be added to the policy.
+For example, when an \`IBucket\` is created from an existing bucket,
+it's not possible to tell whether the bucket already has a policy
+attached, let alone to re-use that policy to add more statements to it.
+So it's safest to do nothing in these cases.
 
 ###### \`permission\`<sup>Required</sup> <a name=\\"permission\\" id=\\"construct-library.submod1.GoodbyeBucket.addToResourcePolicy.parameter.permission\\"></a>
 
@@ -220,7 +234,11 @@ public arnForObjects(keyPattern: string): string
 
 Returns an ARN that represents all objects within the bucket that match the key pattern specified.
 
-To represent all keys, specify \`\`\\"*\\"\`\`.  If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:     arnForObjects(\`home/\${team}/\${user}/*\`)
+To represent all keys, specify \`\`\\"*\\"\`\`.
+
+If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:
+
+   arnForObjects(\`home/\${team}/\${user}/*\`)
 
 ###### \`keyPattern\`<sup>Required</sup> <a name=\\"keyPattern\\" id=\\"construct-library.submod1.GoodbyeBucket.arnForObjects.parameter.keyPattern\\"></a>
 
@@ -260,7 +278,24 @@ public grantPublicAccess(allowedActions: string, keyPrefix?: string): Grant
 
 Allows unrestricted access to objects from this bucket.
 
-IMPORTANT: This permission allows anyone to perform actions on S3 objects in this bucket, which is useful for when you configure your bucket as a website and want everyone to be able to read objects in the bucket without needing to authenticate.  Without arguments, this method will grant read (\\"s3:GetObject\\") access to all objects (\\"*\\") in the bucket.  The method returns the \`iam.Grant\` object, which can then be modified as needed. For example, you can add a condition that will restrict access only to an IPv4 range like this:       const grant = bucket.grantPublicAccess();      grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });  Note that if this \`IBucket\` refers to an existing bucket, possibly not managed by CloudFormation, this method will have no effect, since it's impossible to modify the policy of an existing bucket.
+IMPORTANT: This permission allows anyone to perform actions on S3 objects
+in this bucket, which is useful for when you configure your bucket as a
+website and want everyone to be able to read objects in the bucket without
+needing to authenticate.
+
+Without arguments, this method will grant read (\\"s3:GetObject\\") access to
+all objects (\\"*\\") in the bucket.
+
+The method returns the \`iam.Grant\` object, which can then be modified
+as needed. For example, you can add a condition that will restrict access only
+to an IPv4 range like this:
+
+     const grant = bucket.grantPublicAccess();
+     grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });
+
+Note that if this \`IBucket\` refers to an existing bucket, possibly not
+managed by CloudFormation, this method will have no effect, since it's
+impossible to modify the policy of an existing bucket.
 
 ###### \`allowedActions\`<sup>Required</sup> <a name=\\"allowedActions\\" id=\\"construct-library.submod1.GoodbyeBucket.grantPublicAccess.parameter.allowedActions\\"></a>
 
@@ -288,7 +323,8 @@ public grantPut(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal.
 
-If encryption is used, permission to use the key to encrypt the contents of written files will also be granted to the same principal.
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantPut.parameter.identity\\"></a>
 
@@ -314,7 +350,9 @@ public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
 
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
-If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set, calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects; in this case, if you need to modify object ACLs, call this method explicitly.
+If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
+calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.identity\\"></a>
 
@@ -336,7 +374,8 @@ public grantRead(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
 
-If encryption is used, permission to use the key to decrypt the contents of the bucket will also be granted to the same principal.
+If encryption is used, permission to use the key to decrypt the contents
+of the bucket will also be granted to the same principal.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantRead.parameter.identity\\"></a>
 
@@ -362,7 +401,16 @@ public grantReadWrite(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
 
-If an encryption key is used, permission to use the key for encrypt/decrypt will also be granted.  Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`, which could be used to grant read/write object access to IAM principals in other accounts. If you want to get rid of that behavior, update your CDK version to 1.85.0 or later, and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\` in the \`context\` key of your cdk.json file. If you've already updated, but still need the principal to have permissions to modify the ACLs, use the {@link grantPutAcl} method.
+If an encryption key is used, permission to use the key for
+encrypt/decrypt will also be granted.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.identity\\"></a>
 
@@ -384,7 +432,16 @@ public grantWrite(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grant write permissions to this bucket to an IAM principal.
 
-If encryption is used, permission to use the key to encrypt the contents of written files will also be granted to the same principal.  Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`, which could be used to grant read/write object access to IAM principals in other accounts. If you want to get rid of that behavior, update your CDK version to 1.85.0 or later, and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\` in the \`context\` key of your cdk.json file. If you've already updated, but still need the principal to have permissions to modify the ACLs, use the {@link grantPutAcl} method.
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantWrite.parameter.identity\\"></a>
 
@@ -406,7 +463,8 @@ public onCloudTrailEvent(id: string, options?: OnCloudTrailBucketEventOptions): 
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.submod1.GoodbyeBucket.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -432,7 +490,12 @@ public onCloudTrailPutObject(id: string, options?: OnCloudTrailBucketEventOption
 
 Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call.
 
-Note that some tools like \`aws s3 cp\` will automatically use either PutObject or the multipart upload API depending on the file size, so using \`onCloudTrailWriteObject\` may be preferable.  Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using \`onCloudTrailWriteObject\` may be preferable.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject.parameter.id\\"></a>
 
@@ -458,7 +521,15 @@ public onCloudTrailWriteObject(id: string, options?: OnCloudTrailBucketEventOpti
 
 Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to.
 
-This includes the events PutObject, CopyObject, and CompleteMultipartUpload.  Note that some tools like \`aws s3 cp\` will automatically use either PutObject or the multipart upload API depending on the file size, so using this method may be preferable to \`onCloudTrailPutObject\`.  Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+This includes
+the events PutObject, CopyObject, and CompleteMultipartUpload.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using this method may be preferable to \`onCloudTrailPutObject\`.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject.parameter.id\\"></a>
 
@@ -484,7 +555,8 @@ public s3UrlForObject(key?: string): string
 
 The S3 URL of an S3 object. For example:.
 
-\`s3://onlybucket\` - \`s3://bucket/key\`
+\`s3://onlybucket\`
+- \`s3://bucket/key\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.submod1.GoodbyeBucket.s3UrlForObject.parameter.key\\"></a>
 
@@ -492,7 +564,8 @@ The S3 URL of an S3 object. For example:.
 
 The S3 key of the object.
 
-If not specified, the S3 URL of the bucket is returned.
+If not specified, the S3 URL of the
+bucket is returned.
 
 ---
 
@@ -504,7 +577,9 @@ public urlForObject(key?: string): string
 
 The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:.
 
-\`https://s3.us-west-1.amazonaws.com/onlybucket\` - \`https://s3.us-west-1.amazonaws.com/bucket/key\` - \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
+\`https://s3.us-west-1.amazonaws.com/onlybucket\`
+- \`https://s3.us-west-1.amazonaws.com/bucket/key\`
+- \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.submod1.GoodbyeBucket.urlForObject.parameter.key\\"></a>
 
@@ -512,7 +587,8 @@ The https URL of an S3 object. Specify \`regional: false\` at the options for no
 
 The S3 key of the object.
 
-If not specified, the URL of the bucket is returned.
+If not specified, the URL of the
+bucket is returned.
 
 ---
 
@@ -524,7 +600,10 @@ public virtualHostedUrlForObject(key?: string, options?: VirtualHostedStyleUrlOp
 
 The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:.
 
-\`https://only-bucket.s3.us-west-1.amazonaws.com\` - \`https://bucket.s3.us-west-1.amazonaws.com/key\` - \`https://bucket.s3.amazonaws.com/key\` - \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
+\`https://only-bucket.s3.us-west-1.amazonaws.com\`
+- \`https://bucket.s3.us-west-1.amazonaws.com/key\`
+- \`https://bucket.s3.amazonaws.com/key\`
+- \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.submod1.GoodbyeBucket.virtualHostedUrlForObject.parameter.key\\"></a>
 
@@ -532,7 +611,8 @@ The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the
 
 The S3 key of the object.
 
-If not specified, the URL of the bucket is returned.
+If not specified, the URL of the
+bucket is returned.
 
 ---
 
@@ -717,7 +797,8 @@ The construct's name.
 
 A \`BucketAttributes\` object.
 
-Can be obtained from a call to \`bucket.export()\` or manually created.
+Can be obtained from a call to
+\`bucket.export()\` or manually created.
 
 ---
 
@@ -807,7 +888,12 @@ public readonly env: ResourceEnvironment;
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -941,7 +1027,8 @@ public readonly policy: BucketPolicy;
 
 The resource policy associated with this bucket.
 
-If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the first call to addToResourcePolicy(s).
+If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the
+first call to addToResourcePolicy(s).
 
 ---
 
@@ -1030,7 +1117,13 @@ public applyRemovalPolicy(policy: RemovalPolicy): void
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"construct-library.GreeterBucket.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -1079,7 +1172,9 @@ The notification destination (Lambda, SNS Topic or SQS Queue).
 
 S3 object key filter rules to determine which objects trigger this event.
 
-Each filter must include a \`prefix\` and/or \`suffix\` that will be matched against the s3 object key. Refer to the S3 Developer Guide for details about allowed filter rules.
+Each filter must include a \`prefix\` and/or \`suffix\`
+that will be matched against the s3 object key. Refer to the S3 Developer Guide
+for details about allowed filter rules.
 
 ---
 
@@ -1091,7 +1186,8 @@ public addObjectCreatedNotification(dest: IBucketNotificationDestination, filter
 
 Subscribes a destination to receive notifications when an object is created in the bucket.
 
-This is identical to calling \`onEvent(EventType.OBJECT_CREATED)\`.
+This is identical to calling
+\`onEvent(EventType.OBJECT_CREATED)\`.
 
 ###### \`dest\`<sup>Required</sup> <a name=\\"dest\\" id=\\"construct-library.GreeterBucket.addObjectCreatedNotification.parameter.dest\\"></a>
 
@@ -1117,7 +1213,8 @@ public addObjectRemovedNotification(dest: IBucketNotificationDestination, filter
 
 Subscribes a destination to receive notifications when an object is removed from the bucket.
 
-This is identical to calling \`onEvent(EventType.OBJECT_REMOVED)\`.
+This is identical to calling
+\`onEvent(EventType.OBJECT_REMOVED)\`.
 
 ###### \`dest\`<sup>Required</sup> <a name=\\"dest\\" id=\\"construct-library.GreeterBucket.addObjectRemovedNotification.parameter.dest\\"></a>
 
@@ -1143,7 +1240,11 @@ public addToResourcePolicy(permission: PolicyStatement): AddToResourcePolicyResu
 
 Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects.
 
-Note that the policy statement may or may not be added to the policy. For example, when an \`IBucket\` is created from an existing bucket, it's not possible to tell whether the bucket already has a policy attached, let alone to re-use that policy to add more statements to it. So it's safest to do nothing in these cases.
+Note that the policy statement may or may not be added to the policy.
+For example, when an \`IBucket\` is created from an existing bucket,
+it's not possible to tell whether the bucket already has a policy
+attached, let alone to re-use that policy to add more statements to it.
+So it's safest to do nothing in these cases.
 
 ###### \`permission\`<sup>Required</sup> <a name=\\"permission\\" id=\\"construct-library.GreeterBucket.addToResourcePolicy.parameter.permission\\"></a>
 
@@ -1161,7 +1262,11 @@ public arnForObjects(keyPattern: string): string
 
 Returns an ARN that represents all objects within the bucket that match the key pattern specified.
 
-To represent all keys, specify \`\`\\"*\\"\`\`.  If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:     arnForObjects(\`home/\${team}/\${user}/*\`)
+To represent all keys, specify \`\`\\"*\\"\`\`.
+
+If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:
+
+   arnForObjects(\`home/\${team}/\${user}/*\`)
 
 ###### \`keyPattern\`<sup>Required</sup> <a name=\\"keyPattern\\" id=\\"construct-library.GreeterBucket.arnForObjects.parameter.keyPattern\\"></a>
 
@@ -1201,7 +1306,24 @@ public grantPublicAccess(allowedActions: string, keyPrefix?: string): Grant
 
 Allows unrestricted access to objects from this bucket.
 
-IMPORTANT: This permission allows anyone to perform actions on S3 objects in this bucket, which is useful for when you configure your bucket as a website and want everyone to be able to read objects in the bucket without needing to authenticate.  Without arguments, this method will grant read (\\"s3:GetObject\\") access to all objects (\\"*\\") in the bucket.  The method returns the \`iam.Grant\` object, which can then be modified as needed. For example, you can add a condition that will restrict access only to an IPv4 range like this:       const grant = bucket.grantPublicAccess();      grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });  Note that if this \`IBucket\` refers to an existing bucket, possibly not managed by CloudFormation, this method will have no effect, since it's impossible to modify the policy of an existing bucket.
+IMPORTANT: This permission allows anyone to perform actions on S3 objects
+in this bucket, which is useful for when you configure your bucket as a
+website and want everyone to be able to read objects in the bucket without
+needing to authenticate.
+
+Without arguments, this method will grant read (\\"s3:GetObject\\") access to
+all objects (\\"*\\") in the bucket.
+
+The method returns the \`iam.Grant\` object, which can then be modified
+as needed. For example, you can add a condition that will restrict access only
+to an IPv4 range like this:
+
+     const grant = bucket.grantPublicAccess();
+     grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });
+
+Note that if this \`IBucket\` refers to an existing bucket, possibly not
+managed by CloudFormation, this method will have no effect, since it's
+impossible to modify the policy of an existing bucket.
 
 ###### \`allowedActions\`<sup>Required</sup> <a name=\\"allowedActions\\" id=\\"construct-library.GreeterBucket.grantPublicAccess.parameter.allowedActions\\"></a>
 
@@ -1229,7 +1351,8 @@ public grantPut(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal.
 
-If encryption is used, permission to use the key to encrypt the contents of written files will also be granted to the same principal.
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantPut.parameter.identity\\"></a>
 
@@ -1255,7 +1378,9 @@ public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
 
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
-If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set, calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects; in this case, if you need to modify object ACLs, call this method explicitly.
+If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
+calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantPutAcl.parameter.identity\\"></a>
 
@@ -1277,7 +1402,8 @@ public grantRead(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
 
-If encryption is used, permission to use the key to decrypt the contents of the bucket will also be granted to the same principal.
+If encryption is used, permission to use the key to decrypt the contents
+of the bucket will also be granted to the same principal.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantRead.parameter.identity\\"></a>
 
@@ -1303,7 +1429,16 @@ public grantReadWrite(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
 
-If an encryption key is used, permission to use the key for encrypt/decrypt will also be granted.  Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`, which could be used to grant read/write object access to IAM principals in other accounts. If you want to get rid of that behavior, update your CDK version to 1.85.0 or later, and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\` in the \`context\` key of your cdk.json file. If you've already updated, but still need the principal to have permissions to modify the ACLs, use the {@link grantPutAcl} method.
+If an encryption key is used, permission to use the key for
+encrypt/decrypt will also be granted.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantReadWrite.parameter.identity\\"></a>
 
@@ -1325,7 +1460,16 @@ public grantWrite(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grant write permissions to this bucket to an IAM principal.
 
-If encryption is used, permission to use the key to encrypt the contents of written files will also be granted to the same principal.  Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`, which could be used to grant read/write object access to IAM principals in other accounts. If you want to get rid of that behavior, update your CDK version to 1.85.0 or later, and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\` in the \`context\` key of your cdk.json file. If you've already updated, but still need the principal to have permissions to modify the ACLs, use the {@link grantPutAcl} method.
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantWrite.parameter.identity\\"></a>
 
@@ -1347,7 +1491,8 @@ public onCloudTrailEvent(id: string, options?: OnCloudTrailBucketEventOptions): 
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.GreeterBucket.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -1373,7 +1518,12 @@ public onCloudTrailPutObject(id: string, options?: OnCloudTrailBucketEventOption
 
 Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call.
 
-Note that some tools like \`aws s3 cp\` will automatically use either PutObject or the multipart upload API depending on the file size, so using \`onCloudTrailWriteObject\` may be preferable.  Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using \`onCloudTrailWriteObject\` may be preferable.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.GreeterBucket.onCloudTrailPutObject.parameter.id\\"></a>
 
@@ -1399,7 +1549,15 @@ public onCloudTrailWriteObject(id: string, options?: OnCloudTrailBucketEventOpti
 
 Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to.
 
-This includes the events PutObject, CopyObject, and CompleteMultipartUpload.  Note that some tools like \`aws s3 cp\` will automatically use either PutObject or the multipart upload API depending on the file size, so using this method may be preferable to \`onCloudTrailPutObject\`.  Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+This includes
+the events PutObject, CopyObject, and CompleteMultipartUpload.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using this method may be preferable to \`onCloudTrailPutObject\`.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.GreeterBucket.onCloudTrailWriteObject.parameter.id\\"></a>
 
@@ -1425,7 +1583,8 @@ public s3UrlForObject(key?: string): string
 
 The S3 URL of an S3 object. For example:.
 
-\`s3://onlybucket\` - \`s3://bucket/key\`
+\`s3://onlybucket\`
+- \`s3://bucket/key\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.GreeterBucket.s3UrlForObject.parameter.key\\"></a>
 
@@ -1433,7 +1592,8 @@ The S3 URL of an S3 object. For example:.
 
 The S3 key of the object.
 
-If not specified, the S3 URL of the bucket is returned.
+If not specified, the S3 URL of the
+bucket is returned.
 
 ---
 
@@ -1445,7 +1605,9 @@ public urlForObject(key?: string): string
 
 The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:.
 
-\`https://s3.us-west-1.amazonaws.com/onlybucket\` - \`https://s3.us-west-1.amazonaws.com/bucket/key\` - \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
+\`https://s3.us-west-1.amazonaws.com/onlybucket\`
+- \`https://s3.us-west-1.amazonaws.com/bucket/key\`
+- \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.GreeterBucket.urlForObject.parameter.key\\"></a>
 
@@ -1453,7 +1615,8 @@ The https URL of an S3 object. Specify \`regional: false\` at the options for no
 
 The S3 key of the object.
 
-If not specified, the URL of the bucket is returned.
+If not specified, the URL of the
+bucket is returned.
 
 ---
 
@@ -1465,7 +1628,10 @@ public virtualHostedUrlForObject(key?: string, options?: VirtualHostedStyleUrlOp
 
 The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:.
 
-\`https://only-bucket.s3.us-west-1.amazonaws.com\` - \`https://bucket.s3.us-west-1.amazonaws.com/key\` - \`https://bucket.s3.amazonaws.com/key\` - \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
+\`https://only-bucket.s3.us-west-1.amazonaws.com\`
+- \`https://bucket.s3.us-west-1.amazonaws.com/key\`
+- \`https://bucket.s3.amazonaws.com/key\`
+- \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.GreeterBucket.virtualHostedUrlForObject.parameter.key\\"></a>
 
@@ -1473,7 +1639,8 @@ The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the
 
 The S3 key of the object.
 
-If not specified, the URL of the bucket is returned.
+If not specified, the URL of the
+bucket is returned.
 
 ---
 
@@ -1658,7 +1825,8 @@ The construct's name.
 
 A \`BucketAttributes\` object.
 
-Can be obtained from a call to \`bucket.export()\` or manually created.
+Can be obtained from a call to
+\`bucket.export()\` or manually created.
 
 ---
 
@@ -1748,7 +1916,12 @@ public readonly env: ResourceEnvironment;
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -1882,7 +2055,8 @@ public readonly policy: BucketPolicy;
 
 The resource policy associated with this bucket.
 
-If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the first call to addToResourcePolicy(s).
+If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the
+first call to addToResourcePolicy(s).
 
 ---
 
@@ -1990,7 +2164,12 @@ Specifies a canned ACL that grants predefined permissions to the bucket.
 
 Whether all objects should be automatically deleted when the bucket is removed from the stack or when the stack is deleted.
 
-Requires the \`removalPolicy\` to be set to \`RemovalPolicy.DESTROY\`.  **Warning** if you have deployed a bucket with \`autoDeleteObjects: true\`, switching this to \`false\` in a CDK version *before* \`1.126.0\` will lead to all objects in the bucket being deleted. Be sure to update your bucket resources by deploying with CDK version \`1.126.0\` or later **before** switching this value to \`false\`.
+Requires the \`removalPolicy\` to be set to \`RemovalPolicy.DESTROY\`.
+
+**Warning** if you have deployed a bucket with \`autoDeleteObjects: true\`,
+switching this to \`false\` in a CDK version *before* \`1.126.0\` will lead to
+all objects in the bucket being deleted. Be sure to update your bucket resources
+by deploying with CDK version \`1.126.0\` or later **before** switching this value to \`false\`.
 
 ---
 
@@ -2043,7 +2222,8 @@ The CORS configuration of this bucket.
 
 The kind of server-side encryption to apply to this bucket.
 
-If you choose KMS, you can specify a KMS key via \`encryptionKey\`. If encryption key is not specified, a key will automatically be created.
+If you choose KMS, you can specify a KMS key via \`encryptionKey\`. If
+encryption key is not specified, a key will automatically be created.
 
 ---
 
@@ -2054,7 +2234,9 @@ If you choose KMS, you can specify a KMS key via \`encryptionKey\`. If encryptio
 
 External KMS key to use for bucket encryption.
 
-The 'encryption' property must be either not specified or set to \\"Kms\\". An error will be emitted if encryption is set to \\"Unencrypted\\" or \\"Managed\\".
+The 'encryption' property must be either not specified or set to \\"Kms\\".
+An error will be emitted if encryption is set to \\"Unencrypted\\" or
+\\"Managed\\".
 
 ---
 
@@ -2250,7 +2432,13 @@ def apply_removal_policy(
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"construct-library.submod1.GoodbyeBucket.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -2326,7 +2514,8 @@ def add_object_created_notification(
 
 Subscribes a destination to receive notifications when an object is created in the bucket.
 
-This is identical to calling \`onEvent(EventType.OBJECT_CREATED)\`.
+This is identical to calling
+\`onEvent(EventType.OBJECT_CREATED)\`.
 
 ###### \`dest\`<sup>Required</sup> <a name=\\"dest\\" id=\\"construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification.parameter.dest\\"></a>
 
@@ -2364,7 +2553,8 @@ def add_object_removed_notification(
 
 Subscribes a destination to receive notifications when an object is removed from the bucket.
 
-This is identical to calling \`onEvent(EventType.OBJECT_REMOVED)\`.
+This is identical to calling
+\`onEvent(EventType.OBJECT_REMOVED)\`.
 
 ###### \`dest\`<sup>Required</sup> <a name=\\"dest\\" id=\\"construct-library.submod1.GoodbyeBucket.addObjectRemovedNotification.parameter.dest\\"></a>
 
@@ -2400,7 +2590,11 @@ def add_to_resource_policy(
 
 Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects.
 
-Note that the policy statement may or may not be added to the policy. For example, when an \`IBucket\` is created from an existing bucket, it's not possible to tell whether the bucket already has a policy attached, let alone to re-use that policy to add more statements to it. So it's safest to do nothing in these cases.
+Note that the policy statement may or may not be added to the policy.
+For example, when an \`IBucket\` is created from an existing bucket,
+it's not possible to tell whether the bucket already has a policy
+attached, let alone to re-use that policy to add more statements to it.
+So it's safest to do nothing in these cases.
 
 ###### \`permission\`<sup>Required</sup> <a name=\\"permission\\" id=\\"construct-library.submod1.GoodbyeBucket.addToResourcePolicy.parameter.permission\\"></a>
 
@@ -2420,7 +2614,11 @@ def arn_for_objects(
 
 Returns an ARN that represents all objects within the bucket that match the key pattern specified.
 
-To represent all keys, specify \`\`\\"*\\"\`\`.  If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:     arnForObjects(\`home/\${team}/\${user}/*\`)
+To represent all keys, specify \`\`\\"*\\"\`\`.
+
+If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:
+
+   arnForObjects(\`home/\${team}/\${user}/*\`)
 
 ###### \`key_pattern\`<sup>Required</sup> <a name=\\"key_pattern\\" id=\\"construct-library.submod1.GoodbyeBucket.arnForObjects.parameter.keyPattern\\"></a>
 
@@ -2466,7 +2664,24 @@ def grant_public_access(
 
 Allows unrestricted access to objects from this bucket.
 
-IMPORTANT: This permission allows anyone to perform actions on S3 objects in this bucket, which is useful for when you configure your bucket as a website and want everyone to be able to read objects in the bucket without needing to authenticate.  Without arguments, this method will grant read (\\"s3:GetObject\\") access to all objects (\\"*\\") in the bucket.  The method returns the \`iam.Grant\` object, which can then be modified as needed. For example, you can add a condition that will restrict access only to an IPv4 range like this:       const grant = bucket.grantPublicAccess();      grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });  Note that if this \`IBucket\` refers to an existing bucket, possibly not managed by CloudFormation, this method will have no effect, since it's impossible to modify the policy of an existing bucket.
+IMPORTANT: This permission allows anyone to perform actions on S3 objects
+in this bucket, which is useful for when you configure your bucket as a
+website and want everyone to be able to read objects in the bucket without
+needing to authenticate.
+
+Without arguments, this method will grant read (\\"s3:GetObject\\") access to
+all objects (\\"*\\") in the bucket.
+
+The method returns the \`iam.Grant\` object, which can then be modified
+as needed. For example, you can add a condition that will restrict access only
+to an IPv4 range like this:
+
+     const grant = bucket.grantPublicAccess();
+     grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });
+
+Note that if this \`IBucket\` refers to an existing bucket, possibly not
+managed by CloudFormation, this method will have no effect, since it's
+impossible to modify the policy of an existing bucket.
 
 ###### \`allowed_actions\`<sup>Required</sup> <a name=\\"allowed_actions\\" id=\\"construct-library.submod1.GoodbyeBucket.grantPublicAccess.parameter.allowedActions\\"></a>
 
@@ -2497,7 +2712,8 @@ def grant_put(
 
 Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal.
 
-If encryption is used, permission to use the key to encrypt the contents of written files will also be granted to the same principal.
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantPut.parameter.identity\\"></a>
 
@@ -2526,7 +2742,9 @@ def grant_put_acl(
 
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
-If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set, calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects; in this case, if you need to modify object ACLs, call this method explicitly.
+If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
+calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.identity\\"></a>
 
@@ -2551,7 +2769,8 @@ def grant_read(
 
 Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
 
-If encryption is used, permission to use the key to decrypt the contents of the bucket will also be granted to the same principal.
+If encryption is used, permission to use the key to decrypt the contents
+of the bucket will also be granted to the same principal.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantRead.parameter.identity\\"></a>
 
@@ -2580,7 +2799,16 @@ def grant_read_write(
 
 Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
 
-If an encryption key is used, permission to use the key for encrypt/decrypt will also be granted.  Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`, which could be used to grant read/write object access to IAM principals in other accounts. If you want to get rid of that behavior, update your CDK version to 1.85.0 or later, and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\` in the \`context\` key of your cdk.json file. If you've already updated, but still need the principal to have permissions to modify the ACLs, use the {@link grantPutAcl} method.
+If an encryption key is used, permission to use the key for
+encrypt/decrypt will also be granted.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.identity\\"></a>
 
@@ -2605,7 +2833,16 @@ def grant_write(
 
 Grant write permissions to this bucket to an IAM principal.
 
-If encryption is used, permission to use the key to encrypt the contents of written files will also be granted to the same principal.  Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`, which could be used to grant read/write object access to IAM principals in other accounts. If you want to get rid of that behavior, update your CDK version to 1.85.0 or later, and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\` in the \`context\` key of your cdk.json file. If you've already updated, but still need the principal to have permissions to modify the ACLs, use the {@link grantPutAcl} method.
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantWrite.parameter.identity\\"></a>
 
@@ -2634,7 +2871,8 @@ def on_cloud_trail_event(
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.submod1.GoodbyeBucket.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -2660,7 +2898,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -2708,7 +2948,12 @@ def on_cloud_trail_put_object(
 
 Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call.
 
-Note that some tools like \`aws s3 cp\` will automatically use either PutObject or the multipart upload API depending on the file size, so using \`onCloudTrailWriteObject\` may be preferable.  Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using \`onCloudTrailWriteObject\` may be preferable.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject.parameter.id\\"></a>
 
@@ -2734,7 +2979,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -2782,7 +3029,15 @@ def on_cloud_trail_write_object(
 
 Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to.
 
-This includes the events PutObject, CopyObject, and CompleteMultipartUpload.  Note that some tools like \`aws s3 cp\` will automatically use either PutObject or the multipart upload API depending on the file size, so using this method may be preferable to \`onCloudTrailPutObject\`.  Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+This includes
+the events PutObject, CopyObject, and CompleteMultipartUpload.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using this method may be preferable to \`onCloudTrailPutObject\`.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject.parameter.id\\"></a>
 
@@ -2808,7 +3063,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -2851,7 +3108,8 @@ def s3_url_for_object(
 
 The S3 URL of an S3 object. For example:.
 
-\`s3://onlybucket\` - \`s3://bucket/key\`
+\`s3://onlybucket\`
+- \`s3://bucket/key\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.submod1.GoodbyeBucket.s3UrlForObject.parameter.key\\"></a>
 
@@ -2859,7 +3117,8 @@ The S3 URL of an S3 object. For example:.
 
 The S3 key of the object.
 
-If not specified, the S3 URL of the bucket is returned.
+If not specified, the S3 URL of the
+bucket is returned.
 
 ---
 
@@ -2873,7 +3132,9 @@ def url_for_object(
 
 The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:.
 
-\`https://s3.us-west-1.amazonaws.com/onlybucket\` - \`https://s3.us-west-1.amazonaws.com/bucket/key\` - \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
+\`https://s3.us-west-1.amazonaws.com/onlybucket\`
+- \`https://s3.us-west-1.amazonaws.com/bucket/key\`
+- \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.submod1.GoodbyeBucket.urlForObject.parameter.key\\"></a>
 
@@ -2881,7 +3142,8 @@ The https URL of an S3 object. Specify \`regional: false\` at the options for no
 
 The S3 key of the object.
 
-If not specified, the URL of the bucket is returned.
+If not specified, the URL of the
+bucket is returned.
 
 ---
 
@@ -2896,7 +3158,10 @@ def virtual_hosted_url_for_object(
 
 The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:.
 
-\`https://only-bucket.s3.us-west-1.amazonaws.com\` - \`https://bucket.s3.us-west-1.amazonaws.com/key\` - \`https://bucket.s3.amazonaws.com/key\` - \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
+\`https://only-bucket.s3.us-west-1.amazonaws.com\`
+- \`https://bucket.s3.us-west-1.amazonaws.com/key\`
+- \`https://bucket.s3.amazonaws.com/key\`
+- \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.submod1.GoodbyeBucket.virtualHostedUrlForObject.parameter.key\\"></a>
 
@@ -2904,7 +3169,8 @@ The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the
 
 The S3 key of the object.
 
-If not specified, the URL of the bucket is returned.
+If not specified, the URL of the
+bucket is returned.
 
 ---
 
@@ -3099,7 +3365,10 @@ Add a lifecycle rule to the bucket.
 
 Specifies a lifecycle rule that aborts incomplete multipart uploads to an Amazon S3 bucket.
 
-The AbortIncompleteMultipartUpload property type creates a lifecycle rule that aborts incomplete multipart uploads to an Amazon S3 bucket. When Amazon S3 aborts a multipart upload, it deletes all parts associated with the multipart upload.
+The AbortIncompleteMultipartUpload property type creates a lifecycle
+rule that aborts incomplete multipart uploads to an Amazon S3 bucket.
+When Amazon S3 aborts a multipart upload, it deletes all parts
+associated with the multipart upload.
 
 ---
 
@@ -3119,7 +3388,9 @@ Whether this rule is enabled.
 
 Indicates the number of days after creation when objects are deleted from Amazon S3 and Amazon Glacier.
 
-If you specify an expiration and transition time, you must use the same time unit for both properties (either in days or by date). The expiration time must also be later than the transition time.
+If you specify an expiration and transition time, you must use the same
+time unit for both properties (either in days or by date). The
+expiration time must also be later than the transition time.
 
 ---
 
@@ -3130,7 +3401,11 @@ If you specify an expiration and transition time, you must use the same time uni
 
 Indicates when objects are deleted from Amazon S3 and Amazon Glacier.
 
-The date value must be in ISO 8601 format. The time is always midnight UTC.  If you specify an expiration and transition time, you must use the same time unit for both properties (either in days or by date). The expiration time must also be later than the transition time.
+The date value must be in ISO 8601 format. The time is always midnight UTC.
+
+If you specify an expiration and transition time, you must use the same
+time unit for both properties (either in days or by date). The
+expiration time must also be later than the transition time.
 
 ---
 
@@ -3162,7 +3437,12 @@ The value cannot be more than 255 characters.
 
 Time between when a new version of the object is uploaded to the bucket and when old versions of the object expire.
 
-For buckets with versioning enabled (or suspended), specifies the time, in days, between when a new version of the object is uploaded to the bucket and when old versions of the object expire. When object versions expire, Amazon S3 permanently deletes them. If you specify a transition and expiration time, the expiration time must be later than the transition time.
+For buckets with versioning enabled (or suspended), specifies the time,
+in days, between when a new version of the object is uploaded to the
+bucket and when old versions of the object expire. When object versions
+expire, Amazon S3 permanently deletes them. If you specify a transition
+and expiration time, the expiration time must be later than the
+transition time.
 
 ---
 
@@ -3172,7 +3452,10 @@ For buckets with versioning enabled (or suspended), specifies the time, in days,
 
 One or more transition rules that specify when non-current objects transition to a specified storage class.
 
-Only for for buckets with versioning enabled (or suspended).  If you specify a transition and expiration time, the expiration time must be later than the transition time.
+Only for for buckets with versioning enabled (or suspended).
+
+If you specify a transition and expiration time, the expiration time
+must be later than the transition time.
 
 ---
 
@@ -3201,7 +3484,9 @@ The TagFilter property type specifies tags to use to identify a subset of object
 
 One or more transition rules that specify when an object transitions to a specified storage class.
 
-If you specify an expiration and transition time, you must use the same time unit for both properties (either in days or by date). The expiration time must also be later than the transition time.
+If you specify an expiration and transition time, you must use the same
+time unit for both properties (either in days or by date). The
+expiration time must also be later than the transition time.
 
 ---
 
@@ -3383,7 +3668,8 @@ The account this existing bucket belongs to.
 
 The ARN of the bucket.
 
-At least one of bucketArn or bucketName must be defined in order to initialize a bucket ref.
+At least one of bucketArn or bucketName must be
+defined in order to initialize a bucket ref.
 
 ---
 
@@ -3410,7 +3696,10 @@ The IPv6 DNS name of the specified bucket.
 
 The name of the bucket.
 
-If the underlying value of ARN is a string, the name will be parsed from the ARN. Otherwise, the name is optional, but some features that require the bucket name such as auto-creating a bucket policy, won't work.
+If the underlying value of ARN is a string, the
+name will be parsed from the ARN. Otherwise, the name is optional, but
+some features that require the bucket name such as auto-creating a bucket
+policy, won't work.
 
 ---
 
@@ -3429,7 +3718,8 @@ The regional domain name of the specified bucket.
 
 The format of the website URL of the bucket.
 
-This should be true for regions launched since 2014.
+This should be true for
+regions launched since 2014.
 
 ---
 
@@ -3558,7 +3848,12 @@ env: ResourceEnvironment
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -3692,7 +3987,8 @@ policy: BucketPolicy
 
 The resource policy associated with this bucket.
 
-If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the first call to addToResourcePolicy(s).
+If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the
+first call to addToResourcePolicy(s).
 
 ---
 
@@ -3789,7 +4085,12 @@ Specifies a canned ACL that grants predefined permissions to the bucket.
 
 Whether all objects should be automatically deleted when the bucket is removed from the stack or when the stack is deleted.
 
-Requires the \`removalPolicy\` to be set to \`RemovalPolicy.DESTROY\`.  **Warning** if you have deployed a bucket with \`autoDeleteObjects: true\`, switching this to \`false\` in a CDK version *before* \`1.126.0\` will lead to all objects in the bucket being deleted. Be sure to update your bucket resources by deploying with CDK version \`1.126.0\` or later **before** switching this value to \`false\`.
+Requires the \`removalPolicy\` to be set to \`RemovalPolicy.DESTROY\`.
+
+**Warning** if you have deployed a bucket with \`autoDeleteObjects: true\`,
+switching this to \`false\` in a CDK version *before* \`1.126.0\` will lead to
+all objects in the bucket being deleted. Be sure to update your bucket resources
+by deploying with CDK version \`1.126.0\` or later **before** switching this value to \`false\`.
 
 ---
 
@@ -3842,7 +4143,8 @@ The CORS configuration of this bucket.
 
 The kind of server-side encryption to apply to this bucket.
 
-If you choose KMS, you can specify a KMS key via \`encryptionKey\`. If encryption key is not specified, a key will automatically be created.
+If you choose KMS, you can specify a KMS key via \`encryptionKey\`. If
+encryption key is not specified, a key will automatically be created.
 
 ---
 
@@ -3853,7 +4155,9 @@ If you choose KMS, you can specify a KMS key via \`encryptionKey\`. If encryptio
 
 External KMS key to use for bucket encryption.
 
-The 'encryption' property must be either not specified or set to \\"Kms\\". An error will be emitted if encryption is set to \\"Unencrypted\\" or \\"Managed\\".
+The 'encryption' property must be either not specified or set to \\"Kms\\".
+An error will be emitted if encryption is set to \\"Unencrypted\\" or
+\\"Managed\\".
 
 ---
 
@@ -4049,7 +4353,13 @@ def apply_removal_policy(
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"construct-library.GreeterBucket.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -4125,7 +4435,8 @@ def add_object_created_notification(
 
 Subscribes a destination to receive notifications when an object is created in the bucket.
 
-This is identical to calling \`onEvent(EventType.OBJECT_CREATED)\`.
+This is identical to calling
+\`onEvent(EventType.OBJECT_CREATED)\`.
 
 ###### \`dest\`<sup>Required</sup> <a name=\\"dest\\" id=\\"construct-library.GreeterBucket.addObjectCreatedNotification.parameter.dest\\"></a>
 
@@ -4163,7 +4474,8 @@ def add_object_removed_notification(
 
 Subscribes a destination to receive notifications when an object is removed from the bucket.
 
-This is identical to calling \`onEvent(EventType.OBJECT_REMOVED)\`.
+This is identical to calling
+\`onEvent(EventType.OBJECT_REMOVED)\`.
 
 ###### \`dest\`<sup>Required</sup> <a name=\\"dest\\" id=\\"construct-library.GreeterBucket.addObjectRemovedNotification.parameter.dest\\"></a>
 
@@ -4199,7 +4511,11 @@ def add_to_resource_policy(
 
 Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects.
 
-Note that the policy statement may or may not be added to the policy. For example, when an \`IBucket\` is created from an existing bucket, it's not possible to tell whether the bucket already has a policy attached, let alone to re-use that policy to add more statements to it. So it's safest to do nothing in these cases.
+Note that the policy statement may or may not be added to the policy.
+For example, when an \`IBucket\` is created from an existing bucket,
+it's not possible to tell whether the bucket already has a policy
+attached, let alone to re-use that policy to add more statements to it.
+So it's safest to do nothing in these cases.
 
 ###### \`permission\`<sup>Required</sup> <a name=\\"permission\\" id=\\"construct-library.GreeterBucket.addToResourcePolicy.parameter.permission\\"></a>
 
@@ -4219,7 +4535,11 @@ def arn_for_objects(
 
 Returns an ARN that represents all objects within the bucket that match the key pattern specified.
 
-To represent all keys, specify \`\`\\"*\\"\`\`.  If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:     arnForObjects(\`home/\${team}/\${user}/*\`)
+To represent all keys, specify \`\`\\"*\\"\`\`.
+
+If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:
+
+   arnForObjects(\`home/\${team}/\${user}/*\`)
 
 ###### \`key_pattern\`<sup>Required</sup> <a name=\\"key_pattern\\" id=\\"construct-library.GreeterBucket.arnForObjects.parameter.keyPattern\\"></a>
 
@@ -4265,7 +4585,24 @@ def grant_public_access(
 
 Allows unrestricted access to objects from this bucket.
 
-IMPORTANT: This permission allows anyone to perform actions on S3 objects in this bucket, which is useful for when you configure your bucket as a website and want everyone to be able to read objects in the bucket without needing to authenticate.  Without arguments, this method will grant read (\\"s3:GetObject\\") access to all objects (\\"*\\") in the bucket.  The method returns the \`iam.Grant\` object, which can then be modified as needed. For example, you can add a condition that will restrict access only to an IPv4 range like this:       const grant = bucket.grantPublicAccess();      grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });  Note that if this \`IBucket\` refers to an existing bucket, possibly not managed by CloudFormation, this method will have no effect, since it's impossible to modify the policy of an existing bucket.
+IMPORTANT: This permission allows anyone to perform actions on S3 objects
+in this bucket, which is useful for when you configure your bucket as a
+website and want everyone to be able to read objects in the bucket without
+needing to authenticate.
+
+Without arguments, this method will grant read (\\"s3:GetObject\\") access to
+all objects (\\"*\\") in the bucket.
+
+The method returns the \`iam.Grant\` object, which can then be modified
+as needed. For example, you can add a condition that will restrict access only
+to an IPv4 range like this:
+
+     const grant = bucket.grantPublicAccess();
+     grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });
+
+Note that if this \`IBucket\` refers to an existing bucket, possibly not
+managed by CloudFormation, this method will have no effect, since it's
+impossible to modify the policy of an existing bucket.
 
 ###### \`allowed_actions\`<sup>Required</sup> <a name=\\"allowed_actions\\" id=\\"construct-library.GreeterBucket.grantPublicAccess.parameter.allowedActions\\"></a>
 
@@ -4296,7 +4633,8 @@ def grant_put(
 
 Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal.
 
-If encryption is used, permission to use the key to encrypt the contents of written files will also be granted to the same principal.
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantPut.parameter.identity\\"></a>
 
@@ -4325,7 +4663,9 @@ def grant_put_acl(
 
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
-If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set, calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects; in this case, if you need to modify object ACLs, call this method explicitly.
+If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
+calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantPutAcl.parameter.identity\\"></a>
 
@@ -4350,7 +4690,8 @@ def grant_read(
 
 Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
 
-If encryption is used, permission to use the key to decrypt the contents of the bucket will also be granted to the same principal.
+If encryption is used, permission to use the key to decrypt the contents
+of the bucket will also be granted to the same principal.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantRead.parameter.identity\\"></a>
 
@@ -4379,7 +4720,16 @@ def grant_read_write(
 
 Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
 
-If an encryption key is used, permission to use the key for encrypt/decrypt will also be granted.  Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`, which could be used to grant read/write object access to IAM principals in other accounts. If you want to get rid of that behavior, update your CDK version to 1.85.0 or later, and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\` in the \`context\` key of your cdk.json file. If you've already updated, but still need the principal to have permissions to modify the ACLs, use the {@link grantPutAcl} method.
+If an encryption key is used, permission to use the key for
+encrypt/decrypt will also be granted.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantReadWrite.parameter.identity\\"></a>
 
@@ -4404,7 +4754,16 @@ def grant_write(
 
 Grant write permissions to this bucket to an IAM principal.
 
-If encryption is used, permission to use the key to encrypt the contents of written files will also be granted to the same principal.  Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`, which could be used to grant read/write object access to IAM principals in other accounts. If you want to get rid of that behavior, update your CDK version to 1.85.0 or later, and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\` in the \`context\` key of your cdk.json file. If you've already updated, but still need the principal to have permissions to modify the ACLs, use the {@link grantPutAcl} method.
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantWrite.parameter.identity\\"></a>
 
@@ -4433,7 +4792,8 @@ def on_cloud_trail_event(
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.GreeterBucket.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -4459,7 +4819,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -4507,7 +4869,12 @@ def on_cloud_trail_put_object(
 
 Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call.
 
-Note that some tools like \`aws s3 cp\` will automatically use either PutObject or the multipart upload API depending on the file size, so using \`onCloudTrailWriteObject\` may be preferable.  Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using \`onCloudTrailWriteObject\` may be preferable.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.GreeterBucket.onCloudTrailPutObject.parameter.id\\"></a>
 
@@ -4533,7 +4900,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -4581,7 +4950,15 @@ def on_cloud_trail_write_object(
 
 Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to.
 
-This includes the events PutObject, CopyObject, and CompleteMultipartUpload.  Note that some tools like \`aws s3 cp\` will automatically use either PutObject or the multipart upload API depending on the file size, so using this method may be preferable to \`onCloudTrailPutObject\`.  Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+This includes
+the events PutObject, CopyObject, and CompleteMultipartUpload.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using this method may be preferable to \`onCloudTrailPutObject\`.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.GreeterBucket.onCloudTrailWriteObject.parameter.id\\"></a>
 
@@ -4607,7 +4984,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -4650,7 +5029,8 @@ def s3_url_for_object(
 
 The S3 URL of an S3 object. For example:.
 
-\`s3://onlybucket\` - \`s3://bucket/key\`
+\`s3://onlybucket\`
+- \`s3://bucket/key\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.GreeterBucket.s3UrlForObject.parameter.key\\"></a>
 
@@ -4658,7 +5038,8 @@ The S3 URL of an S3 object. For example:.
 
 The S3 key of the object.
 
-If not specified, the S3 URL of the bucket is returned.
+If not specified, the S3 URL of the
+bucket is returned.
 
 ---
 
@@ -4672,7 +5053,9 @@ def url_for_object(
 
 The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:.
 
-\`https://s3.us-west-1.amazonaws.com/onlybucket\` - \`https://s3.us-west-1.amazonaws.com/bucket/key\` - \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
+\`https://s3.us-west-1.amazonaws.com/onlybucket\`
+- \`https://s3.us-west-1.amazonaws.com/bucket/key\`
+- \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.GreeterBucket.urlForObject.parameter.key\\"></a>
 
@@ -4680,7 +5063,8 @@ The https URL of an S3 object. Specify \`regional: false\` at the options for no
 
 The S3 key of the object.
 
-If not specified, the URL of the bucket is returned.
+If not specified, the URL of the
+bucket is returned.
 
 ---
 
@@ -4695,7 +5079,10 @@ def virtual_hosted_url_for_object(
 
 The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:.
 
-\`https://only-bucket.s3.us-west-1.amazonaws.com\` - \`https://bucket.s3.us-west-1.amazonaws.com/key\` - \`https://bucket.s3.amazonaws.com/key\` - \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
+\`https://only-bucket.s3.us-west-1.amazonaws.com\`
+- \`https://bucket.s3.us-west-1.amazonaws.com/key\`
+- \`https://bucket.s3.amazonaws.com/key\`
+- \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.GreeterBucket.virtualHostedUrlForObject.parameter.key\\"></a>
 
@@ -4703,7 +5090,8 @@ The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the
 
 The S3 key of the object.
 
-If not specified, the URL of the bucket is returned.
+If not specified, the URL of the
+bucket is returned.
 
 ---
 
@@ -4898,7 +5286,10 @@ Add a lifecycle rule to the bucket.
 
 Specifies a lifecycle rule that aborts incomplete multipart uploads to an Amazon S3 bucket.
 
-The AbortIncompleteMultipartUpload property type creates a lifecycle rule that aborts incomplete multipart uploads to an Amazon S3 bucket. When Amazon S3 aborts a multipart upload, it deletes all parts associated with the multipart upload.
+The AbortIncompleteMultipartUpload property type creates a lifecycle
+rule that aborts incomplete multipart uploads to an Amazon S3 bucket.
+When Amazon S3 aborts a multipart upload, it deletes all parts
+associated with the multipart upload.
 
 ---
 
@@ -4918,7 +5309,9 @@ Whether this rule is enabled.
 
 Indicates the number of days after creation when objects are deleted from Amazon S3 and Amazon Glacier.
 
-If you specify an expiration and transition time, you must use the same time unit for both properties (either in days or by date). The expiration time must also be later than the transition time.
+If you specify an expiration and transition time, you must use the same
+time unit for both properties (either in days or by date). The
+expiration time must also be later than the transition time.
 
 ---
 
@@ -4929,7 +5322,11 @@ If you specify an expiration and transition time, you must use the same time uni
 
 Indicates when objects are deleted from Amazon S3 and Amazon Glacier.
 
-The date value must be in ISO 8601 format. The time is always midnight UTC.  If you specify an expiration and transition time, you must use the same time unit for both properties (either in days or by date). The expiration time must also be later than the transition time.
+The date value must be in ISO 8601 format. The time is always midnight UTC.
+
+If you specify an expiration and transition time, you must use the same
+time unit for both properties (either in days or by date). The
+expiration time must also be later than the transition time.
 
 ---
 
@@ -4961,7 +5358,12 @@ The value cannot be more than 255 characters.
 
 Time between when a new version of the object is uploaded to the bucket and when old versions of the object expire.
 
-For buckets with versioning enabled (or suspended), specifies the time, in days, between when a new version of the object is uploaded to the bucket and when old versions of the object expire. When object versions expire, Amazon S3 permanently deletes them. If you specify a transition and expiration time, the expiration time must be later than the transition time.
+For buckets with versioning enabled (or suspended), specifies the time,
+in days, between when a new version of the object is uploaded to the
+bucket and when old versions of the object expire. When object versions
+expire, Amazon S3 permanently deletes them. If you specify a transition
+and expiration time, the expiration time must be later than the
+transition time.
 
 ---
 
@@ -4971,7 +5373,10 @@ For buckets with versioning enabled (or suspended), specifies the time, in days,
 
 One or more transition rules that specify when non-current objects transition to a specified storage class.
 
-Only for for buckets with versioning enabled (or suspended).  If you specify a transition and expiration time, the expiration time must be later than the transition time.
+Only for for buckets with versioning enabled (or suspended).
+
+If you specify a transition and expiration time, the expiration time
+must be later than the transition time.
 
 ---
 
@@ -5000,7 +5405,9 @@ The TagFilter property type specifies tags to use to identify a subset of object
 
 One or more transition rules that specify when an object transitions to a specified storage class.
 
-If you specify an expiration and transition time, you must use the same time unit for both properties (either in days or by date). The expiration time must also be later than the transition time.
+If you specify an expiration and transition time, you must use the same
+time unit for both properties (either in days or by date). The
+expiration time must also be later than the transition time.
 
 ---
 
@@ -5182,7 +5589,8 @@ The account this existing bucket belongs to.
 
 The ARN of the bucket.
 
-At least one of bucketArn or bucketName must be defined in order to initialize a bucket ref.
+At least one of bucketArn or bucketName must be
+defined in order to initialize a bucket ref.
 
 ---
 
@@ -5209,7 +5617,10 @@ The IPv6 DNS name of the specified bucket.
 
 The name of the bucket.
 
-If the underlying value of ARN is a string, the name will be parsed from the ARN. Otherwise, the name is optional, but some features that require the bucket name such as auto-creating a bucket policy, won't work.
+If the underlying value of ARN is a string, the
+name will be parsed from the ARN. Otherwise, the name is optional, but
+some features that require the bucket name such as auto-creating a bucket
+policy, won't work.
 
 ---
 
@@ -5228,7 +5639,8 @@ The regional domain name of the specified bucket.
 
 The format of the website URL of the bucket.
 
-This should be true for regions launched since 2014.
+This should be true for
+regions launched since 2014.
 
 ---
 
@@ -5357,7 +5769,12 @@ env: ResourceEnvironment
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -5491,7 +5908,8 @@ policy: BucketPolicy
 
 The resource policy associated with this bucket.
 
-If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the first call to addToResourcePolicy(s).
+If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the
+first call to addToResourcePolicy(s).
 
 ---
 
@@ -5591,7 +6009,13 @@ public applyRemovalPolicy(policy: RemovalPolicy): void
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"construct-library.GreeterBucket.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -5640,7 +6064,9 @@ The notification destination (Lambda, SNS Topic or SQS Queue).
 
 S3 object key filter rules to determine which objects trigger this event.
 
-Each filter must include a \`prefix\` and/or \`suffix\` that will be matched against the s3 object key. Refer to the S3 Developer Guide for details about allowed filter rules.
+Each filter must include a \`prefix\` and/or \`suffix\`
+that will be matched against the s3 object key. Refer to the S3 Developer Guide
+for details about allowed filter rules.
 
 ---
 
@@ -5652,7 +6078,8 @@ public addObjectCreatedNotification(dest: IBucketNotificationDestination, filter
 
 Subscribes a destination to receive notifications when an object is created in the bucket.
 
-This is identical to calling \`onEvent(EventType.OBJECT_CREATED)\`.
+This is identical to calling
+\`onEvent(EventType.OBJECT_CREATED)\`.
 
 ###### \`dest\`<sup>Required</sup> <a name=\\"dest\\" id=\\"construct-library.GreeterBucket.addObjectCreatedNotification.parameter.dest\\"></a>
 
@@ -5678,7 +6105,8 @@ public addObjectRemovedNotification(dest: IBucketNotificationDestination, filter
 
 Subscribes a destination to receive notifications when an object is removed from the bucket.
 
-This is identical to calling \`onEvent(EventType.OBJECT_REMOVED)\`.
+This is identical to calling
+\`onEvent(EventType.OBJECT_REMOVED)\`.
 
 ###### \`dest\`<sup>Required</sup> <a name=\\"dest\\" id=\\"construct-library.GreeterBucket.addObjectRemovedNotification.parameter.dest\\"></a>
 
@@ -5704,7 +6132,11 @@ public addToResourcePolicy(permission: PolicyStatement): AddToResourcePolicyResu
 
 Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects.
 
-Note that the policy statement may or may not be added to the policy. For example, when an \`IBucket\` is created from an existing bucket, it's not possible to tell whether the bucket already has a policy attached, let alone to re-use that policy to add more statements to it. So it's safest to do nothing in these cases.
+Note that the policy statement may or may not be added to the policy.
+For example, when an \`IBucket\` is created from an existing bucket,
+it's not possible to tell whether the bucket already has a policy
+attached, let alone to re-use that policy to add more statements to it.
+So it's safest to do nothing in these cases.
 
 ###### \`permission\`<sup>Required</sup> <a name=\\"permission\\" id=\\"construct-library.GreeterBucket.addToResourcePolicy.parameter.permission\\"></a>
 
@@ -5722,7 +6154,11 @@ public arnForObjects(keyPattern: string): string
 
 Returns an ARN that represents all objects within the bucket that match the key pattern specified.
 
-To represent all keys, specify \`\`\\"*\\"\`\`.  If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:     arnForObjects(\`home/\${team}/\${user}/*\`)
+To represent all keys, specify \`\`\\"*\\"\`\`.
+
+If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:
+
+   arnForObjects(\`home/\${team}/\${user}/*\`)
 
 ###### \`keyPattern\`<sup>Required</sup> <a name=\\"keyPattern\\" id=\\"construct-library.GreeterBucket.arnForObjects.parameter.keyPattern\\"></a>
 
@@ -5762,7 +6198,24 @@ public grantPublicAccess(allowedActions: string, keyPrefix?: string): Grant
 
 Allows unrestricted access to objects from this bucket.
 
-IMPORTANT: This permission allows anyone to perform actions on S3 objects in this bucket, which is useful for when you configure your bucket as a website and want everyone to be able to read objects in the bucket without needing to authenticate.  Without arguments, this method will grant read (\\"s3:GetObject\\") access to all objects (\\"*\\") in the bucket.  The method returns the \`iam.Grant\` object, which can then be modified as needed. For example, you can add a condition that will restrict access only to an IPv4 range like this:       const grant = bucket.grantPublicAccess();      grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });  Note that if this \`IBucket\` refers to an existing bucket, possibly not managed by CloudFormation, this method will have no effect, since it's impossible to modify the policy of an existing bucket.
+IMPORTANT: This permission allows anyone to perform actions on S3 objects
+in this bucket, which is useful for when you configure your bucket as a
+website and want everyone to be able to read objects in the bucket without
+needing to authenticate.
+
+Without arguments, this method will grant read (\\"s3:GetObject\\") access to
+all objects (\\"*\\") in the bucket.
+
+The method returns the \`iam.Grant\` object, which can then be modified
+as needed. For example, you can add a condition that will restrict access only
+to an IPv4 range like this:
+
+     const grant = bucket.grantPublicAccess();
+     grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });
+
+Note that if this \`IBucket\` refers to an existing bucket, possibly not
+managed by CloudFormation, this method will have no effect, since it's
+impossible to modify the policy of an existing bucket.
 
 ###### \`allowedActions\`<sup>Required</sup> <a name=\\"allowedActions\\" id=\\"construct-library.GreeterBucket.grantPublicAccess.parameter.allowedActions\\"></a>
 
@@ -5790,7 +6243,8 @@ public grantPut(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal.
 
-If encryption is used, permission to use the key to encrypt the contents of written files will also be granted to the same principal.
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantPut.parameter.identity\\"></a>
 
@@ -5816,7 +6270,9 @@ public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
 
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
-If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set, calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects; in this case, if you need to modify object ACLs, call this method explicitly.
+If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
+calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantPutAcl.parameter.identity\\"></a>
 
@@ -5838,7 +6294,8 @@ public grantRead(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
 
-If encryption is used, permission to use the key to decrypt the contents of the bucket will also be granted to the same principal.
+If encryption is used, permission to use the key to decrypt the contents
+of the bucket will also be granted to the same principal.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantRead.parameter.identity\\"></a>
 
@@ -5864,7 +6321,16 @@ public grantReadWrite(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
 
-If an encryption key is used, permission to use the key for encrypt/decrypt will also be granted.  Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`, which could be used to grant read/write object access to IAM principals in other accounts. If you want to get rid of that behavior, update your CDK version to 1.85.0 or later, and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\` in the \`context\` key of your cdk.json file. If you've already updated, but still need the principal to have permissions to modify the ACLs, use the {@link grantPutAcl} method.
+If an encryption key is used, permission to use the key for
+encrypt/decrypt will also be granted.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantReadWrite.parameter.identity\\"></a>
 
@@ -5886,7 +6352,16 @@ public grantWrite(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grant write permissions to this bucket to an IAM principal.
 
-If encryption is used, permission to use the key to encrypt the contents of written files will also be granted to the same principal.  Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`, which could be used to grant read/write object access to IAM principals in other accounts. If you want to get rid of that behavior, update your CDK version to 1.85.0 or later, and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\` in the \`context\` key of your cdk.json file. If you've already updated, but still need the principal to have permissions to modify the ACLs, use the {@link grantPutAcl} method.
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.GreeterBucket.grantWrite.parameter.identity\\"></a>
 
@@ -5908,7 +6383,8 @@ public onCloudTrailEvent(id: string, options?: OnCloudTrailBucketEventOptions): 
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.GreeterBucket.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -5934,7 +6410,12 @@ public onCloudTrailPutObject(id: string, options?: OnCloudTrailBucketEventOption
 
 Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call.
 
-Note that some tools like \`aws s3 cp\` will automatically use either PutObject or the multipart upload API depending on the file size, so using \`onCloudTrailWriteObject\` may be preferable.  Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using \`onCloudTrailWriteObject\` may be preferable.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.GreeterBucket.onCloudTrailPutObject.parameter.id\\"></a>
 
@@ -5960,7 +6441,15 @@ public onCloudTrailWriteObject(id: string, options?: OnCloudTrailBucketEventOpti
 
 Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to.
 
-This includes the events PutObject, CopyObject, and CompleteMultipartUpload.  Note that some tools like \`aws s3 cp\` will automatically use either PutObject or the multipart upload API depending on the file size, so using this method may be preferable to \`onCloudTrailPutObject\`.  Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+This includes
+the events PutObject, CopyObject, and CompleteMultipartUpload.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using this method may be preferable to \`onCloudTrailPutObject\`.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.GreeterBucket.onCloudTrailWriteObject.parameter.id\\"></a>
 
@@ -5986,7 +6475,8 @@ public s3UrlForObject(key?: string): string
 
 The S3 URL of an S3 object. For example:.
 
-\`s3://onlybucket\` - \`s3://bucket/key\`
+\`s3://onlybucket\`
+- \`s3://bucket/key\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.GreeterBucket.s3UrlForObject.parameter.key\\"></a>
 
@@ -5994,7 +6484,8 @@ The S3 URL of an S3 object. For example:.
 
 The S3 key of the object.
 
-If not specified, the S3 URL of the bucket is returned.
+If not specified, the S3 URL of the
+bucket is returned.
 
 ---
 
@@ -6006,7 +6497,9 @@ public urlForObject(key?: string): string
 
 The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:.
 
-\`https://s3.us-west-1.amazonaws.com/onlybucket\` - \`https://s3.us-west-1.amazonaws.com/bucket/key\` - \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
+\`https://s3.us-west-1.amazonaws.com/onlybucket\`
+- \`https://s3.us-west-1.amazonaws.com/bucket/key\`
+- \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.GreeterBucket.urlForObject.parameter.key\\"></a>
 
@@ -6014,7 +6507,8 @@ The https URL of an S3 object. Specify \`regional: false\` at the options for no
 
 The S3 key of the object.
 
-If not specified, the URL of the bucket is returned.
+If not specified, the URL of the
+bucket is returned.
 
 ---
 
@@ -6026,7 +6520,10 @@ public virtualHostedUrlForObject(key?: string, options?: VirtualHostedStyleUrlOp
 
 The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:.
 
-\`https://only-bucket.s3.us-west-1.amazonaws.com\` - \`https://bucket.s3.us-west-1.amazonaws.com/key\` - \`https://bucket.s3.amazonaws.com/key\` - \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
+\`https://only-bucket.s3.us-west-1.amazonaws.com\`
+- \`https://bucket.s3.us-west-1.amazonaws.com/key\`
+- \`https://bucket.s3.amazonaws.com/key\`
+- \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.GreeterBucket.virtualHostedUrlForObject.parameter.key\\"></a>
 
@@ -6034,7 +6531,8 @@ The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the
 
 The S3 key of the object.
 
-If not specified, the URL of the bucket is returned.
+If not specified, the URL of the
+bucket is returned.
 
 ---
 
@@ -6219,7 +6717,8 @@ The construct's name.
 
 A \`BucketAttributes\` object.
 
-Can be obtained from a call to \`bucket.export()\` or manually created.
+Can be obtained from a call to
+\`bucket.export()\` or manually created.
 
 ---
 
@@ -6309,7 +6808,12 @@ public readonly env: ResourceEnvironment;
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -6443,7 +6947,8 @@ public readonly policy: BucketPolicy;
 
 The resource policy associated with this bucket.
 
-If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the first call to addToResourcePolicy(s).
+If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the
+first call to addToResourcePolicy(s).
 
 ---
 
@@ -6543,7 +7048,13 @@ public applyRemovalPolicy(policy: RemovalPolicy): void
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"construct-library.submod1.GoodbyeBucket.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -6592,7 +7103,9 @@ The notification destination (Lambda, SNS Topic or SQS Queue).
 
 S3 object key filter rules to determine which objects trigger this event.
 
-Each filter must include a \`prefix\` and/or \`suffix\` that will be matched against the s3 object key. Refer to the S3 Developer Guide for details about allowed filter rules.
+Each filter must include a \`prefix\` and/or \`suffix\`
+that will be matched against the s3 object key. Refer to the S3 Developer Guide
+for details about allowed filter rules.
 
 ---
 
@@ -6604,7 +7117,8 @@ public addObjectCreatedNotification(dest: IBucketNotificationDestination, filter
 
 Subscribes a destination to receive notifications when an object is created in the bucket.
 
-This is identical to calling \`onEvent(EventType.OBJECT_CREATED)\`.
+This is identical to calling
+\`onEvent(EventType.OBJECT_CREATED)\`.
 
 ###### \`dest\`<sup>Required</sup> <a name=\\"dest\\" id=\\"construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification.parameter.dest\\"></a>
 
@@ -6630,7 +7144,8 @@ public addObjectRemovedNotification(dest: IBucketNotificationDestination, filter
 
 Subscribes a destination to receive notifications when an object is removed from the bucket.
 
-This is identical to calling \`onEvent(EventType.OBJECT_REMOVED)\`.
+This is identical to calling
+\`onEvent(EventType.OBJECT_REMOVED)\`.
 
 ###### \`dest\`<sup>Required</sup> <a name=\\"dest\\" id=\\"construct-library.submod1.GoodbyeBucket.addObjectRemovedNotification.parameter.dest\\"></a>
 
@@ -6656,7 +7171,11 @@ public addToResourcePolicy(permission: PolicyStatement): AddToResourcePolicyResu
 
 Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects.
 
-Note that the policy statement may or may not be added to the policy. For example, when an \`IBucket\` is created from an existing bucket, it's not possible to tell whether the bucket already has a policy attached, let alone to re-use that policy to add more statements to it. So it's safest to do nothing in these cases.
+Note that the policy statement may or may not be added to the policy.
+For example, when an \`IBucket\` is created from an existing bucket,
+it's not possible to tell whether the bucket already has a policy
+attached, let alone to re-use that policy to add more statements to it.
+So it's safest to do nothing in these cases.
 
 ###### \`permission\`<sup>Required</sup> <a name=\\"permission\\" id=\\"construct-library.submod1.GoodbyeBucket.addToResourcePolicy.parameter.permission\\"></a>
 
@@ -6674,7 +7193,11 @@ public arnForObjects(keyPattern: string): string
 
 Returns an ARN that represents all objects within the bucket that match the key pattern specified.
 
-To represent all keys, specify \`\`\\"*\\"\`\`.  If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:     arnForObjects(\`home/\${team}/\${user}/*\`)
+To represent all keys, specify \`\`\\"*\\"\`\`.
+
+If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:
+
+   arnForObjects(\`home/\${team}/\${user}/*\`)
 
 ###### \`keyPattern\`<sup>Required</sup> <a name=\\"keyPattern\\" id=\\"construct-library.submod1.GoodbyeBucket.arnForObjects.parameter.keyPattern\\"></a>
 
@@ -6714,7 +7237,24 @@ public grantPublicAccess(allowedActions: string, keyPrefix?: string): Grant
 
 Allows unrestricted access to objects from this bucket.
 
-IMPORTANT: This permission allows anyone to perform actions on S3 objects in this bucket, which is useful for when you configure your bucket as a website and want everyone to be able to read objects in the bucket without needing to authenticate.  Without arguments, this method will grant read (\\"s3:GetObject\\") access to all objects (\\"*\\") in the bucket.  The method returns the \`iam.Grant\` object, which can then be modified as needed. For example, you can add a condition that will restrict access only to an IPv4 range like this:       const grant = bucket.grantPublicAccess();      grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });  Note that if this \`IBucket\` refers to an existing bucket, possibly not managed by CloudFormation, this method will have no effect, since it's impossible to modify the policy of an existing bucket.
+IMPORTANT: This permission allows anyone to perform actions on S3 objects
+in this bucket, which is useful for when you configure your bucket as a
+website and want everyone to be able to read objects in the bucket without
+needing to authenticate.
+
+Without arguments, this method will grant read (\\"s3:GetObject\\") access to
+all objects (\\"*\\") in the bucket.
+
+The method returns the \`iam.Grant\` object, which can then be modified
+as needed. For example, you can add a condition that will restrict access only
+to an IPv4 range like this:
+
+     const grant = bucket.grantPublicAccess();
+     grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });
+
+Note that if this \`IBucket\` refers to an existing bucket, possibly not
+managed by CloudFormation, this method will have no effect, since it's
+impossible to modify the policy of an existing bucket.
 
 ###### \`allowedActions\`<sup>Required</sup> <a name=\\"allowedActions\\" id=\\"construct-library.submod1.GoodbyeBucket.grantPublicAccess.parameter.allowedActions\\"></a>
 
@@ -6742,7 +7282,8 @@ public grantPut(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal.
 
-If encryption is used, permission to use the key to encrypt the contents of written files will also be granted to the same principal.
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantPut.parameter.identity\\"></a>
 
@@ -6768,7 +7309,9 @@ public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
 
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
-If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set, calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects; in this case, if you need to modify object ACLs, call this method explicitly.
+If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
+calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.identity\\"></a>
 
@@ -6790,7 +7333,8 @@ public grantRead(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
 
-If encryption is used, permission to use the key to decrypt the contents of the bucket will also be granted to the same principal.
+If encryption is used, permission to use the key to decrypt the contents
+of the bucket will also be granted to the same principal.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantRead.parameter.identity\\"></a>
 
@@ -6816,7 +7360,16 @@ public grantReadWrite(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
 
-If an encryption key is used, permission to use the key for encrypt/decrypt will also be granted.  Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`, which could be used to grant read/write object access to IAM principals in other accounts. If you want to get rid of that behavior, update your CDK version to 1.85.0 or later, and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\` in the \`context\` key of your cdk.json file. If you've already updated, but still need the principal to have permissions to modify the ACLs, use the {@link grantPutAcl} method.
+If an encryption key is used, permission to use the key for
+encrypt/decrypt will also be granted.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.identity\\"></a>
 
@@ -6838,7 +7391,16 @@ public grantWrite(identity: IGrantable, objectsKeyPattern?: any): Grant
 
 Grant write permissions to this bucket to an IAM principal.
 
-If encryption is used, permission to use the key to encrypt the contents of written files will also be granted to the same principal.  Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`, which could be used to grant read/write object access to IAM principals in other accounts. If you want to get rid of that behavior, update your CDK version to 1.85.0 or later, and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\` in the \`context\` key of your cdk.json file. If you've already updated, but still need the principal to have permissions to modify the ACLs, use the {@link grantPutAcl} method.
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
 
 ###### \`identity\`<sup>Required</sup> <a name=\\"identity\\" id=\\"construct-library.submod1.GoodbyeBucket.grantWrite.parameter.identity\\"></a>
 
@@ -6860,7 +7422,8 @@ public onCloudTrailEvent(id: string, options?: OnCloudTrailBucketEventOptions): 
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.submod1.GoodbyeBucket.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -6886,7 +7449,12 @@ public onCloudTrailPutObject(id: string, options?: OnCloudTrailBucketEventOption
 
 Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call.
 
-Note that some tools like \`aws s3 cp\` will automatically use either PutObject or the multipart upload API depending on the file size, so using \`onCloudTrailWriteObject\` may be preferable.  Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using \`onCloudTrailWriteObject\` may be preferable.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject.parameter.id\\"></a>
 
@@ -6912,7 +7480,15 @@ public onCloudTrailWriteObject(id: string, options?: OnCloudTrailBucketEventOpti
 
 Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to.
 
-This includes the events PutObject, CopyObject, and CompleteMultipartUpload.  Note that some tools like \`aws s3 cp\` will automatically use either PutObject or the multipart upload API depending on the file size, so using this method may be preferable to \`onCloudTrailPutObject\`.  Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+This includes
+the events PutObject, CopyObject, and CompleteMultipartUpload.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using this method may be preferable to \`onCloudTrailPutObject\`.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject.parameter.id\\"></a>
 
@@ -6938,7 +7514,8 @@ public s3UrlForObject(key?: string): string
 
 The S3 URL of an S3 object. For example:.
 
-\`s3://onlybucket\` - \`s3://bucket/key\`
+\`s3://onlybucket\`
+- \`s3://bucket/key\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.submod1.GoodbyeBucket.s3UrlForObject.parameter.key\\"></a>
 
@@ -6946,7 +7523,8 @@ The S3 URL of an S3 object. For example:.
 
 The S3 key of the object.
 
-If not specified, the S3 URL of the bucket is returned.
+If not specified, the S3 URL of the
+bucket is returned.
 
 ---
 
@@ -6958,7 +7536,9 @@ public urlForObject(key?: string): string
 
 The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:.
 
-\`https://s3.us-west-1.amazonaws.com/onlybucket\` - \`https://s3.us-west-1.amazonaws.com/bucket/key\` - \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
+\`https://s3.us-west-1.amazonaws.com/onlybucket\`
+- \`https://s3.us-west-1.amazonaws.com/bucket/key\`
+- \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.submod1.GoodbyeBucket.urlForObject.parameter.key\\"></a>
 
@@ -6966,7 +7546,8 @@ The https URL of an S3 object. Specify \`regional: false\` at the options for no
 
 The S3 key of the object.
 
-If not specified, the URL of the bucket is returned.
+If not specified, the URL of the
+bucket is returned.
 
 ---
 
@@ -6978,7 +7559,10 @@ public virtualHostedUrlForObject(key?: string, options?: VirtualHostedStyleUrlOp
 
 The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:.
 
-\`https://only-bucket.s3.us-west-1.amazonaws.com\` - \`https://bucket.s3.us-west-1.amazonaws.com/key\` - \`https://bucket.s3.amazonaws.com/key\` - \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
+\`https://only-bucket.s3.us-west-1.amazonaws.com\`
+- \`https://bucket.s3.us-west-1.amazonaws.com/key\`
+- \`https://bucket.s3.amazonaws.com/key\`
+- \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
 
 ###### \`key\`<sup>Optional</sup> <a name=\\"key\\" id=\\"construct-library.submod1.GoodbyeBucket.virtualHostedUrlForObject.parameter.key\\"></a>
 
@@ -6986,7 +7570,8 @@ The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the
 
 The S3 key of the object.
 
-If not specified, the URL of the bucket is returned.
+If not specified, the URL of the
+bucket is returned.
 
 ---
 
@@ -7171,7 +7756,8 @@ The construct's name.
 
 A \`BucketAttributes\` object.
 
-Can be obtained from a call to \`bucket.export()\` or manually created.
+Can be obtained from a call to
+\`bucket.export()\` or manually created.
 
 ---
 
@@ -7261,7 +7847,12 @@ public readonly env: ResourceEnvironment;
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -7395,7 +7986,8 @@ public readonly policy: BucketPolicy;
 
 The resource policy associated with this bucket.
 
-If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the first call to addToResourcePolicy(s).
+If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the
+first call to addToResourcePolicy(s).
 
 ---
 

--- a/test/docgen/transpile/__snapshots__/transpile.test.ts.snap
+++ b/test/docgen/transpile/__snapshots__/transpile.test.ts.snap
@@ -11,7 +11,11 @@ exports[`submodules without an explicit name csharp 1`] = `
 
 A Lambda@Edge function.
 
-Convenience resource for requesting a Lambda function in the 'us-east-1' region for use with Lambda@Edge. Implements several restrictions enforced by Lambda@Edge.  Note that this construct requires that the 'us-east-1' region has been bootstrapped. See https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html or 'cdk bootstrap --help' for options.
+Convenience resource for requesting a Lambda function in the 'us-east-1' region for use with Lambda@Edge.
+Implements several restrictions enforced by Lambda@Edge.
+
+Note that this construct requires that the 'us-east-1' region has been bootstrapped.
+See https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html or 'cdk bootstrap --help' for options.
 
 #### Initializers <a name=\\"Initializers\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.Initializer\\"></a>
 
@@ -84,7 +88,13 @@ private void ApplyRemovalPolicy(RemovalPolicy Policy)
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`Policy\`<sup>Required</sup> <a name=\\"Policy\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -238,7 +248,10 @@ private Metric MetricDuration(MetricOptions Props = null)
 
 Metric for the Duration of this Lambda How long execution of this Lambda takes.
 
-Average over 5 minutes Metric for the Duration of this Lambda How long execution of this Lambda takes.  Average over 5 minutes
+Average over 5 minutes
+Metric for the Duration of this Lambda How long execution of this Lambda takes.
+
+Average over 5 minutes
 
 ###### \`Props\`<sup>Optional</sup> <a name=\\"Props\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.metricDuration.parameter.props\\"></a>
 
@@ -270,7 +283,10 @@ private Metric MetricInvocations(MetricOptions Props = null)
 
 Metric for the number of invocations of this Lambda How often this Lambda is invoked.
 
-Sum over 5 minutes Metric for the number of invocations of this Lambda How often this Lambda is invoked.  Sum over 5 minutes
+Sum over 5 minutes
+Metric for the number of invocations of this Lambda How often this Lambda is invoked.
+
+Sum over 5 minutes
 
 ###### \`Props\`<sup>Optional</sup> <a name=\\"Props\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.metricInvocations.parameter.props\\"></a>
 
@@ -286,7 +302,10 @@ private Metric MetricThrottles(MetricOptions Props = null)
 
 Metric for the number of throttled invocations of this Lambda How often this Lambda is throttled.
 
-Sum over 5 minutes Metric for the number of throttled invocations of this Lambda How often this Lambda is throttled.  Sum over 5 minutes
+Sum over 5 minutes
+Metric for the number of throttled invocations of this Lambda How often this Lambda is throttled.
+
+Sum over 5 minutes
 
 ###### \`Props\`<sup>Optional</sup> <a name=\\"Props\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.metricThrottles.parameter.props\\"></a>
 
@@ -379,7 +398,12 @@ public ResourceEnvironment Env { get; }
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -505,7 +529,12 @@ public IVersion LatestVersion { get; }
 
 The \`$LATEST\` version of this function.
 
-Note that this is reference to a non-specific AWS Lambda version, which means the function this version refers to can return different results in different invocations.  To obtain a reference to an explicit version which references the current function configuration, use \`lambdaFunction.currentVersion\` instead.
+Note that this is reference to a non-specific AWS Lambda version, which
+means the function this version refers to can return different results in
+different invocations.
+
+To obtain a reference to an explicit version which references the current
+function configuration, use \`lambdaFunction.currentVersion\` instead.
 
 ---
 
@@ -655,7 +684,8 @@ public Duration MaxEventAge { get; set; }
 
 The maximum age of a request that Lambda sends to a function for processing.
 
-Minimum: 60 seconds Maximum: 6 hours
+Minimum: 60 seconds
+Maximum: 6 hours
 
 ---
 
@@ -696,7 +726,8 @@ public double RetryAttempts { get; set; }
 
 The maximum number of times to retry when the function returns an error.
 
-Minimum: 0 Maximum: 2
+Minimum: 0
+Maximum: 2
 
 ---
 
@@ -711,7 +742,8 @@ public bool AllowAllOutbound { get; set; }
 
 Whether to allow the Lambda to send all network traffic.
 
-If set to false, you must individually add traffic rules to allow the Lambda to connect to network targets.
+If set to false, you must individually add traffic rules to allow the
+Lambda to connect to network targets.
 
 ---
 
@@ -795,7 +827,8 @@ public bool DeadLetterQueueEnabled { get; set; }
 
 Enabled DLQ.
 
-If \`deadLetterQueue\` is undefined, an SQS queue with default options will be defined for your Function.
+If \`deadLetterQueue\` is undefined,
+an SQS queue with default options will be defined for your Function.
 
 ---
 
@@ -823,7 +856,9 @@ public System.Collections.Generic.IDictionary<string, string> Environment { get;
 
 Key-value pairs that Lambda caches and makes available for your Lambda functions.
 
-Use environment variables to apply configuration changes, such as test and production environment configurations, without changing your Lambda function source code.
+Use environment variables to apply configuration changes, such
+as test and production environment configurations, without changing your
+Lambda function source code.
 
 ---
 
@@ -922,7 +957,9 @@ public ILayerVersion[] Layers { get; set; }
 
 A list of layers to add to the function's execution environment.
 
-You can configure your Lambda function to pull in additional code during initialization in the form of layers. Layers are packages of libraries or other dependencies that can be used by multiple functions.
+You can configure your Lambda function to pull in
+additional code during initialization in the form of layers. Layers are packages of libraries or other dependencies
+that can be used by multiple functions.
 
 ---
 
@@ -937,7 +974,9 @@ public RetentionDays LogRetention { get; set; }
 
 The number of days log events are kept in CloudWatch Logs.
 
-When updating this property, unsetting it doesn't remove the log retention policy. To remove the retention policy, set the value to \`INFINITE\`.
+When updating
+this property, unsetting it doesn't remove the log retention policy. To
+remove the retention policy, set the value to \`INFINITE\`.
 
 ---
 
@@ -980,7 +1019,9 @@ public double MemorySize { get; set; }
 
 The amount of memory, in MB, that is allocated to your Lambda function.
 
-Lambda uses this value to proportionally allocate the amount of CPU power. For more information, see Resource Model in the AWS Lambda Developer Guide.
+Lambda uses this value to proportionally allocate the amount of CPU
+power. For more information, see Resource Model in the AWS Lambda
+Developer Guide.
 
 ---
 
@@ -1040,7 +1081,15 @@ public IRole Role { get; set; }
 
 Lambda execution role.
 
-This is the role that will be assumed by the function upon execution. It controls the permissions that the function will have. The Role must be assumable by the 'lambda.amazonaws.com' service principal.  The default Role automatically has permissions granted for Lambda execution. If you provide a Role, you must add the relevant AWS managed policies yourself.  The relevant managed policies are \\"service-role/AWSLambdaBasicExecutionRole\\" and \\"service-role/AWSLambdaVPCAccessExecutionRole\\".
+This is the role that will be assumed by the function upon execution.
+It controls the permissions that the function will have. The Role must
+be assumable by the 'lambda.amazonaws.com' service principal.
+
+The default Role automatically has permissions granted for Lambda execution. If you
+provide a Role, you must add the relevant AWS managed policies yourself.
+
+The relevant managed policies are \\"service-role/AWSLambdaBasicExecutionRole\\" and
+\\"service-role/AWSLambdaVPCAccessExecutionRole\\".
 
 ---
 
@@ -1057,7 +1106,10 @@ public ISecurityGroup SecurityGroup { get; set; }
 
 What security group to associate with the Lambda's network interfaces. This property is being deprecated, consider using securityGroups instead.
 
-Only used if 'vpc' is supplied.  Use securityGroups property instead. Function constructor will throw an error if both are specified.
+Only used if 'vpc' is supplied.
+
+Use securityGroups property instead.
+Function constructor will throw an error if both are specified.
 
 ---
 
@@ -1087,7 +1139,8 @@ public Duration Timeout { get; set; }
 
 The function execution time (in seconds) after which Lambda terminates the function.
 
-Because the execution time affects cost, set this value based on the function's expected execution time.
+Because the execution time affects cost, set this value
+based on the function's expected execution time.
 
 ---
 
@@ -1130,7 +1183,8 @@ public SubnetSelection VpcSubnets { get; set; }
 
 Where to place the network interfaces within the VPC.
 
-Only used if 'vpc' is supplied. Note: internet access for Lambdas requires a NAT gateway, so picking Public subnets is not allowed.
+Only used if 'vpc' is supplied. Note: internet access for Lambdas
+requires a NAT gateway, so picking Public subnets is not allowed.
 
 ---
 
@@ -1144,7 +1198,9 @@ public Code Code { get; set; }
 
 The source code of your Lambda function.
 
-You can point to a file in an Amazon Simple Storage Service (Amazon S3) bucket or specify your source code as inline text.
+You can point to a file in an
+Amazon Simple Storage Service (Amazon S3) bucket or specify your source
+code as inline text.
 
 ---
 
@@ -1158,7 +1214,15 @@ public string Handler { get; set; }
 
 The name of the method within your code that Lambda calls to execute your function.
 
-The format includes the file name. It can also include namespaces and other qualifiers, depending on the runtime. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.  Use \`Handler.FROM_IMAGE\` when defining a function from a Docker image.  NOTE: If you specify your source code as inline text by specifying the ZipFile property within the Code property, specify index.function_name as the handler.
+The format includes the file name. It can also include
+namespaces and other qualifiers, depending on the runtime.
+For more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.
+
+Use \`Handler.FROM_IMAGE\` when defining a function from a Docker image.
+
+NOTE: If you specify your source code as inline text by specifying the
+ZipFile property within the Code property, specify index.function_name as
+the handler.
 
 ---
 
@@ -1172,7 +1236,10 @@ public Runtime Runtime { get; set; }
 
 The runtime environment for the Lambda function that you are uploading.
 
-For valid values, see the Runtime property in the AWS Lambda Developer Guide.  Use \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.
+For valid values, see the Runtime property in the AWS Lambda Developer
+Guide.
+
+Use \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.
 
 ---
 
@@ -1205,7 +1272,11 @@ exports[`submodules without an explicit name java 1`] = `
 
 A Lambda@Edge function.
 
-Convenience resource for requesting a Lambda function in the 'us-east-1' region for use with Lambda@Edge. Implements several restrictions enforced by Lambda@Edge.  Note that this construct requires that the 'us-east-1' region has been bootstrapped. See https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html or 'cdk bootstrap --help' for options.
+Convenience resource for requesting a Lambda function in the 'us-east-1' region for use with Lambda@Edge.
+Implements several restrictions enforced by Lambda@Edge.
+
+Note that this construct requires that the 'us-east-1' region has been bootstrapped.
+See https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html or 'cdk bootstrap --help' for options.
 
 #### Initializers <a name=\\"Initializers\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.Initializer\\"></a>
 
@@ -1318,7 +1389,8 @@ EdgeFunction.Builder.create(Construct scope, java.lang.String id)
 
 The maximum age of a request that Lambda sends to a function for processing.
 
-Minimum: 60 seconds Maximum: 6 hours
+Minimum: 60 seconds
+Maximum: 6 hours
 
 ---
 
@@ -1347,7 +1419,8 @@ The destination for successful invocations.
 
 The maximum number of times to retry when the function returns an error.
 
-Minimum: 0 Maximum: 2
+Minimum: 0
+Maximum: 2
 
 ---
 
@@ -1358,7 +1431,8 @@ Minimum: 0 Maximum: 2
 
 Whether to allow the Lambda to send all network traffic.
 
-If set to false, you must individually add traffic rules to allow the Lambda to connect to network targets.
+If set to false, you must individually add traffic rules to allow the
+Lambda to connect to network targets.
 
 ---
 
@@ -1418,7 +1492,8 @@ The SQS queue to use if DLQ is enabled.
 
 Enabled DLQ.
 
-If \`deadLetterQueue\` is undefined, an SQS queue with default options will be defined for your Function.
+If \`deadLetterQueue\` is undefined,
+an SQS queue with default options will be defined for your Function.
 
 ---
 
@@ -1438,7 +1513,9 @@ A description of the function.
 
 Key-value pairs that Lambda caches and makes available for your Lambda functions.
 
-Use environment variables to apply configuration changes, such as test and production environment configurations, without changing your Lambda function source code.
+Use environment variables to apply configuration changes, such
+as test and production environment configurations, without changing your
+Lambda function source code.
 
 ---
 
@@ -1509,7 +1586,9 @@ Specify the version of CloudWatch Lambda insights to use for monitoring.
 
 A list of layers to add to the function's execution environment.
 
-You can configure your Lambda function to pull in additional code during initialization in the form of layers. Layers are packages of libraries or other dependencies that can be used by multiple functions.
+You can configure your Lambda function to pull in
+additional code during initialization in the form of layers. Layers are packages of libraries or other dependencies
+that can be used by multiple functions.
 
 ---
 
@@ -1520,7 +1599,9 @@ You can configure your Lambda function to pull in additional code during initial
 
 The number of days log events are kept in CloudWatch Logs.
 
-When updating this property, unsetting it doesn't remove the log retention policy. To remove the retention policy, set the value to \`INFINITE\`.
+When updating
+this property, unsetting it doesn't remove the log retention policy. To
+remove the retention policy, set the value to \`INFINITE\`.
 
 ---
 
@@ -1551,7 +1632,9 @@ The IAM role for the Lambda function associated with the custom resource that se
 
 The amount of memory, in MB, that is allocated to your Lambda function.
 
-Lambda uses this value to proportionally allocate the amount of CPU power. For more information, see Resource Model in the AWS Lambda Developer Guide.
+Lambda uses this value to proportionally allocate the amount of CPU
+power. For more information, see Resource Model in the AWS Lambda
+Developer Guide.
 
 ---
 
@@ -1595,7 +1678,15 @@ The maximum of concurrent executions you want to reserve for the function.
 
 Lambda execution role.
 
-This is the role that will be assumed by the function upon execution. It controls the permissions that the function will have. The Role must be assumable by the 'lambda.amazonaws.com' service principal.  The default Role automatically has permissions granted for Lambda execution. If you provide a Role, you must add the relevant AWS managed policies yourself.  The relevant managed policies are \\"service-role/AWSLambdaBasicExecutionRole\\" and \\"service-role/AWSLambdaVPCAccessExecutionRole\\".
+This is the role that will be assumed by the function upon execution.
+It controls the permissions that the function will have. The Role must
+be assumable by the 'lambda.amazonaws.com' service principal.
+
+The default Role automatically has permissions granted for Lambda execution. If you
+provide a Role, you must add the relevant AWS managed policies yourself.
+
+The relevant managed policies are \\"service-role/AWSLambdaBasicExecutionRole\\" and
+\\"service-role/AWSLambdaVPCAccessExecutionRole\\".
 
 ---
 
@@ -1608,7 +1699,10 @@ This is the role that will be assumed by the function upon execution. It control
 
 What security group to associate with the Lambda's network interfaces. This property is being deprecated, consider using securityGroups instead.
 
-Only used if 'vpc' is supplied.  Use securityGroups property instead. Function constructor will throw an error if both are specified.
+Only used if 'vpc' is supplied.
+
+Use securityGroups property instead.
+Function constructor will throw an error if both are specified.
 
 ---
 
@@ -1630,7 +1724,8 @@ Only used if 'vpc' is supplied.
 
 The function execution time (in seconds) after which Lambda terminates the function.
 
-Because the execution time affects cost, set this value based on the function's expected execution time.
+Because the execution time affects cost, set this value
+based on the function's expected execution time.
 
 ---
 
@@ -1661,7 +1756,8 @@ Specify this if the Lambda function needs to access resources in a VPC.
 
 Where to place the network interfaces within the VPC.
 
-Only used if 'vpc' is supplied. Note: internet access for Lambdas requires a NAT gateway, so picking Public subnets is not allowed.
+Only used if 'vpc' is supplied. Note: internet access for Lambdas
+requires a NAT gateway, so picking Public subnets is not allowed.
 
 ---
 
@@ -1671,7 +1767,9 @@ Only used if 'vpc' is supplied. Note: internet access for Lambdas requires a NAT
 
 The source code of your Lambda function.
 
-You can point to a file in an Amazon Simple Storage Service (Amazon S3) bucket or specify your source code as inline text.
+You can point to a file in an
+Amazon Simple Storage Service (Amazon S3) bucket or specify your source
+code as inline text.
 
 ---
 
@@ -1681,7 +1779,15 @@ You can point to a file in an Amazon Simple Storage Service (Amazon S3) bucket o
 
 The name of the method within your code that Lambda calls to execute your function.
 
-The format includes the file name. It can also include namespaces and other qualifiers, depending on the runtime. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.  Use \`Handler.FROM_IMAGE\` when defining a function from a Docker image.  NOTE: If you specify your source code as inline text by specifying the ZipFile property within the Code property, specify index.function_name as the handler.
+The format includes the file name. It can also include
+namespaces and other qualifiers, depending on the runtime.
+For more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.
+
+Use \`Handler.FROM_IMAGE\` when defining a function from a Docker image.
+
+NOTE: If you specify your source code as inline text by specifying the
+ZipFile property within the Code property, specify index.function_name as
+the handler.
 
 ---
 
@@ -1691,7 +1797,10 @@ The format includes the file name. It can also include namespaces and other qual
 
 The runtime environment for the Lambda function that you are uploading.
 
-For valid values, see the Runtime property in the AWS Lambda Developer Guide.  Use \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.
+For valid values, see the Runtime property in the AWS Lambda Developer
+Guide.
+
+Use \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.
 
 ---
 
@@ -1741,7 +1850,13 @@ public void applyRemovalPolicy(RemovalPolicy policy)
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -1898,7 +2013,10 @@ public Metric metricDuration(MetricOptions props)
 
 Metric for the Duration of this Lambda How long execution of this Lambda takes.
 
-Average over 5 minutes Metric for the Duration of this Lambda How long execution of this Lambda takes.  Average over 5 minutes
+Average over 5 minutes
+Metric for the Duration of this Lambda How long execution of this Lambda takes.
+
+Average over 5 minutes
 
 ###### \`props\`<sup>Optional</sup> <a name=\\"props\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.metricDuration.parameter.props\\"></a>
 
@@ -1932,7 +2050,10 @@ public Metric metricInvocations(MetricOptions props)
 
 Metric for the number of invocations of this Lambda How often this Lambda is invoked.
 
-Sum over 5 minutes Metric for the number of invocations of this Lambda How often this Lambda is invoked.  Sum over 5 minutes
+Sum over 5 minutes
+Metric for the number of invocations of this Lambda How often this Lambda is invoked.
+
+Sum over 5 minutes
 
 ###### \`props\`<sup>Optional</sup> <a name=\\"props\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.metricInvocations.parameter.props\\"></a>
 
@@ -1949,7 +2070,10 @@ public Metric metricThrottles(MetricOptions props)
 
 Metric for the number of throttled invocations of this Lambda How often this Lambda is throttled.
 
-Sum over 5 minutes Metric for the number of throttled invocations of this Lambda How often this Lambda is throttled.  Sum over 5 minutes
+Sum over 5 minutes
+Metric for the number of throttled invocations of this Lambda How often this Lambda is throttled.
+
+Sum over 5 minutes
 
 ###### \`props\`<sup>Optional</sup> <a name=\\"props\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.metricThrottles.parameter.props\\"></a>
 
@@ -2042,7 +2166,12 @@ public ResourceEnvironment getEnv();
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -2168,7 +2297,12 @@ public IVersion getLatestVersion();
 
 The \`$LATEST\` version of this function.
 
-Note that this is reference to a non-specific AWS Lambda version, which means the function this version refers to can return different results in different invocations.  To obtain a reference to an explicit version which references the current function configuration, use \`lambdaFunction.currentVersion\` instead.
+Note that this is reference to a non-specific AWS Lambda version, which
+means the function this version refers to can return different results in
+different invocations.
+
+To obtain a reference to an explicit version which references the current
+function configuration, use \`lambdaFunction.currentVersion\` instead.
 
 ---
 
@@ -2318,7 +2452,8 @@ public Duration getMaxEventAge();
 
 The maximum age of a request that Lambda sends to a function for processing.
 
-Minimum: 60 seconds Maximum: 6 hours
+Minimum: 60 seconds
+Maximum: 6 hours
 
 ---
 
@@ -2359,7 +2494,8 @@ public java.lang.Number getRetryAttempts();
 
 The maximum number of times to retry when the function returns an error.
 
-Minimum: 0 Maximum: 2
+Minimum: 0
+Maximum: 2
 
 ---
 
@@ -2374,7 +2510,8 @@ public java.lang.Boolean getAllowAllOutbound();
 
 Whether to allow the Lambda to send all network traffic.
 
-If set to false, you must individually add traffic rules to allow the Lambda to connect to network targets.
+If set to false, you must individually add traffic rules to allow the
+Lambda to connect to network targets.
 
 ---
 
@@ -2458,7 +2595,8 @@ public java.lang.Boolean getDeadLetterQueueEnabled();
 
 Enabled DLQ.
 
-If \`deadLetterQueue\` is undefined, an SQS queue with default options will be defined for your Function.
+If \`deadLetterQueue\` is undefined,
+an SQS queue with default options will be defined for your Function.
 
 ---
 
@@ -2486,7 +2624,9 @@ public java.util.Map<java.lang.String, java.lang.String> getEnvironment();
 
 Key-value pairs that Lambda caches and makes available for your Lambda functions.
 
-Use environment variables to apply configuration changes, such as test and production environment configurations, without changing your Lambda function source code.
+Use environment variables to apply configuration changes, such
+as test and production environment configurations, without changing your
+Lambda function source code.
 
 ---
 
@@ -2585,7 +2725,9 @@ public java.util.List<ILayerVersion> getLayers();
 
 A list of layers to add to the function's execution environment.
 
-You can configure your Lambda function to pull in additional code during initialization in the form of layers. Layers are packages of libraries or other dependencies that can be used by multiple functions.
+You can configure your Lambda function to pull in
+additional code during initialization in the form of layers. Layers are packages of libraries or other dependencies
+that can be used by multiple functions.
 
 ---
 
@@ -2600,7 +2742,9 @@ public RetentionDays getLogRetention();
 
 The number of days log events are kept in CloudWatch Logs.
 
-When updating this property, unsetting it doesn't remove the log retention policy. To remove the retention policy, set the value to \`INFINITE\`.
+When updating
+this property, unsetting it doesn't remove the log retention policy. To
+remove the retention policy, set the value to \`INFINITE\`.
 
 ---
 
@@ -2643,7 +2787,9 @@ public java.lang.Number getMemorySize();
 
 The amount of memory, in MB, that is allocated to your Lambda function.
 
-Lambda uses this value to proportionally allocate the amount of CPU power. For more information, see Resource Model in the AWS Lambda Developer Guide.
+Lambda uses this value to proportionally allocate the amount of CPU
+power. For more information, see Resource Model in the AWS Lambda
+Developer Guide.
 
 ---
 
@@ -2703,7 +2849,15 @@ public IRole getRole();
 
 Lambda execution role.
 
-This is the role that will be assumed by the function upon execution. It controls the permissions that the function will have. The Role must be assumable by the 'lambda.amazonaws.com' service principal.  The default Role automatically has permissions granted for Lambda execution. If you provide a Role, you must add the relevant AWS managed policies yourself.  The relevant managed policies are \\"service-role/AWSLambdaBasicExecutionRole\\" and \\"service-role/AWSLambdaVPCAccessExecutionRole\\".
+This is the role that will be assumed by the function upon execution.
+It controls the permissions that the function will have. The Role must
+be assumable by the 'lambda.amazonaws.com' service principal.
+
+The default Role automatically has permissions granted for Lambda execution. If you
+provide a Role, you must add the relevant AWS managed policies yourself.
+
+The relevant managed policies are \\"service-role/AWSLambdaBasicExecutionRole\\" and
+\\"service-role/AWSLambdaVPCAccessExecutionRole\\".
 
 ---
 
@@ -2720,7 +2874,10 @@ public ISecurityGroup getSecurityGroup();
 
 What security group to associate with the Lambda's network interfaces. This property is being deprecated, consider using securityGroups instead.
 
-Only used if 'vpc' is supplied.  Use securityGroups property instead. Function constructor will throw an error if both are specified.
+Only used if 'vpc' is supplied.
+
+Use securityGroups property instead.
+Function constructor will throw an error if both are specified.
 
 ---
 
@@ -2750,7 +2907,8 @@ public Duration getTimeout();
 
 The function execution time (in seconds) after which Lambda terminates the function.
 
-Because the execution time affects cost, set this value based on the function's expected execution time.
+Because the execution time affects cost, set this value
+based on the function's expected execution time.
 
 ---
 
@@ -2793,7 +2951,8 @@ public SubnetSelection getVpcSubnets();
 
 Where to place the network interfaces within the VPC.
 
-Only used if 'vpc' is supplied. Note: internet access for Lambdas requires a NAT gateway, so picking Public subnets is not allowed.
+Only used if 'vpc' is supplied. Note: internet access for Lambdas
+requires a NAT gateway, so picking Public subnets is not allowed.
 
 ---
 
@@ -2807,7 +2966,9 @@ public Code getCode();
 
 The source code of your Lambda function.
 
-You can point to a file in an Amazon Simple Storage Service (Amazon S3) bucket or specify your source code as inline text.
+You can point to a file in an
+Amazon Simple Storage Service (Amazon S3) bucket or specify your source
+code as inline text.
 
 ---
 
@@ -2821,7 +2982,15 @@ public java.lang.String getHandler();
 
 The name of the method within your code that Lambda calls to execute your function.
 
-The format includes the file name. It can also include namespaces and other qualifiers, depending on the runtime. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.  Use \`Handler.FROM_IMAGE\` when defining a function from a Docker image.  NOTE: If you specify your source code as inline text by specifying the ZipFile property within the Code property, specify index.function_name as the handler.
+The format includes the file name. It can also include
+namespaces and other qualifiers, depending on the runtime.
+For more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.
+
+Use \`Handler.FROM_IMAGE\` when defining a function from a Docker image.
+
+NOTE: If you specify your source code as inline text by specifying the
+ZipFile property within the Code property, specify index.function_name as
+the handler.
 
 ---
 
@@ -2835,7 +3004,10 @@ public Runtime getRuntime();
 
 The runtime environment for the Lambda function that you are uploading.
 
-For valid values, see the Runtime property in the AWS Lambda Developer Guide.  Use \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.
+For valid values, see the Runtime property in the AWS Lambda Developer
+Guide.
+
+Use \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.
 
 ---
 
@@ -2868,7 +3040,11 @@ exports[`submodules without an explicit name python 1`] = `
 
 A Lambda@Edge function.
 
-Convenience resource for requesting a Lambda function in the 'us-east-1' region for use with Lambda@Edge. Implements several restrictions enforced by Lambda@Edge.  Note that this construct requires that the 'us-east-1' region has been bootstrapped. See https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html or 'cdk bootstrap --help' for options.
+Convenience resource for requesting a Lambda function in the 'us-east-1' region for use with Lambda@Edge.
+Implements several restrictions enforced by Lambda@Edge.
+
+Note that this construct requires that the 'us-east-1' region has been bootstrapped.
+See https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html or 'cdk bootstrap --help' for options.
 
 #### Initializers <a name=\\"Initializers\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.Initializer\\"></a>
 
@@ -2983,7 +3159,8 @@ experimental.EdgeFunction(
 
 The maximum age of a request that Lambda sends to a function for processing.
 
-Minimum: 60 seconds Maximum: 6 hours
+Minimum: 60 seconds
+Maximum: 6 hours
 
 ---
 
@@ -3012,7 +3189,8 @@ The destination for successful invocations.
 
 The maximum number of times to retry when the function returns an error.
 
-Minimum: 0 Maximum: 2
+Minimum: 0
+Maximum: 2
 
 ---
 
@@ -3023,7 +3201,8 @@ Minimum: 0 Maximum: 2
 
 Whether to allow the Lambda to send all network traffic.
 
-If set to false, you must individually add traffic rules to allow the Lambda to connect to network targets.
+If set to false, you must individually add traffic rules to allow the
+Lambda to connect to network targets.
 
 ---
 
@@ -3083,7 +3262,8 @@ The SQS queue to use if DLQ is enabled.
 
 Enabled DLQ.
 
-If \`deadLetterQueue\` is undefined, an SQS queue with default options will be defined for your Function.
+If \`deadLetterQueue\` is undefined,
+an SQS queue with default options will be defined for your Function.
 
 ---
 
@@ -3103,7 +3283,9 @@ A description of the function.
 
 Key-value pairs that Lambda caches and makes available for your Lambda functions.
 
-Use environment variables to apply configuration changes, such as test and production environment configurations, without changing your Lambda function source code.
+Use environment variables to apply configuration changes, such
+as test and production environment configurations, without changing your
+Lambda function source code.
 
 ---
 
@@ -3174,7 +3356,9 @@ Specify the version of CloudWatch Lambda insights to use for monitoring.
 
 A list of layers to add to the function's execution environment.
 
-You can configure your Lambda function to pull in additional code during initialization in the form of layers. Layers are packages of libraries or other dependencies that can be used by multiple functions.
+You can configure your Lambda function to pull in
+additional code during initialization in the form of layers. Layers are packages of libraries or other dependencies
+that can be used by multiple functions.
 
 ---
 
@@ -3185,7 +3369,9 @@ You can configure your Lambda function to pull in additional code during initial
 
 The number of days log events are kept in CloudWatch Logs.
 
-When updating this property, unsetting it doesn't remove the log retention policy. To remove the retention policy, set the value to \`INFINITE\`.
+When updating
+this property, unsetting it doesn't remove the log retention policy. To
+remove the retention policy, set the value to \`INFINITE\`.
 
 ---
 
@@ -3216,7 +3402,9 @@ The IAM role for the Lambda function associated with the custom resource that se
 
 The amount of memory, in MB, that is allocated to your Lambda function.
 
-Lambda uses this value to proportionally allocate the amount of CPU power. For more information, see Resource Model in the AWS Lambda Developer Guide.
+Lambda uses this value to proportionally allocate the amount of CPU
+power. For more information, see Resource Model in the AWS Lambda
+Developer Guide.
 
 ---
 
@@ -3260,7 +3448,15 @@ The maximum of concurrent executions you want to reserve for the function.
 
 Lambda execution role.
 
-This is the role that will be assumed by the function upon execution. It controls the permissions that the function will have. The Role must be assumable by the 'lambda.amazonaws.com' service principal.  The default Role automatically has permissions granted for Lambda execution. If you provide a Role, you must add the relevant AWS managed policies yourself.  The relevant managed policies are \\"service-role/AWSLambdaBasicExecutionRole\\" and \\"service-role/AWSLambdaVPCAccessExecutionRole\\".
+This is the role that will be assumed by the function upon execution.
+It controls the permissions that the function will have. The Role must
+be assumable by the 'lambda.amazonaws.com' service principal.
+
+The default Role automatically has permissions granted for Lambda execution. If you
+provide a Role, you must add the relevant AWS managed policies yourself.
+
+The relevant managed policies are \\"service-role/AWSLambdaBasicExecutionRole\\" and
+\\"service-role/AWSLambdaVPCAccessExecutionRole\\".
 
 ---
 
@@ -3273,7 +3469,10 @@ This is the role that will be assumed by the function upon execution. It control
 
 What security group to associate with the Lambda's network interfaces. This property is being deprecated, consider using securityGroups instead.
 
-Only used if 'vpc' is supplied.  Use securityGroups property instead. Function constructor will throw an error if both are specified.
+Only used if 'vpc' is supplied.
+
+Use securityGroups property instead.
+Function constructor will throw an error if both are specified.
 
 ---
 
@@ -3295,7 +3494,8 @@ Only used if 'vpc' is supplied.
 
 The function execution time (in seconds) after which Lambda terminates the function.
 
-Because the execution time affects cost, set this value based on the function's expected execution time.
+Because the execution time affects cost, set this value
+based on the function's expected execution time.
 
 ---
 
@@ -3326,7 +3526,8 @@ Specify this if the Lambda function needs to access resources in a VPC.
 
 Where to place the network interfaces within the VPC.
 
-Only used if 'vpc' is supplied. Note: internet access for Lambdas requires a NAT gateway, so picking Public subnets is not allowed.
+Only used if 'vpc' is supplied. Note: internet access for Lambdas
+requires a NAT gateway, so picking Public subnets is not allowed.
 
 ---
 
@@ -3336,7 +3537,9 @@ Only used if 'vpc' is supplied. Note: internet access for Lambdas requires a NAT
 
 The source code of your Lambda function.
 
-You can point to a file in an Amazon Simple Storage Service (Amazon S3) bucket or specify your source code as inline text.
+You can point to a file in an
+Amazon Simple Storage Service (Amazon S3) bucket or specify your source
+code as inline text.
 
 ---
 
@@ -3346,7 +3549,15 @@ You can point to a file in an Amazon Simple Storage Service (Amazon S3) bucket o
 
 The name of the method within your code that Lambda calls to execute your function.
 
-The format includes the file name. It can also include namespaces and other qualifiers, depending on the runtime. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.  Use \`Handler.FROM_IMAGE\` when defining a function from a Docker image.  NOTE: If you specify your source code as inline text by specifying the ZipFile property within the Code property, specify index.function_name as the handler.
+The format includes the file name. It can also include
+namespaces and other qualifiers, depending on the runtime.
+For more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.
+
+Use \`Handler.FROM_IMAGE\` when defining a function from a Docker image.
+
+NOTE: If you specify your source code as inline text by specifying the
+ZipFile property within the Code property, specify index.function_name as
+the handler.
 
 ---
 
@@ -3356,7 +3567,10 @@ The format includes the file name. It can also include namespaces and other qual
 
 The runtime environment for the Lambda function that you are uploading.
 
-For valid values, see the Runtime property in the AWS Lambda Developer Guide.  Use \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.
+For valid values, see the Runtime property in the AWS Lambda Developer
+Guide.
+
+Use \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.
 
 ---
 
@@ -3408,7 +3622,13 @@ def apply_removal_policy(
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -3446,7 +3666,8 @@ Defines an alias for this version.
 
 The maximum age of a request that Lambda sends to a function for processing.
 
-Minimum: 60 seconds Maximum: 6 hours
+Minimum: 60 seconds
+Maximum: 6 hours
 
 ---
 
@@ -3475,7 +3696,8 @@ The destination for successful invocations.
 
 The maximum number of times to retry when the function returns an error.
 
-Minimum: 0 Maximum: 2
+Minimum: 0
+Maximum: 2
 
 ---
 
@@ -3486,7 +3708,17 @@ Minimum: 0 Maximum: 2
 
 Additional versions with individual weights this alias points to.
 
-Individual additional version weights specified here should add up to (less than) one. All remaining weight is routed to the default version.  For example, the config is      version: \\"1\\"     additionalVersions: [{ version: \\"2\\", weight: 0.05 }]  Then 5% of traffic will be routed to function version 2, while the remaining 95% of traffic will be routed to function version 1.
+Individual additional version weights specified here should add up to
+(less than) one. All remaining weight is routed to the default
+version.
+
+For example, the config is
+
+    version: \\"1\\"
+    additionalVersions: [{ version: \\"2\\", weight: 0.05 }]
+
+Then 5% of traffic will be routed to function version 2, while
+the remaining 95% of traffic will be routed to function version 1.
 
 ---
 
@@ -3562,7 +3794,10 @@ Adds an event source that maps to this AWS Lambda function.
 
 The largest number of records that AWS Lambda will retrieve from your event source at the time of invoking your function.
 
-Your function receives an event with all the retrieved records.  Valid Range: Minimum value of 1. Maximum value of 10000.
+Your function receives an
+event with all the retrieved records.
+
+Valid Range: Minimum value of 1. Maximum value of 10000.
 
 ---
 
@@ -3591,7 +3826,8 @@ Set to false to disable the event source upon creation.
 
 The Amazon Resource Name (ARN) of the event source.
 
-Any record added to this stream can invoke the Lambda function.
+Any record added to
+this stream can invoke the Lambda function.
 
 ---
 
@@ -3633,7 +3869,9 @@ Maximum of Duration.minutes(5)
 
 The maximum age of a record that Lambda sends to a function for processing.
 
-Valid Range: * Minimum value of 60 seconds * Maximum value of 7 days
+Valid Range:
+* Minimum value of 60 seconds
+* Maximum value of 7 days
 
 ---
 
@@ -3653,7 +3891,9 @@ An Amazon SQS queue or Amazon SNS topic destination for discarded records.
 
 The number of batches to process from each shard concurrently.
 
-Valid Range: * Minimum value of 1 * Maximum value of 10
+Valid Range:
+* Minimum value of 1
+* Maximum value of 10
 
 ---
 
@@ -3675,7 +3915,12 @@ Allow functions to return partially successful responses for a batch of records.
 
 The maximum number of times to retry when the function returns an error.
 
-Set to \`undefined\` if you want lambda to keep retrying infinitely or until the record expires.  Valid Range: * Minimum value of 0 * Maximum value of 10000
+Set to \`undefined\` if you want lambda to keep retrying infinitely or until
+the record expires.
+
+Valid Range:
+* Minimum value of 0
+* Maximum value of 10000
 
 ---
 
@@ -3744,7 +3989,13 @@ Adds a permission to the Lambda resource policy.
 
 The entity for which you are granting permission to invoke the Lambda function.
 
-This entity can be any valid AWS service principal, such as s3.amazonaws.com or sns.amazonaws.com, or, if you are granting cross-account permission, an AWS account ID. For example, you might want to allow a custom application in another AWS account to push events to Lambda by invoking your function.  The principal can be either an AccountPrincipal or a ServicePrincipal.
+This entity can be any valid AWS service principal, such as
+s3.amazonaws.com or sns.amazonaws.com, or, if you are granting
+cross-account permission, an AWS account ID. For example, you might want
+to allow a custom application in another AWS account to push events to
+Lambda by invoking your function.
+
+The principal can be either an AccountPrincipal or a ServicePrincipal.
 
 ---
 
@@ -3755,7 +4006,11 @@ This entity can be any valid AWS service principal, such as s3.amazonaws.com or 
 
 The Lambda actions that you want to allow in this statement.
 
-For example, you can specify lambda:CreateFunction to specify a certain action, or use a wildcard (\`\`lambda:*\`\`) to grant permission to all Lambda actions. For a list of actions, see Actions and Condition Context Keys for AWS Lambda in the IAM User Guide.
+For example,
+you can specify lambda:CreateFunction to specify a certain action, or use
+a wildcard (\`\`lambda:*\`\`) to grant permission to all Lambda actions. For a
+list of actions, see Actions and Condition Context Keys for AWS Lambda in
+the IAM User Guide.
 
 ---
 
@@ -3775,7 +4030,10 @@ A unique token that must be supplied by the principal invoking the function.
 
 The scope to which the permission constructs be attached.
 
-The default is the Lambda function construct itself, but this would need to be different in cases such as cross-stack references where the Permissions would need to sit closer to the consumer of this permission (i.e., the caller).
+The default is
+the Lambda function construct itself, but this would need to be different
+in cases such as cross-stack references where the Permissions would need
+to sit closer to the consumer of this permission (i.e., the caller).
 
 ---
 
@@ -3785,7 +4043,10 @@ The default is the Lambda function construct itself, but this would need to be d
 
 The AWS account ID (without hyphens) of the source owner.
 
-For example, if you specify an S3 bucket in the SourceArn property, this value is the bucket owner's account ID. You can use this property to ensure that all source principals are owned by a specific account.
+For example, if
+you specify an S3 bucket in the SourceArn property, this value is the
+bucket owner's account ID. You can use this property to ensure that all
+source principals are owned by a specific account.
 
 ---
 
@@ -3795,7 +4056,12 @@ For example, if you specify an S3 bucket in the SourceArn property, this value i
 
 The ARN of a resource that is invoking your function.
 
-When granting Amazon Simple Storage Service (Amazon S3) permission to invoke your function, specify this property with the bucket ARN as its value. This ensures that events generated only from the specified bucket, not just any bucket from any AWS account that creates a mapping to your function, can invoke the function.
+When granting
+Amazon Simple Storage Service (Amazon S3) permission to invoke your
+function, specify this property with the bucket ARN as its value. This
+ensures that events generated only from the specified bucket, not just
+any bucket from any AWS account that creates a mapping to your function,
+can invoke the function.
 
 ---
 
@@ -3835,7 +4101,8 @@ Configures options for asynchronous invocation.
 
 The maximum age of a request that Lambda sends to a function for processing.
 
-Minimum: 60 seconds Maximum: 6 hours
+Minimum: 60 seconds
+Maximum: 6 hours
 
 ---
 
@@ -3864,7 +4131,8 @@ The destination for successful invocations.
 
 The maximum number of times to retry when the function returns an error.
 
-Minimum: 0 Maximum: 2
+Minimum: 0
+Maximum: 2
 
 ---
 
@@ -3983,7 +4251,14 @@ Region which this metric comes from.
 
 What function to use for aggregating.
 
-Can be one of the following:  - \\"Minimum\\" | \\"min\\" - \\"Maximum\\" | \\"max\\" - \\"Average\\" | \\"avg\\" - \\"Sum\\" | \\"sum\\" - \\"SampleCount | \\"n\\" - \\"pNN.NN\\"
+Can be one of the following:
+
+- \\"Minimum\\" | \\"min\\"
+- \\"Maximum\\" | \\"max\\"
+- \\"Average\\" | \\"avg\\"
+- \\"Sum\\" | \\"sum\\"
+- \\"SampleCount | \\"n\\"
+- \\"pNN.NN\\"
 
 ---
 
@@ -3994,7 +4269,14 @@ Can be one of the following:  - \\"Minimum\\" | \\"min\\" - \\"Maximum\\" | \\"m
 
 Unit used to filter the metric stream.
 
-Only refer to datums emitted to the metric stream with the given unit and ignore all others. Only useful when datums are being emitted to the same metric stream under different units.  The default is to use all matric datums in the stream, regardless of unit, which is recommended in nearly all cases.  CloudWatch does not honor this property for graphs.
+Only refer to datums emitted to the metric stream with the given unit and
+ignore all others. Only useful when datums are being emitted to the same
+metric stream under different units.
+
+The default is to use all matric datums in the stream, regardless of unit,
+which is recommended in nearly all cases.
+
+CloudWatch does not honor this property for graphs.
 
 ---
 
@@ -4016,7 +4298,10 @@ def metric_duration(
 
 Metric for the Duration of this Lambda How long execution of this Lambda takes.
 
-Average over 5 minutes Metric for the Duration of this Lambda How long execution of this Lambda takes.  Average over 5 minutes
+Average over 5 minutes
+Metric for the Duration of this Lambda How long execution of this Lambda takes.
+
+Average over 5 minutes
 
 ###### \`account\`<sup>Optional</sup> <a name=\\"account\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.metricDuration.parameter.account\\"></a>
 
@@ -4090,7 +4375,14 @@ Region which this metric comes from.
 
 What function to use for aggregating.
 
-Can be one of the following:  - \\"Minimum\\" | \\"min\\" - \\"Maximum\\" | \\"max\\" - \\"Average\\" | \\"avg\\" - \\"Sum\\" | \\"sum\\" - \\"SampleCount | \\"n\\" - \\"pNN.NN\\"
+Can be one of the following:
+
+- \\"Minimum\\" | \\"min\\"
+- \\"Maximum\\" | \\"max\\"
+- \\"Average\\" | \\"avg\\"
+- \\"Sum\\" | \\"sum\\"
+- \\"SampleCount | \\"n\\"
+- \\"pNN.NN\\"
 
 ---
 
@@ -4101,7 +4393,14 @@ Can be one of the following:  - \\"Minimum\\" | \\"min\\" - \\"Maximum\\" | \\"m
 
 Unit used to filter the metric stream.
 
-Only refer to datums emitted to the metric stream with the given unit and ignore all others. Only useful when datums are being emitted to the same metric stream under different units.  The default is to use all matric datums in the stream, regardless of unit, which is recommended in nearly all cases.  CloudWatch does not honor this property for graphs.
+Only refer to datums emitted to the metric stream with the given unit and
+ignore all others. Only useful when datums are being emitted to the same
+metric stream under different units.
+
+The default is to use all matric datums in the stream, regardless of unit,
+which is recommended in nearly all cases.
+
+CloudWatch does not honor this property for graphs.
 
 ---
 
@@ -4197,7 +4496,14 @@ Region which this metric comes from.
 
 What function to use for aggregating.
 
-Can be one of the following:  - \\"Minimum\\" | \\"min\\" - \\"Maximum\\" | \\"max\\" - \\"Average\\" | \\"avg\\" - \\"Sum\\" | \\"sum\\" - \\"SampleCount | \\"n\\" - \\"pNN.NN\\"
+Can be one of the following:
+
+- \\"Minimum\\" | \\"min\\"
+- \\"Maximum\\" | \\"max\\"
+- \\"Average\\" | \\"avg\\"
+- \\"Sum\\" | \\"sum\\"
+- \\"SampleCount | \\"n\\"
+- \\"pNN.NN\\"
 
 ---
 
@@ -4208,7 +4514,14 @@ Can be one of the following:  - \\"Minimum\\" | \\"min\\" - \\"Maximum\\" | \\"m
 
 Unit used to filter the metric stream.
 
-Only refer to datums emitted to the metric stream with the given unit and ignore all others. Only useful when datums are being emitted to the same metric stream under different units.  The default is to use all matric datums in the stream, regardless of unit, which is recommended in nearly all cases.  CloudWatch does not honor this property for graphs.
+Only refer to datums emitted to the metric stream with the given unit and
+ignore all others. Only useful when datums are being emitted to the same
+metric stream under different units.
+
+The default is to use all matric datums in the stream, regardless of unit,
+which is recommended in nearly all cases.
+
+CloudWatch does not honor this property for graphs.
 
 ---
 
@@ -4230,7 +4543,10 @@ def metric_invocations(
 
 Metric for the number of invocations of this Lambda How often this Lambda is invoked.
 
-Sum over 5 minutes Metric for the number of invocations of this Lambda How often this Lambda is invoked.  Sum over 5 minutes
+Sum over 5 minutes
+Metric for the number of invocations of this Lambda How often this Lambda is invoked.
+
+Sum over 5 minutes
 
 ###### \`account\`<sup>Optional</sup> <a name=\\"account\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.metricInvocations.parameter.account\\"></a>
 
@@ -4304,7 +4620,14 @@ Region which this metric comes from.
 
 What function to use for aggregating.
 
-Can be one of the following:  - \\"Minimum\\" | \\"min\\" - \\"Maximum\\" | \\"max\\" - \\"Average\\" | \\"avg\\" - \\"Sum\\" | \\"sum\\" - \\"SampleCount | \\"n\\" - \\"pNN.NN\\"
+Can be one of the following:
+
+- \\"Minimum\\" | \\"min\\"
+- \\"Maximum\\" | \\"max\\"
+- \\"Average\\" | \\"avg\\"
+- \\"Sum\\" | \\"sum\\"
+- \\"SampleCount | \\"n\\"
+- \\"pNN.NN\\"
 
 ---
 
@@ -4315,7 +4638,14 @@ Can be one of the following:  - \\"Minimum\\" | \\"min\\" - \\"Maximum\\" | \\"m
 
 Unit used to filter the metric stream.
 
-Only refer to datums emitted to the metric stream with the given unit and ignore all others. Only useful when datums are being emitted to the same metric stream under different units.  The default is to use all matric datums in the stream, regardless of unit, which is recommended in nearly all cases.  CloudWatch does not honor this property for graphs.
+Only refer to datums emitted to the metric stream with the given unit and
+ignore all others. Only useful when datums are being emitted to the same
+metric stream under different units.
+
+The default is to use all matric datums in the stream, regardless of unit,
+which is recommended in nearly all cases.
+
+CloudWatch does not honor this property for graphs.
 
 ---
 
@@ -4337,7 +4667,10 @@ def metric_throttles(
 
 Metric for the number of throttled invocations of this Lambda How often this Lambda is throttled.
 
-Sum over 5 minutes Metric for the number of throttled invocations of this Lambda How often this Lambda is throttled.  Sum over 5 minutes
+Sum over 5 minutes
+Metric for the number of throttled invocations of this Lambda How often this Lambda is throttled.
+
+Sum over 5 minutes
 
 ###### \`account\`<sup>Optional</sup> <a name=\\"account\\" id=\\"@aws-cdk/aws-cloudfront.experimental.EdgeFunction.metricThrottles.parameter.account\\"></a>
 
@@ -4411,7 +4744,14 @@ Region which this metric comes from.
 
 What function to use for aggregating.
 
-Can be one of the following:  - \\"Minimum\\" | \\"min\\" - \\"Maximum\\" | \\"max\\" - \\"Average\\" | \\"avg\\" - \\"Sum\\" | \\"sum\\" - \\"SampleCount | \\"n\\" - \\"pNN.NN\\"
+Can be one of the following:
+
+- \\"Minimum\\" | \\"min\\"
+- \\"Maximum\\" | \\"max\\"
+- \\"Average\\" | \\"avg\\"
+- \\"Sum\\" | \\"sum\\"
+- \\"SampleCount | \\"n\\"
+- \\"pNN.NN\\"
 
 ---
 
@@ -4422,7 +4762,14 @@ Can be one of the following:  - \\"Minimum\\" | \\"min\\" - \\"Maximum\\" | \\"m
 
 Unit used to filter the metric stream.
 
-Only refer to datums emitted to the metric stream with the given unit and ignore all others. Only useful when datums are being emitted to the same metric stream under different units.  The default is to use all matric datums in the stream, regardless of unit, which is recommended in nearly all cases.  CloudWatch does not honor this property for graphs.
+Only refer to datums emitted to the metric stream with the given unit and
+ignore all others. Only useful when datums are being emitted to the same
+metric stream under different units.
+
+The default is to use all matric datums in the stream, regardless of unit,
+which is recommended in nearly all cases.
+
+CloudWatch does not honor this property for graphs.
 
 ---
 
@@ -4515,7 +4862,12 @@ env: ResourceEnvironment
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -4641,7 +4993,12 @@ latest_version: IVersion
 
 The \`$LATEST\` version of this function.
 
-Note that this is reference to a non-specific AWS Lambda version, which means the function this version refers to can return different results in different invocations.  To obtain a reference to an explicit version which references the current function configuration, use \`lambdaFunction.currentVersion\` instead.
+Note that this is reference to a non-specific AWS Lambda version, which
+means the function this version refers to can return different results in
+different invocations.
+
+To obtain a reference to an explicit version which references the current
+function configuration, use \`lambdaFunction.currentVersion\` instead.
 
 ---
 
@@ -4791,7 +5148,8 @@ max_event_age: Duration
 
 The maximum age of a request that Lambda sends to a function for processing.
 
-Minimum: 60 seconds Maximum: 6 hours
+Minimum: 60 seconds
+Maximum: 6 hours
 
 ---
 
@@ -4832,7 +5190,8 @@ retry_attempts: typing.Union[int, float]
 
 The maximum number of times to retry when the function returns an error.
 
-Minimum: 0 Maximum: 2
+Minimum: 0
+Maximum: 2
 
 ---
 
@@ -4847,7 +5206,8 @@ allow_all_outbound: bool
 
 Whether to allow the Lambda to send all network traffic.
 
-If set to false, you must individually add traffic rules to allow the Lambda to connect to network targets.
+If set to false, you must individually add traffic rules to allow the
+Lambda to connect to network targets.
 
 ---
 
@@ -4931,7 +5291,8 @@ dead_letter_queue_enabled: bool
 
 Enabled DLQ.
 
-If \`deadLetterQueue\` is undefined, an SQS queue with default options will be defined for your Function.
+If \`deadLetterQueue\` is undefined,
+an SQS queue with default options will be defined for your Function.
 
 ---
 
@@ -4959,7 +5320,9 @@ environment: typing.Mapping[str]
 
 Key-value pairs that Lambda caches and makes available for your Lambda functions.
 
-Use environment variables to apply configuration changes, such as test and production environment configurations, without changing your Lambda function source code.
+Use environment variables to apply configuration changes, such
+as test and production environment configurations, without changing your
+Lambda function source code.
 
 ---
 
@@ -5058,7 +5421,9 @@ layers: typing.List[ILayerVersion]
 
 A list of layers to add to the function's execution environment.
 
-You can configure your Lambda function to pull in additional code during initialization in the form of layers. Layers are packages of libraries or other dependencies that can be used by multiple functions.
+You can configure your Lambda function to pull in
+additional code during initialization in the form of layers. Layers are packages of libraries or other dependencies
+that can be used by multiple functions.
 
 ---
 
@@ -5073,7 +5438,9 @@ log_retention: RetentionDays
 
 The number of days log events are kept in CloudWatch Logs.
 
-When updating this property, unsetting it doesn't remove the log retention policy. To remove the retention policy, set the value to \`INFINITE\`.
+When updating
+this property, unsetting it doesn't remove the log retention policy. To
+remove the retention policy, set the value to \`INFINITE\`.
 
 ---
 
@@ -5116,7 +5483,9 @@ memory_size: typing.Union[int, float]
 
 The amount of memory, in MB, that is allocated to your Lambda function.
 
-Lambda uses this value to proportionally allocate the amount of CPU power. For more information, see Resource Model in the AWS Lambda Developer Guide.
+Lambda uses this value to proportionally allocate the amount of CPU
+power. For more information, see Resource Model in the AWS Lambda
+Developer Guide.
 
 ---
 
@@ -5176,7 +5545,15 @@ role: IRole
 
 Lambda execution role.
 
-This is the role that will be assumed by the function upon execution. It controls the permissions that the function will have. The Role must be assumable by the 'lambda.amazonaws.com' service principal.  The default Role automatically has permissions granted for Lambda execution. If you provide a Role, you must add the relevant AWS managed policies yourself.  The relevant managed policies are \\"service-role/AWSLambdaBasicExecutionRole\\" and \\"service-role/AWSLambdaVPCAccessExecutionRole\\".
+This is the role that will be assumed by the function upon execution.
+It controls the permissions that the function will have. The Role must
+be assumable by the 'lambda.amazonaws.com' service principal.
+
+The default Role automatically has permissions granted for Lambda execution. If you
+provide a Role, you must add the relevant AWS managed policies yourself.
+
+The relevant managed policies are \\"service-role/AWSLambdaBasicExecutionRole\\" and
+\\"service-role/AWSLambdaVPCAccessExecutionRole\\".
 
 ---
 
@@ -5193,7 +5570,10 @@ security_group: ISecurityGroup
 
 What security group to associate with the Lambda's network interfaces. This property is being deprecated, consider using securityGroups instead.
 
-Only used if 'vpc' is supplied.  Use securityGroups property instead. Function constructor will throw an error if both are specified.
+Only used if 'vpc' is supplied.
+
+Use securityGroups property instead.
+Function constructor will throw an error if both are specified.
 
 ---
 
@@ -5223,7 +5603,8 @@ timeout: Duration
 
 The function execution time (in seconds) after which Lambda terminates the function.
 
-Because the execution time affects cost, set this value based on the function's expected execution time.
+Because the execution time affects cost, set this value
+based on the function's expected execution time.
 
 ---
 
@@ -5266,7 +5647,8 @@ vpc_subnets: SubnetSelection
 
 Where to place the network interfaces within the VPC.
 
-Only used if 'vpc' is supplied. Note: internet access for Lambdas requires a NAT gateway, so picking Public subnets is not allowed.
+Only used if 'vpc' is supplied. Note: internet access for Lambdas
+requires a NAT gateway, so picking Public subnets is not allowed.
 
 ---
 
@@ -5280,7 +5662,9 @@ code: Code
 
 The source code of your Lambda function.
 
-You can point to a file in an Amazon Simple Storage Service (Amazon S3) bucket or specify your source code as inline text.
+You can point to a file in an
+Amazon Simple Storage Service (Amazon S3) bucket or specify your source
+code as inline text.
 
 ---
 
@@ -5294,7 +5678,15 @@ handler: str
 
 The name of the method within your code that Lambda calls to execute your function.
 
-The format includes the file name. It can also include namespaces and other qualifiers, depending on the runtime. For more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.  Use \`Handler.FROM_IMAGE\` when defining a function from a Docker image.  NOTE: If you specify your source code as inline text by specifying the ZipFile property within the Code property, specify index.function_name as the handler.
+The format includes the file name. It can also include
+namespaces and other qualifiers, depending on the runtime.
+For more information, see https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html#gettingstarted-features-programmingmodel.
+
+Use \`Handler.FROM_IMAGE\` when defining a function from a Docker image.
+
+NOTE: If you specify your source code as inline text by specifying the
+ZipFile property within the Code property, specify index.function_name as
+the handler.
 
 ---
 
@@ -5308,7 +5700,10 @@ runtime: Runtime
 
 The runtime environment for the Lambda function that you are uploading.
 
-For valid values, see the Runtime property in the AWS Lambda Developer Guide.  Use \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.
+For valid values, see the Runtime property in the AWS Lambda Developer
+Guide.
+
+Use \`Runtime.FROM_IMAGE\` when when defining a function from a Docker image.
 
 ---
 

--- a/test/docgen/view/__snapshots__/interface.test.ts.snap
+++ b/test/docgen/view/__snapshots__/interface.test.ts.snap
@@ -632,7 +632,8 @@ private Rule OnCloudTrailEvent(string Id, OnEventOptions Options = null)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -658,7 +659,8 @@ private Rule OnCloudTrailImagePushed(string Id, OnCloudTrailImagePushedOptions O
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -684,7 +686,8 @@ private Rule OnEvent(string Id, OnEventOptions Options = null)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onEvent.parameter.id\\"></a>
 
@@ -793,7 +796,12 @@ public ResourceEnvironment Env { get; }
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -1488,7 +1496,8 @@ public Rule onCloudTrailEvent(java.lang.String id, OnEventOptions options)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -1515,7 +1524,8 @@ public Rule onCloudTrailImagePushed(java.lang.String id, OnCloudTrailImagePushed
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -1542,7 +1552,8 @@ public Rule onEvent(java.lang.String id, OnEventOptions options)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onEvent.parameter.id\\"></a>
 
@@ -1654,7 +1665,12 @@ public ResourceEnvironment getEnv();
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -2646,7 +2662,8 @@ def on_cloud_trail_event(
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -2672,7 +2689,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -2711,7 +2730,8 @@ def on_cloud_trail_image_pushed(
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -2737,7 +2757,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -2784,7 +2806,8 @@ def on_event(
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onEvent.parameter.id\\"></a>
 
@@ -2808,7 +2831,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -2871,7 +2896,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -2981,7 +3008,12 @@ env: ResourceEnvironment
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -3669,7 +3701,8 @@ public onCloudTrailEvent(id: string, options?: OnEventOptions): Rule
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -3695,7 +3728,8 @@ public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOpti
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -3721,7 +3755,8 @@ public onEvent(id: string, options?: OnEventOptions): Rule
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onEvent.parameter.id\\"></a>
 
@@ -3830,7 +3865,12 @@ public readonly env: ResourceEnvironment;
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 

--- a/test/docgen/view/__snapshots__/markdown.test.ts.snap
+++ b/test/docgen/view/__snapshots__/markdown.test.ts.snap
@@ -1837,7 +1837,8 @@ private void AddDependsOn(CfnResource Target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`Target\`<sup>Required</sup> <a name=\\"Target\\" id=\\"CfnPublicRepository.addDependsOn.parameter.target\\"></a>
 
@@ -1883,7 +1884,41 @@ private void AddOverride(string Path, object Value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`Path\`<sup>Required</sup> <a name=\\"Path\\" id=\\"CfnPublicRepository.addOverride.parameter.path\\"></a>
 
@@ -1891,7 +1926,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -1975,7 +2011,8 @@ private Reference GetAtt(string AttributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`AttributeName\`<sup>Required</sup> <a name=\\"AttributeName\\" id=\\"CfnPublicRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -2061,7 +2098,8 @@ CfnPublicRepository.IsCfnElement(object X);
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`X\`<sup>Required</sup> <a name=\\"X\\" id=\\"CfnPublicRepository.isCfnElement.parameter.x\\"></a>
 
@@ -2136,7 +2174,10 @@ public string LogicalId { get; }
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -2164,7 +2205,8 @@ public string Ref { get; }
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -2393,7 +2435,8 @@ private void AddDependsOn(CfnResource Target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`Target\`<sup>Required</sup> <a name=\\"Target\\" id=\\"CfnRegistryPolicy.addDependsOn.parameter.target\\"></a>
 
@@ -2439,7 +2482,41 @@ private void AddOverride(string Path, object Value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`Path\`<sup>Required</sup> <a name=\\"Path\\" id=\\"CfnRegistryPolicy.addOverride.parameter.path\\"></a>
 
@@ -2447,7 +2524,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -2531,7 +2609,8 @@ private Reference GetAtt(string AttributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`AttributeName\`<sup>Required</sup> <a name=\\"AttributeName\\" id=\\"CfnRegistryPolicy.getAtt.parameter.attributeName\\"></a>
 
@@ -2617,7 +2696,8 @@ CfnRegistryPolicy.IsCfnElement(object X);
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`X\`<sup>Required</sup> <a name=\\"X\\" id=\\"CfnRegistryPolicy.isCfnElement.parameter.x\\"></a>
 
@@ -2689,7 +2769,10 @@ public string LogicalId { get; }
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -2717,7 +2800,8 @@ public string Ref { get; }
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -2904,7 +2988,8 @@ private void AddDependsOn(CfnResource Target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`Target\`<sup>Required</sup> <a name=\\"Target\\" id=\\"CfnReplicationConfiguration.addDependsOn.parameter.target\\"></a>
 
@@ -2950,7 +3035,41 @@ private void AddOverride(string Path, object Value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`Path\`<sup>Required</sup> <a name=\\"Path\\" id=\\"CfnReplicationConfiguration.addOverride.parameter.path\\"></a>
 
@@ -2958,7 +3077,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -3042,7 +3162,8 @@ private Reference GetAtt(string AttributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`AttributeName\`<sup>Required</sup> <a name=\\"AttributeName\\" id=\\"CfnReplicationConfiguration.getAtt.parameter.attributeName\\"></a>
 
@@ -3128,7 +3249,8 @@ CfnReplicationConfiguration.IsCfnElement(object X);
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`X\`<sup>Required</sup> <a name=\\"X\\" id=\\"CfnReplicationConfiguration.isCfnElement.parameter.x\\"></a>
 
@@ -3200,7 +3322,10 @@ public string LogicalId { get; }
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -3228,7 +3353,8 @@ public string Ref { get; }
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -3415,7 +3541,8 @@ private void AddDependsOn(CfnResource Target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`Target\`<sup>Required</sup> <a name=\\"Target\\" id=\\"CfnRepository.addDependsOn.parameter.target\\"></a>
 
@@ -3461,7 +3588,41 @@ private void AddOverride(string Path, object Value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`Path\`<sup>Required</sup> <a name=\\"Path\\" id=\\"CfnRepository.addOverride.parameter.path\\"></a>
 
@@ -3469,7 +3630,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -3553,7 +3715,8 @@ private Reference GetAtt(string AttributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`AttributeName\`<sup>Required</sup> <a name=\\"AttributeName\\" id=\\"CfnRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -3639,7 +3802,8 @@ CfnRepository.IsCfnElement(object X);
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`X\`<sup>Required</sup> <a name=\\"X\\" id=\\"CfnRepository.isCfnElement.parameter.x\\"></a>
 
@@ -3718,7 +3882,10 @@ public string LogicalId { get; }
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -3746,7 +3913,8 @@ public string Ref { get; }
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -3986,7 +4154,13 @@ private void ApplyRemovalPolicy(RemovalPolicy Policy)
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`Policy\`<sup>Required</sup> <a name=\\"Policy\\" id=\\"Repository.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -4064,7 +4238,8 @@ private Rule OnCloudTrailEvent(string Id, OnEventOptions Options = null)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"Repository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -4090,7 +4265,8 @@ private Rule OnCloudTrailImagePushed(string Id, OnCloudTrailImagePushedOptions O
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"Repository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -4116,7 +4292,8 @@ private Rule OnEvent(string Id, OnEventOptions Options = null)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"Repository.onEvent.parameter.id\\"></a>
 
@@ -4198,7 +4375,8 @@ private void AddLifecycleRule(LifecycleRule Rule)
 
 Add a life cycle rule to the repository.
 
-Life cycle rules automatically expire images from the repository that match certain conditions.
+Life cycle rules automatically expire images from the repository that match
+certain conditions.
 
 ###### \`Rule\`<sup>Required</sup> <a name=\\"Rule\\" id=\\"Repository.addLifecycleRule.parameter.rule\\"></a>
 
@@ -4394,7 +4572,12 @@ public ResourceEnvironment Env { get; }
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -4526,7 +4709,13 @@ private void ApplyRemovalPolicy(RemovalPolicy Policy)
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`Policy\`<sup>Required</sup> <a name=\\"Policy\\" id=\\"RepositoryBase.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -4604,7 +4793,8 @@ private Rule OnCloudTrailEvent(string Id, OnEventOptions Options = null)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"RepositoryBase.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -4630,7 +4820,8 @@ private Rule OnCloudTrailImagePushed(string Id, OnCloudTrailImagePushedOptions O
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"RepositoryBase.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -4656,7 +4847,8 @@ private Rule OnEvent(string Id, OnEventOptions Options = null)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"RepositoryBase.onEvent.parameter.id\\"></a>
 
@@ -4806,7 +4998,12 @@ public ResourceEnvironment Env { get; }
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -5295,7 +5492,14 @@ public double RulePriority { get; set; }
 
 Controls the order in which rules are evaluated (low to high).
 
-All rules must have a unique priority, where lower numbers have higher precedence. The first rule that matches is applied to an image.  There can only be one rule with a tagStatus of Any, and it must have the highest rulePriority.  All rules without a specified priority will have incrementing priorities automatically assigned to them, higher than any rules that DO have priorities.
+All rules must have a unique priority, where lower numbers have
+higher precedence. The first rule that matches is applied to an image.
+
+There can only be one rule with a tagStatus of Any, and it must have
+the highest rulePriority.
+
+All rules without a specified priority will have incrementing priorities
+automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
@@ -5324,7 +5528,8 @@ public TagStatus TagStatus { get; set; }
 
 Select images based on tags.
 
-Only one rule is allowed to select untagged images, and it must have the highest rulePriority.
+Only one rule is allowed to select untagged images, and it must
+have the highest rulePriority.
 
 ---
 
@@ -5382,7 +5587,9 @@ public EventPattern EventPattern { get; set; }
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -5481,7 +5688,9 @@ public EventPattern EventPattern { get; set; }
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -5971,7 +6180,8 @@ private Rule OnCloudTrailEvent(string Id, OnEventOptions Options = null)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"IRepository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -5997,7 +6207,8 @@ private Rule OnCloudTrailImagePushed(string Id, OnCloudTrailImagePushedOptions O
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"IRepository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -6023,7 +6234,8 @@ private Rule OnEvent(string Id, OnEventOptions Options = null)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"IRepository.onEvent.parameter.id\\"></a>
 
@@ -6132,7 +6344,12 @@ public ResourceEnvironment Env { get; }
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -6513,7 +6730,8 @@ public void addDependsOn(CfnResource target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"CfnPublicRepository.addDependsOn.parameter.target\\"></a>
 
@@ -6559,7 +6777,41 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"CfnPublicRepository.addOverride.parameter.path\\"></a>
 
@@ -6567,7 +6819,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -6653,7 +6906,8 @@ public Reference getAtt(java.lang.String attributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"CfnPublicRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -6739,7 +6993,8 @@ CfnPublicRepository.isCfnElement(java.lang.Object x)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"CfnPublicRepository.isCfnElement.parameter.x\\"></a>
 
@@ -6814,7 +7069,10 @@ public java.lang.String getLogicalId();
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -6842,7 +7100,8 @@ public java.lang.String getRef();
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -7075,7 +7334,8 @@ public void addDependsOn(CfnResource target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"CfnRegistryPolicy.addDependsOn.parameter.target\\"></a>
 
@@ -7121,7 +7381,41 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"CfnRegistryPolicy.addOverride.parameter.path\\"></a>
 
@@ -7129,7 +7423,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -7215,7 +7510,8 @@ public Reference getAtt(java.lang.String attributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"CfnRegistryPolicy.getAtt.parameter.attributeName\\"></a>
 
@@ -7301,7 +7597,8 @@ CfnRegistryPolicy.isCfnElement(java.lang.Object x)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"CfnRegistryPolicy.isCfnElement.parameter.x\\"></a>
 
@@ -7373,7 +7670,10 @@ public java.lang.String getLogicalId();
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -7401,7 +7701,8 @@ public java.lang.String getRef();
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -7593,7 +7894,8 @@ public void addDependsOn(CfnResource target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"CfnReplicationConfiguration.addDependsOn.parameter.target\\"></a>
 
@@ -7639,7 +7941,41 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"CfnReplicationConfiguration.addOverride.parameter.path\\"></a>
 
@@ -7647,7 +7983,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -7733,7 +8070,8 @@ public Reference getAtt(java.lang.String attributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"CfnReplicationConfiguration.getAtt.parameter.attributeName\\"></a>
 
@@ -7819,7 +8157,8 @@ CfnReplicationConfiguration.isCfnElement(java.lang.Object x)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"CfnReplicationConfiguration.isCfnElement.parameter.x\\"></a>
 
@@ -7891,7 +8230,10 @@ public java.lang.String getLogicalId();
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -7919,7 +8261,8 @@ public java.lang.String getRef();
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -8183,7 +8526,8 @@ public void addDependsOn(CfnResource target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"CfnRepository.addDependsOn.parameter.target\\"></a>
 
@@ -8229,7 +8573,41 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"CfnRepository.addOverride.parameter.path\\"></a>
 
@@ -8237,7 +8615,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -8323,7 +8702,8 @@ public Reference getAtt(java.lang.String attributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"CfnRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -8409,7 +8789,8 @@ CfnRepository.isCfnElement(java.lang.Object x)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"CfnRepository.isCfnElement.parameter.x\\"></a>
 
@@ -8488,7 +8869,10 @@ public java.lang.String getLogicalId();
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -8516,7 +8900,8 @@ public java.lang.String getRef();
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -8820,7 +9205,13 @@ public void applyRemovalPolicy(RemovalPolicy policy)
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"Repository.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -8899,7 +9290,8 @@ public Rule onCloudTrailEvent(java.lang.String id, OnEventOptions options)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"Repository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -8926,7 +9318,8 @@ public Rule onCloudTrailImagePushed(java.lang.String id, OnCloudTrailImagePushed
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"Repository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -8953,7 +9346,8 @@ public Rule onEvent(java.lang.String id, OnEventOptions options)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"Repository.onEvent.parameter.id\\"></a>
 
@@ -9038,7 +9432,8 @@ public void addLifecycleRule(LifecycleRule rule)
 
 Add a life cycle rule to the repository.
 
-Life cycle rules automatically expire images from the repository that match certain conditions.
+Life cycle rules automatically expire images from the repository that match
+certain conditions.
 
 ###### \`rule\`<sup>Required</sup> <a name=\\"rule\\" id=\\"Repository.addLifecycleRule.parameter.rule\\"></a>
 
@@ -9234,7 +9629,12 @@ public ResourceEnvironment getEnv();
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -9349,7 +9749,10 @@ The AWS account ID this resource belongs to.
 
 ARN to deduce region and account from.
 
-The ARN is parsed and the account and region are taken from the ARN. This should be used for imported resources.  Cannot be supplied together with either \`account\` or \`region\`.
+The ARN is parsed and the account and region are taken from the ARN.
+This should be used for imported resources.
+
+Cannot be supplied together with either \`account\` or \`region\`.
 
 ---
 
@@ -9360,7 +9763,11 @@ The ARN is parsed and the account and region are taken from the ARN. This should
 
 The value passed in by users to the physical name prop of the resource.
 
-\`undefined\` implies that a physical name will be allocated by    CloudFormation during deployment. - a concrete value implies a specific physical name - \`PhysicalName.GENERATE_IF_NEEDED\` is a marker that indicates that a physical will only be generated    by the CDK if it is needed for cross-environment references. Otherwise, it will be allocated by CloudFormation.
+\`undefined\` implies that a physical name will be allocated by
+   CloudFormation during deployment.
+- a concrete value implies a specific physical name
+- \`PhysicalName.GENERATE_IF_NEEDED\` is a marker that indicates that a physical will only be generated
+   by the CDK if it is needed for cross-environment references. Otherwise, it will be allocated by CloudFormation.
 
 ---
 
@@ -9408,7 +9815,13 @@ public void applyRemovalPolicy(RemovalPolicy policy)
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"RepositoryBase.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -9487,7 +9900,8 @@ public Rule onCloudTrailEvent(java.lang.String id, OnEventOptions options)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"RepositoryBase.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -9514,7 +9928,8 @@ public Rule onCloudTrailImagePushed(java.lang.String id, OnCloudTrailImagePushed
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"RepositoryBase.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -9541,7 +9956,8 @@ public Rule onEvent(java.lang.String id, OnEventOptions options)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"RepositoryBase.onEvent.parameter.id\\"></a>
 
@@ -9694,7 +10110,12 @@ public ResourceEnvironment getEnv();
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -10185,7 +10606,14 @@ public java.lang.Number getRulePriority();
 
 Controls the order in which rules are evaluated (low to high).
 
-All rules must have a unique priority, where lower numbers have higher precedence. The first rule that matches is applied to an image.  There can only be one rule with a tagStatus of Any, and it must have the highest rulePriority.  All rules without a specified priority will have incrementing priorities automatically assigned to them, higher than any rules that DO have priorities.
+All rules must have a unique priority, where lower numbers have
+higher precedence. The first rule that matches is applied to an image.
+
+There can only be one rule with a tagStatus of Any, and it must have
+the highest rulePriority.
+
+All rules without a specified priority will have incrementing priorities
+automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
@@ -10214,7 +10642,8 @@ public TagStatus getTagStatus();
 
 Select images based on tags.
 
-Only one rule is allowed to select untagged images, and it must have the highest rulePriority.
+Only one rule is allowed to select untagged images, and it must
+have the highest rulePriority.
 
 ---
 
@@ -10272,7 +10701,9 @@ public EventPattern getEventPattern();
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -10371,7 +10802,9 @@ public EventPattern getEventPattern();
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -10866,7 +11299,8 @@ public Rule onCloudTrailEvent(java.lang.String id, OnEventOptions options)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"IRepository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -10893,7 +11327,8 @@ public Rule onCloudTrailImagePushed(java.lang.String id, OnCloudTrailImagePushed
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"IRepository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -10920,7 +11355,8 @@ public Rule onEvent(java.lang.String id, OnEventOptions options)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"IRepository.onEvent.parameter.id\\"></a>
 
@@ -11032,7 +11468,12 @@ public ResourceEnvironment getEnv();
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -11421,7 +11862,8 @@ def add_depends_on(
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"CfnPublicRepository.addDependsOn.parameter.target\\"></a>
 
@@ -11473,7 +11915,41 @@ def add_override(
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"CfnPublicRepository.addOverride.parameter.path\\"></a>
 
@@ -11481,7 +11957,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -11588,7 +12065,8 @@ def get_att(
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attribute_name\`<sup>Required</sup> <a name=\\"attribute_name\\" id=\\"CfnPublicRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -11682,7 +12160,8 @@ aws_cdk.aws_ecr.CfnPublicRepository.is_cfn_element(
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"CfnPublicRepository.isCfnElement.parameter.x\\"></a>
 
@@ -11759,7 +12238,10 @@ logical_id: str
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -11787,7 +12269,8 @@ ref: str
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -12028,7 +12511,8 @@ def add_depends_on(
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"CfnRegistryPolicy.addDependsOn.parameter.target\\"></a>
 
@@ -12080,7 +12564,41 @@ def add_override(
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"CfnRegistryPolicy.addOverride.parameter.path\\"></a>
 
@@ -12088,7 +12606,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -12195,7 +12714,8 @@ def get_att(
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attribute_name\`<sup>Required</sup> <a name=\\"attribute_name\\" id=\\"CfnRegistryPolicy.getAtt.parameter.attributeName\\"></a>
 
@@ -12289,7 +12809,8 @@ aws_cdk.aws_ecr.CfnRegistryPolicy.is_cfn_element(
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"CfnRegistryPolicy.isCfnElement.parameter.x\\"></a>
 
@@ -12363,7 +12884,10 @@ logical_id: str
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -12391,7 +12915,8 @@ ref: str
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -12590,7 +13115,8 @@ def add_depends_on(
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"CfnReplicationConfiguration.addDependsOn.parameter.target\\"></a>
 
@@ -12642,7 +13168,41 @@ def add_override(
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"CfnReplicationConfiguration.addOverride.parameter.path\\"></a>
 
@@ -12650,7 +13210,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -12757,7 +13318,8 @@ def get_att(
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attribute_name\`<sup>Required</sup> <a name=\\"attribute_name\\" id=\\"CfnReplicationConfiguration.getAtt.parameter.attributeName\\"></a>
 
@@ -12851,7 +13413,8 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.is_cfn_element(
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"CfnReplicationConfiguration.isCfnElement.parameter.x\\"></a>
 
@@ -12925,7 +13488,10 @@ logical_id: str
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -12953,7 +13519,8 @@ ref: str
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -13224,7 +13791,8 @@ def add_depends_on(
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"CfnRepository.addDependsOn.parameter.target\\"></a>
 
@@ -13276,7 +13844,41 @@ def add_override(
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"CfnRepository.addOverride.parameter.path\\"></a>
 
@@ -13284,7 +13886,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -13391,7 +13994,8 @@ def get_att(
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attribute_name\`<sup>Required</sup> <a name=\\"attribute_name\\" id=\\"CfnRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -13485,7 +14089,8 @@ aws_cdk.aws_ecr.CfnRepository.is_cfn_element(
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"CfnRepository.isCfnElement.parameter.x\\"></a>
 
@@ -13566,7 +14171,10 @@ logical_id: str
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -13594,7 +14202,8 @@ ref: str
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -13902,7 +14511,13 @@ def apply_removal_policy(
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"Repository.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -13995,7 +14610,8 @@ def on_cloud_trail_event(
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"Repository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -14021,7 +14637,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -14060,7 +14678,8 @@ def on_cloud_trail_image_pushed(
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"Repository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -14086,7 +14705,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -14133,7 +14754,8 @@ def on_event(
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"Repository.onEvent.parameter.id\\"></a>
 
@@ -14157,7 +14779,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -14220,7 +14844,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -14310,7 +14936,8 @@ def add_lifecycle_rule(
 
 Add a life cycle rule to the repository.
 
-Life cycle rules automatically expire images from the repository that match certain conditions.
+Life cycle rules automatically expire images from the repository that match
+certain conditions.
 
 ###### \`description\`<sup>Optional</sup> <a name=\\"description\\" id=\\"Repository.addLifecycleRule.parameter.description\\"></a>
 
@@ -14348,7 +14975,14 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 Controls the order in which rules are evaluated (low to high).
 
-All rules must have a unique priority, where lower numbers have higher precedence. The first rule that matches is applied to an image.  There can only be one rule with a tagStatus of Any, and it must have the highest rulePriority.  All rules without a specified priority will have incrementing priorities automatically assigned to them, higher than any rules that DO have priorities.
+All rules must have a unique priority, where lower numbers have
+higher precedence. The first rule that matches is applied to an image.
+
+There can only be one rule with a tagStatus of Any, and it must have
+the highest rulePriority.
+
+All rules without a specified priority will have incrementing priorities
+automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
@@ -14369,7 +15003,8 @@ Only if tagStatus == TagStatus.Tagged
 
 Select images based on tags.
 
-Only one rule is allowed to select untagged images, and it must have the highest rulePriority.
+Only one rule is allowed to select untagged images, and it must
+have the highest rulePriority.
 
 ---
 
@@ -14588,7 +15223,12 @@ env: ResourceEnvironment
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -14705,7 +15345,10 @@ The AWS account ID this resource belongs to.
 
 ARN to deduce region and account from.
 
-The ARN is parsed and the account and region are taken from the ARN. This should be used for imported resources.  Cannot be supplied together with either \`account\` or \`region\`.
+The ARN is parsed and the account and region are taken from the ARN.
+This should be used for imported resources.
+
+Cannot be supplied together with either \`account\` or \`region\`.
 
 ---
 
@@ -14716,7 +15359,11 @@ The ARN is parsed and the account and region are taken from the ARN. This should
 
 The value passed in by users to the physical name prop of the resource.
 
-\`undefined\` implies that a physical name will be allocated by    CloudFormation during deployment. - a concrete value implies a specific physical name - \`PhysicalName.GENERATE_IF_NEEDED\` is a marker that indicates that a physical will only be generated    by the CDK if it is needed for cross-environment references. Otherwise, it will be allocated by CloudFormation.
+\`undefined\` implies that a physical name will be allocated by
+   CloudFormation during deployment.
+- a concrete value implies a specific physical name
+- \`PhysicalName.GENERATE_IF_NEEDED\` is a marker that indicates that a physical will only be generated
+   by the CDK if it is needed for cross-environment references. Otherwise, it will be allocated by CloudFormation.
 
 ---
 
@@ -14766,7 +15413,13 @@ def apply_removal_policy(
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"RepositoryBase.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -14859,7 +15512,8 @@ def on_cloud_trail_event(
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"RepositoryBase.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -14885,7 +15539,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -14924,7 +15580,8 @@ def on_cloud_trail_image_pushed(
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"RepositoryBase.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -14950,7 +15607,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -14997,7 +15656,8 @@ def on_event(
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"RepositoryBase.onEvent.parameter.id\\"></a>
 
@@ -15021,7 +15681,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -15084,7 +15746,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -15239,7 +15903,12 @@ env: ResourceEnvironment
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -15728,7 +16397,14 @@ rule_priority: typing.Union[int, float]
 
 Controls the order in which rules are evaluated (low to high).
 
-All rules must have a unique priority, where lower numbers have higher precedence. The first rule that matches is applied to an image.  There can only be one rule with a tagStatus of Any, and it must have the highest rulePriority.  All rules without a specified priority will have incrementing priorities automatically assigned to them, higher than any rules that DO have priorities.
+All rules must have a unique priority, where lower numbers have
+higher precedence. The first rule that matches is applied to an image.
+
+There can only be one rule with a tagStatus of Any, and it must have
+the highest rulePriority.
+
+All rules without a specified priority will have incrementing priorities
+automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
@@ -15757,7 +16433,8 @@ tag_status: TagStatus
 
 Select images based on tags.
 
-Only one rule is allowed to select untagged images, and it must have the highest rulePriority.
+Only one rule is allowed to select untagged images, and it must
+have the highest rulePriority.
 
 ---
 
@@ -15815,7 +16492,9 @@ event_pattern: EventPattern
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -15914,7 +16593,9 @@ event_pattern: EventPattern
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -16423,7 +17104,8 @@ def on_cloud_trail_event(
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"IRepository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -16449,7 +17131,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -16488,7 +17172,8 @@ def on_cloud_trail_image_pushed(
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"IRepository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -16514,7 +17199,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -16561,7 +17248,8 @@ def on_event(
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"IRepository.onEvent.parameter.id\\"></a>
 
@@ -16585,7 +17273,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -16648,7 +17338,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -16758,7 +17450,12 @@ env: ResourceEnvironment
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -17095,7 +17792,8 @@ public addDependsOn(target: CfnResource): void
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"CfnPublicRepository.addDependsOn.parameter.target\\"></a>
 
@@ -17141,7 +17839,41 @@ public addOverride(path: string, value: any): void
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"CfnPublicRepository.addOverride.parameter.path\\"></a>
 
@@ -17149,7 +17881,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -17233,7 +17966,8 @@ public getAtt(attributeName: string): Reference
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"CfnPublicRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -17319,7 +18053,8 @@ CfnPublicRepository.isCfnElement(x: any)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"CfnPublicRepository.isCfnElement.parameter.x\\"></a>
 
@@ -17394,7 +18129,10 @@ public readonly logicalId: string;
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -17422,7 +18160,8 @@ public readonly ref: string;
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -17651,7 +18390,8 @@ public addDependsOn(target: CfnResource): void
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"CfnRegistryPolicy.addDependsOn.parameter.target\\"></a>
 
@@ -17697,7 +18437,41 @@ public addOverride(path: string, value: any): void
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"CfnRegistryPolicy.addOverride.parameter.path\\"></a>
 
@@ -17705,7 +18479,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -17789,7 +18564,8 @@ public getAtt(attributeName: string): Reference
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"CfnRegistryPolicy.getAtt.parameter.attributeName\\"></a>
 
@@ -17875,7 +18651,8 @@ CfnRegistryPolicy.isCfnElement(x: any)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"CfnRegistryPolicy.isCfnElement.parameter.x\\"></a>
 
@@ -17947,7 +18724,10 @@ public readonly logicalId: string;
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -17975,7 +18755,8 @@ public readonly ref: string;
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -18162,7 +18943,8 @@ public addDependsOn(target: CfnResource): void
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"CfnReplicationConfiguration.addDependsOn.parameter.target\\"></a>
 
@@ -18208,7 +18990,41 @@ public addOverride(path: string, value: any): void
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"CfnReplicationConfiguration.addOverride.parameter.path\\"></a>
 
@@ -18216,7 +19032,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -18300,7 +19117,8 @@ public getAtt(attributeName: string): Reference
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"CfnReplicationConfiguration.getAtt.parameter.attributeName\\"></a>
 
@@ -18386,7 +19204,8 @@ CfnReplicationConfiguration.isCfnElement(x: any)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"CfnReplicationConfiguration.isCfnElement.parameter.x\\"></a>
 
@@ -18458,7 +19277,10 @@ public readonly logicalId: string;
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -18486,7 +19308,8 @@ public readonly ref: string;
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -18673,7 +19496,8 @@ public addDependsOn(target: CfnResource): void
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"CfnRepository.addDependsOn.parameter.target\\"></a>
 
@@ -18719,7 +19543,41 @@ public addOverride(path: string, value: any): void
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"CfnRepository.addOverride.parameter.path\\"></a>
 
@@ -18727,7 +19585,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -18811,7 +19670,8 @@ public getAtt(attributeName: string): Reference
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"CfnRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -18897,7 +19757,8 @@ CfnRepository.isCfnElement(x: any)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"CfnRepository.isCfnElement.parameter.x\\"></a>
 
@@ -18976,7 +19837,10 @@ public readonly logicalId: string;
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -19004,7 +19868,8 @@ public readonly ref: string;
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -19244,7 +20109,13 @@ public applyRemovalPolicy(policy: RemovalPolicy): void
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"Repository.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -19322,7 +20193,8 @@ public onCloudTrailEvent(id: string, options?: OnEventOptions): Rule
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"Repository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -19348,7 +20220,8 @@ public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOpti
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"Repository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -19374,7 +20247,8 @@ public onEvent(id: string, options?: OnEventOptions): Rule
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"Repository.onEvent.parameter.id\\"></a>
 
@@ -19456,7 +20330,8 @@ public addLifecycleRule(rule: LifecycleRule): void
 
 Add a life cycle rule to the repository.
 
-Life cycle rules automatically expire images from the repository that match certain conditions.
+Life cycle rules automatically expire images from the repository that match
+certain conditions.
 
 ###### \`rule\`<sup>Required</sup> <a name=\\"rule\\" id=\\"Repository.addLifecycleRule.parameter.rule\\"></a>
 
@@ -19652,7 +20527,12 @@ public readonly env: ResourceEnvironment;
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -19784,7 +20664,13 @@ public applyRemovalPolicy(policy: RemovalPolicy): void
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"RepositoryBase.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -19862,7 +20748,8 @@ public onCloudTrailEvent(id: string, options?: OnEventOptions): Rule
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"RepositoryBase.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -19888,7 +20775,8 @@ public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOpti
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"RepositoryBase.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -19914,7 +20802,8 @@ public onEvent(id: string, options?: OnEventOptions): Rule
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"RepositoryBase.onEvent.parameter.id\\"></a>
 
@@ -20064,7 +20953,12 @@ public readonly env: ResourceEnvironment;
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -20526,7 +21420,14 @@ public readonly rulePriority: number;
 
 Controls the order in which rules are evaluated (low to high).
 
-All rules must have a unique priority, where lower numbers have higher precedence. The first rule that matches is applied to an image.  There can only be one rule with a tagStatus of Any, and it must have the highest rulePriority.  All rules without a specified priority will have incrementing priorities automatically assigned to them, higher than any rules that DO have priorities.
+All rules must have a unique priority, where lower numbers have
+higher precedence. The first rule that matches is applied to an image.
+
+There can only be one rule with a tagStatus of Any, and it must have
+the highest rulePriority.
+
+All rules without a specified priority will have incrementing priorities
+automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
@@ -20555,7 +21456,8 @@ public readonly tagStatus: TagStatus;
 
 Select images based on tags.
 
-Only one rule is allowed to select untagged images, and it must have the highest rulePriority.
+Only one rule is allowed to select untagged images, and it must
+have the highest rulePriority.
 
 ---
 
@@ -20607,7 +21509,9 @@ public readonly eventPattern: EventPattern;
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -20700,7 +21604,9 @@ public readonly eventPattern: EventPattern;
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -21173,7 +22079,8 @@ public onCloudTrailEvent(id: string, options?: OnEventOptions): Rule
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"IRepository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -21199,7 +22106,8 @@ public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOpti
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"IRepository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -21225,7 +22133,8 @@ public onEvent(id: string, options?: OnEventOptions): Rule
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"IRepository.onEvent.parameter.id\\"></a>
 
@@ -21334,7 +22243,12 @@ public readonly env: ResourceEnvironment;
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -21675,7 +22589,8 @@ private void AddDependsOn(CfnResource Target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`Target\`<sup>Required</sup> <a name=\\"Target\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.addDependsOn.parameter.target\\"></a>
 
@@ -21721,7 +22636,41 @@ private void AddOverride(string Path, object Value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`Path\`<sup>Required</sup> <a name=\\"Path\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.addOverride.parameter.path\\"></a>
 
@@ -21729,7 +22678,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -21813,7 +22763,8 @@ private Reference GetAtt(string AttributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`AttributeName\`<sup>Required</sup> <a name=\\"AttributeName\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -21899,7 +22850,8 @@ CfnPublicRepository.IsCfnElement(object X);
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`X\`<sup>Required</sup> <a name=\\"X\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.isCfnElement.parameter.x\\"></a>
 
@@ -21974,7 +22926,10 @@ public string LogicalId { get; }
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -22002,7 +22957,8 @@ public string Ref { get; }
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -22231,7 +23187,8 @@ private void AddDependsOn(CfnResource Target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`Target\`<sup>Required</sup> <a name=\\"Target\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.addDependsOn.parameter.target\\"></a>
 
@@ -22277,7 +23234,41 @@ private void AddOverride(string Path, object Value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`Path\`<sup>Required</sup> <a name=\\"Path\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.addOverride.parameter.path\\"></a>
 
@@ -22285,7 +23276,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -22369,7 +23361,8 @@ private Reference GetAtt(string AttributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`AttributeName\`<sup>Required</sup> <a name=\\"AttributeName\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.getAtt.parameter.attributeName\\"></a>
 
@@ -22455,7 +23448,8 @@ CfnRegistryPolicy.IsCfnElement(object X);
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`X\`<sup>Required</sup> <a name=\\"X\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.isCfnElement.parameter.x\\"></a>
 
@@ -22527,7 +23521,10 @@ public string LogicalId { get; }
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -22555,7 +23552,8 @@ public string Ref { get; }
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -22742,7 +23740,8 @@ private void AddDependsOn(CfnResource Target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`Target\`<sup>Required</sup> <a name=\\"Target\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.addDependsOn.parameter.target\\"></a>
 
@@ -22788,7 +23787,41 @@ private void AddOverride(string Path, object Value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`Path\`<sup>Required</sup> <a name=\\"Path\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.addOverride.parameter.path\\"></a>
 
@@ -22796,7 +23829,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -22880,7 +23914,8 @@ private Reference GetAtt(string AttributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`AttributeName\`<sup>Required</sup> <a name=\\"AttributeName\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.getAtt.parameter.attributeName\\"></a>
 
@@ -22966,7 +24001,8 @@ CfnReplicationConfiguration.IsCfnElement(object X);
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`X\`<sup>Required</sup> <a name=\\"X\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.isCfnElement.parameter.x\\"></a>
 
@@ -23038,7 +24074,10 @@ public string LogicalId { get; }
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -23066,7 +24105,8 @@ public string Ref { get; }
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -23253,7 +24293,8 @@ private void AddDependsOn(CfnResource Target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`Target\`<sup>Required</sup> <a name=\\"Target\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.addDependsOn.parameter.target\\"></a>
 
@@ -23299,7 +24340,41 @@ private void AddOverride(string Path, object Value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`Path\`<sup>Required</sup> <a name=\\"Path\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.addOverride.parameter.path\\"></a>
 
@@ -23307,7 +24382,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -23391,7 +24467,8 @@ private Reference GetAtt(string AttributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`AttributeName\`<sup>Required</sup> <a name=\\"AttributeName\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -23477,7 +24554,8 @@ CfnRepository.IsCfnElement(object X);
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`X\`<sup>Required</sup> <a name=\\"X\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.isCfnElement.parameter.x\\"></a>
 
@@ -23556,7 +24634,10 @@ public string LogicalId { get; }
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -23584,7 +24665,8 @@ public string Ref { get; }
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -23824,7 +24906,13 @@ private void ApplyRemovalPolicy(RemovalPolicy Policy)
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`Policy\`<sup>Required</sup> <a name=\\"Policy\\" id=\\"@aws-cdk/aws-ecr.Repository.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -23902,7 +24990,8 @@ private Rule OnCloudTrailEvent(string Id, OnEventOptions Options = null)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"@aws-cdk/aws-ecr.Repository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -23928,7 +25017,8 @@ private Rule OnCloudTrailImagePushed(string Id, OnCloudTrailImagePushedOptions O
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"@aws-cdk/aws-ecr.Repository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -23954,7 +25044,8 @@ private Rule OnEvent(string Id, OnEventOptions Options = null)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"@aws-cdk/aws-ecr.Repository.onEvent.parameter.id\\"></a>
 
@@ -24036,7 +25127,8 @@ private void AddLifecycleRule(LifecycleRule Rule)
 
 Add a life cycle rule to the repository.
 
-Life cycle rules automatically expire images from the repository that match certain conditions.
+Life cycle rules automatically expire images from the repository that match
+certain conditions.
 
 ###### \`Rule\`<sup>Required</sup> <a name=\\"Rule\\" id=\\"@aws-cdk/aws-ecr.Repository.addLifecycleRule.parameter.rule\\"></a>
 
@@ -24232,7 +25324,12 @@ public ResourceEnvironment Env { get; }
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -24364,7 +25461,13 @@ private void ApplyRemovalPolicy(RemovalPolicy Policy)
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`Policy\`<sup>Required</sup> <a name=\\"Policy\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -24442,7 +25545,8 @@ private Rule OnCloudTrailEvent(string Id, OnEventOptions Options = null)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -24468,7 +25572,8 @@ private Rule OnCloudTrailImagePushed(string Id, OnCloudTrailImagePushedOptions O
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -24494,7 +25599,8 @@ private Rule OnEvent(string Id, OnEventOptions Options = null)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.onEvent.parameter.id\\"></a>
 
@@ -24644,7 +25750,12 @@ public ResourceEnvironment Env { get; }
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -25133,7 +26244,14 @@ public double RulePriority { get; set; }
 
 Controls the order in which rules are evaluated (low to high).
 
-All rules must have a unique priority, where lower numbers have higher precedence. The first rule that matches is applied to an image.  There can only be one rule with a tagStatus of Any, and it must have the highest rulePriority.  All rules without a specified priority will have incrementing priorities automatically assigned to them, higher than any rules that DO have priorities.
+All rules must have a unique priority, where lower numbers have
+higher precedence. The first rule that matches is applied to an image.
+
+There can only be one rule with a tagStatus of Any, and it must have
+the highest rulePriority.
+
+All rules without a specified priority will have incrementing priorities
+automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
@@ -25162,7 +26280,8 @@ public TagStatus TagStatus { get; set; }
 
 Select images based on tags.
 
-Only one rule is allowed to select untagged images, and it must have the highest rulePriority.
+Only one rule is allowed to select untagged images, and it must
+have the highest rulePriority.
 
 ---
 
@@ -25220,7 +26339,9 @@ public EventPattern EventPattern { get; set; }
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -25319,7 +26440,9 @@ public EventPattern EventPattern { get; set; }
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -25809,7 +26932,8 @@ private Rule OnCloudTrailEvent(string Id, OnEventOptions Options = null)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -25835,7 +26959,8 @@ private Rule OnCloudTrailImagePushed(string Id, OnCloudTrailImagePushedOptions O
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -25861,7 +26986,8 @@ private Rule OnEvent(string Id, OnEventOptions Options = null)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`Id\`<sup>Required</sup> <a name=\\"Id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onEvent.parameter.id\\"></a>
 
@@ -25970,7 +27096,12 @@ public ResourceEnvironment Env { get; }
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -26351,7 +27482,8 @@ public void addDependsOn(CfnResource target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.addDependsOn.parameter.target\\"></a>
 
@@ -26397,7 +27529,41 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.addOverride.parameter.path\\"></a>
 
@@ -26405,7 +27571,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -26491,7 +27658,8 @@ public Reference getAtt(java.lang.String attributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -26577,7 +27745,8 @@ CfnPublicRepository.isCfnElement(java.lang.Object x)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.isCfnElement.parameter.x\\"></a>
 
@@ -26652,7 +27821,10 @@ public java.lang.String getLogicalId();
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -26680,7 +27852,8 @@ public java.lang.String getRef();
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -26913,7 +28086,8 @@ public void addDependsOn(CfnResource target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.addDependsOn.parameter.target\\"></a>
 
@@ -26959,7 +28133,41 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.addOverride.parameter.path\\"></a>
 
@@ -26967,7 +28175,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -27053,7 +28262,8 @@ public Reference getAtt(java.lang.String attributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.getAtt.parameter.attributeName\\"></a>
 
@@ -27139,7 +28349,8 @@ CfnRegistryPolicy.isCfnElement(java.lang.Object x)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.isCfnElement.parameter.x\\"></a>
 
@@ -27211,7 +28422,10 @@ public java.lang.String getLogicalId();
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -27239,7 +28453,8 @@ public java.lang.String getRef();
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -27431,7 +28646,8 @@ public void addDependsOn(CfnResource target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.addDependsOn.parameter.target\\"></a>
 
@@ -27477,7 +28693,41 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.addOverride.parameter.path\\"></a>
 
@@ -27485,7 +28735,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -27571,7 +28822,8 @@ public Reference getAtt(java.lang.String attributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.getAtt.parameter.attributeName\\"></a>
 
@@ -27657,7 +28909,8 @@ CfnReplicationConfiguration.isCfnElement(java.lang.Object x)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.isCfnElement.parameter.x\\"></a>
 
@@ -27729,7 +28982,10 @@ public java.lang.String getLogicalId();
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -27757,7 +29013,8 @@ public java.lang.String getRef();
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -28021,7 +29278,8 @@ public void addDependsOn(CfnResource target)
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.addDependsOn.parameter.target\\"></a>
 
@@ -28067,7 +29325,41 @@ public void addOverride(java.lang.String path, java.lang.Object value)
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.addOverride.parameter.path\\"></a>
 
@@ -28075,7 +29367,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -28161,7 +29454,8 @@ public Reference getAtt(java.lang.String attributeName)
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -28247,7 +29541,8 @@ CfnRepository.isCfnElement(java.lang.Object x)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.isCfnElement.parameter.x\\"></a>
 
@@ -28326,7 +29621,10 @@ public java.lang.String getLogicalId();
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -28354,7 +29652,8 @@ public java.lang.String getRef();
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -28658,7 +29957,13 @@ public void applyRemovalPolicy(RemovalPolicy policy)
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"@aws-cdk/aws-ecr.Repository.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -28737,7 +30042,8 @@ public Rule onCloudTrailEvent(java.lang.String id, OnEventOptions options)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.Repository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -28764,7 +30070,8 @@ public Rule onCloudTrailImagePushed(java.lang.String id, OnCloudTrailImagePushed
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.Repository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -28791,7 +30098,8 @@ public Rule onEvent(java.lang.String id, OnEventOptions options)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.Repository.onEvent.parameter.id\\"></a>
 
@@ -28876,7 +30184,8 @@ public void addLifecycleRule(LifecycleRule rule)
 
 Add a life cycle rule to the repository.
 
-Life cycle rules automatically expire images from the repository that match certain conditions.
+Life cycle rules automatically expire images from the repository that match
+certain conditions.
 
 ###### \`rule\`<sup>Required</sup> <a name=\\"rule\\" id=\\"@aws-cdk/aws-ecr.Repository.addLifecycleRule.parameter.rule\\"></a>
 
@@ -29072,7 +30381,12 @@ public ResourceEnvironment getEnv();
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -29187,7 +30501,10 @@ The AWS account ID this resource belongs to.
 
 ARN to deduce region and account from.
 
-The ARN is parsed and the account and region are taken from the ARN. This should be used for imported resources.  Cannot be supplied together with either \`account\` or \`region\`.
+The ARN is parsed and the account and region are taken from the ARN.
+This should be used for imported resources.
+
+Cannot be supplied together with either \`account\` or \`region\`.
 
 ---
 
@@ -29198,7 +30515,11 @@ The ARN is parsed and the account and region are taken from the ARN. This should
 
 The value passed in by users to the physical name prop of the resource.
 
-\`undefined\` implies that a physical name will be allocated by    CloudFormation during deployment. - a concrete value implies a specific physical name - \`PhysicalName.GENERATE_IF_NEEDED\` is a marker that indicates that a physical will only be generated    by the CDK if it is needed for cross-environment references. Otherwise, it will be allocated by CloudFormation.
+\`undefined\` implies that a physical name will be allocated by
+   CloudFormation during deployment.
+- a concrete value implies a specific physical name
+- \`PhysicalName.GENERATE_IF_NEEDED\` is a marker that indicates that a physical will only be generated
+   by the CDK if it is needed for cross-environment references. Otherwise, it will be allocated by CloudFormation.
 
 ---
 
@@ -29246,7 +30567,13 @@ public void applyRemovalPolicy(RemovalPolicy policy)
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -29325,7 +30652,8 @@ public Rule onCloudTrailEvent(java.lang.String id, OnEventOptions options)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -29352,7 +30680,8 @@ public Rule onCloudTrailImagePushed(java.lang.String id, OnCloudTrailImagePushed
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -29379,7 +30708,8 @@ public Rule onEvent(java.lang.String id, OnEventOptions options)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.onEvent.parameter.id\\"></a>
 
@@ -29532,7 +30862,12 @@ public ResourceEnvironment getEnv();
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -30023,7 +31358,14 @@ public java.lang.Number getRulePriority();
 
 Controls the order in which rules are evaluated (low to high).
 
-All rules must have a unique priority, where lower numbers have higher precedence. The first rule that matches is applied to an image.  There can only be one rule with a tagStatus of Any, and it must have the highest rulePriority.  All rules without a specified priority will have incrementing priorities automatically assigned to them, higher than any rules that DO have priorities.
+All rules must have a unique priority, where lower numbers have
+higher precedence. The first rule that matches is applied to an image.
+
+There can only be one rule with a tagStatus of Any, and it must have
+the highest rulePriority.
+
+All rules without a specified priority will have incrementing priorities
+automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
@@ -30052,7 +31394,8 @@ public TagStatus getTagStatus();
 
 Select images based on tags.
 
-Only one rule is allowed to select untagged images, and it must have the highest rulePriority.
+Only one rule is allowed to select untagged images, and it must
+have the highest rulePriority.
 
 ---
 
@@ -30110,7 +31453,9 @@ public EventPattern getEventPattern();
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -30209,7 +31554,9 @@ public EventPattern getEventPattern();
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -30704,7 +32051,8 @@ public Rule onCloudTrailEvent(java.lang.String id, OnEventOptions options)
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -30731,7 +32079,8 @@ public Rule onCloudTrailImagePushed(java.lang.String id, OnCloudTrailImagePushed
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -30758,7 +32107,8 @@ public Rule onEvent(java.lang.String id, OnEventOptions options)
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onEvent.parameter.id\\"></a>
 
@@ -30870,7 +32220,12 @@ public ResourceEnvironment getEnv();
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -31259,7 +32614,8 @@ def add_depends_on(
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.addDependsOn.parameter.target\\"></a>
 
@@ -31311,7 +32667,41 @@ def add_override(
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.addOverride.parameter.path\\"></a>
 
@@ -31319,7 +32709,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -31426,7 +32817,8 @@ def get_att(
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attribute_name\`<sup>Required</sup> <a name=\\"attribute_name\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -31520,7 +32912,8 @@ aws_cdk.aws_ecr.CfnPublicRepository.is_cfn_element(
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.isCfnElement.parameter.x\\"></a>
 
@@ -31597,7 +32990,10 @@ logical_id: str
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -31625,7 +33021,8 @@ ref: str
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -31866,7 +33263,8 @@ def add_depends_on(
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.addDependsOn.parameter.target\\"></a>
 
@@ -31918,7 +33316,41 @@ def add_override(
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.addOverride.parameter.path\\"></a>
 
@@ -31926,7 +33358,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -32033,7 +33466,8 @@ def get_att(
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attribute_name\`<sup>Required</sup> <a name=\\"attribute_name\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.getAtt.parameter.attributeName\\"></a>
 
@@ -32127,7 +33561,8 @@ aws_cdk.aws_ecr.CfnRegistryPolicy.is_cfn_element(
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.isCfnElement.parameter.x\\"></a>
 
@@ -32201,7 +33636,10 @@ logical_id: str
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -32229,7 +33667,8 @@ ref: str
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -32428,7 +33867,8 @@ def add_depends_on(
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.addDependsOn.parameter.target\\"></a>
 
@@ -32480,7 +33920,41 @@ def add_override(
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.addOverride.parameter.path\\"></a>
 
@@ -32488,7 +33962,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -32595,7 +34070,8 @@ def get_att(
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attribute_name\`<sup>Required</sup> <a name=\\"attribute_name\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.getAtt.parameter.attributeName\\"></a>
 
@@ -32689,7 +34165,8 @@ aws_cdk.aws_ecr.CfnReplicationConfiguration.is_cfn_element(
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.isCfnElement.parameter.x\\"></a>
 
@@ -32763,7 +34240,10 @@ logical_id: str
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -32791,7 +34271,8 @@ ref: str
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -33062,7 +34543,8 @@ def add_depends_on(
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.addDependsOn.parameter.target\\"></a>
 
@@ -33114,7 +34596,41 @@ def add_override(
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.addOverride.parameter.path\\"></a>
 
@@ -33122,7 +34638,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -33229,7 +34746,8 @@ def get_att(
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attribute_name\`<sup>Required</sup> <a name=\\"attribute_name\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -33323,7 +34841,8 @@ aws_cdk.aws_ecr.CfnRepository.is_cfn_element(
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.isCfnElement.parameter.x\\"></a>
 
@@ -33404,7 +34923,10 @@ logical_id: str
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -33432,7 +34954,8 @@ ref: str
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -33740,7 +35263,13 @@ def apply_removal_policy(
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"@aws-cdk/aws-ecr.Repository.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -33833,7 +35362,8 @@ def on_cloud_trail_event(
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.Repository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -33859,7 +35389,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -33898,7 +35430,8 @@ def on_cloud_trail_image_pushed(
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.Repository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -33924,7 +35457,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -33971,7 +35506,8 @@ def on_event(
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.Repository.onEvent.parameter.id\\"></a>
 
@@ -33995,7 +35531,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -34058,7 +35596,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -34148,7 +35688,8 @@ def add_lifecycle_rule(
 
 Add a life cycle rule to the repository.
 
-Life cycle rules automatically expire images from the repository that match certain conditions.
+Life cycle rules automatically expire images from the repository that match
+certain conditions.
 
 ###### \`description\`<sup>Optional</sup> <a name=\\"description\\" id=\\"@aws-cdk/aws-ecr.Repository.addLifecycleRule.parameter.description\\"></a>
 
@@ -34186,7 +35727,14 @@ Specify exactly one of maxImageCount and maxImageAge.
 
 Controls the order in which rules are evaluated (low to high).
 
-All rules must have a unique priority, where lower numbers have higher precedence. The first rule that matches is applied to an image.  There can only be one rule with a tagStatus of Any, and it must have the highest rulePriority.  All rules without a specified priority will have incrementing priorities automatically assigned to them, higher than any rules that DO have priorities.
+All rules must have a unique priority, where lower numbers have
+higher precedence. The first rule that matches is applied to an image.
+
+There can only be one rule with a tagStatus of Any, and it must have
+the highest rulePriority.
+
+All rules without a specified priority will have incrementing priorities
+automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
@@ -34207,7 +35755,8 @@ Only if tagStatus == TagStatus.Tagged
 
 Select images based on tags.
 
-Only one rule is allowed to select untagged images, and it must have the highest rulePriority.
+Only one rule is allowed to select untagged images, and it must
+have the highest rulePriority.
 
 ---
 
@@ -34426,7 +35975,12 @@ env: ResourceEnvironment
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -34543,7 +36097,10 @@ The AWS account ID this resource belongs to.
 
 ARN to deduce region and account from.
 
-The ARN is parsed and the account and region are taken from the ARN. This should be used for imported resources.  Cannot be supplied together with either \`account\` or \`region\`.
+The ARN is parsed and the account and region are taken from the ARN.
+This should be used for imported resources.
+
+Cannot be supplied together with either \`account\` or \`region\`.
 
 ---
 
@@ -34554,7 +36111,11 @@ The ARN is parsed and the account and region are taken from the ARN. This should
 
 The value passed in by users to the physical name prop of the resource.
 
-\`undefined\` implies that a physical name will be allocated by    CloudFormation during deployment. - a concrete value implies a specific physical name - \`PhysicalName.GENERATE_IF_NEEDED\` is a marker that indicates that a physical will only be generated    by the CDK if it is needed for cross-environment references. Otherwise, it will be allocated by CloudFormation.
+\`undefined\` implies that a physical name will be allocated by
+   CloudFormation during deployment.
+- a concrete value implies a specific physical name
+- \`PhysicalName.GENERATE_IF_NEEDED\` is a marker that indicates that a physical will only be generated
+   by the CDK if it is needed for cross-environment references. Otherwise, it will be allocated by CloudFormation.
 
 ---
 
@@ -34604,7 +36165,13 @@ def apply_removal_policy(
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -34697,7 +36264,8 @@ def on_cloud_trail_event(
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -34723,7 +36291,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -34762,7 +36332,8 @@ def on_cloud_trail_image_pushed(
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -34788,7 +36359,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -34835,7 +36408,8 @@ def on_event(
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.onEvent.parameter.id\\"></a>
 
@@ -34859,7 +36433,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -34922,7 +36498,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -35077,7 +36655,12 @@ env: ResourceEnvironment
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -35566,7 +37149,14 @@ rule_priority: typing.Union[int, float]
 
 Controls the order in which rules are evaluated (low to high).
 
-All rules must have a unique priority, where lower numbers have higher precedence. The first rule that matches is applied to an image.  There can only be one rule with a tagStatus of Any, and it must have the highest rulePriority.  All rules without a specified priority will have incrementing priorities automatically assigned to them, higher than any rules that DO have priorities.
+All rules must have a unique priority, where lower numbers have
+higher precedence. The first rule that matches is applied to an image.
+
+There can only be one rule with a tagStatus of Any, and it must have
+the highest rulePriority.
+
+All rules without a specified priority will have incrementing priorities
+automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
@@ -35595,7 +37185,8 @@ tag_status: TagStatus
 
 Select images based on tags.
 
-Only one rule is allowed to select untagged images, and it must have the highest rulePriority.
+Only one rule is allowed to select untagged images, and it must
+have the highest rulePriority.
 
 ---
 
@@ -35653,7 +37244,9 @@ event_pattern: EventPattern
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -35752,7 +37345,9 @@ event_pattern: EventPattern
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -36261,7 +37856,8 @@ def on_cloud_trail_event(
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -36287,7 +37883,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -36326,7 +37924,8 @@ def on_cloud_trail_image_pushed(
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -36352,7 +37951,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -36399,7 +38000,8 @@ def on_event(
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onEvent.parameter.id\\"></a>
 
@@ -36423,7 +38025,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -36486,7 +38090,9 @@ A description of the rule's purpose.
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -36596,7 +38202,12 @@ env: ResourceEnvironment
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -36933,7 +38544,8 @@ public addDependsOn(target: CfnResource): void
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.addDependsOn.parameter.target\\"></a>
 
@@ -36979,7 +38591,41 @@ public addOverride(path: string, value: any): void
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.addOverride.parameter.path\\"></a>
 
@@ -36987,7 +38633,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -37071,7 +38718,8 @@ public getAtt(attributeName: string): Reference
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -37157,7 +38805,8 @@ CfnPublicRepository.isCfnElement(x: any)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"@aws-cdk/aws-ecr.CfnPublicRepository.isCfnElement.parameter.x\\"></a>
 
@@ -37232,7 +38881,10 @@ public readonly logicalId: string;
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -37260,7 +38912,8 @@ public readonly ref: string;
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -37489,7 +39142,8 @@ public addDependsOn(target: CfnResource): void
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.addDependsOn.parameter.target\\"></a>
 
@@ -37535,7 +39189,41 @@ public addOverride(path: string, value: any): void
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.addOverride.parameter.path\\"></a>
 
@@ -37543,7 +39231,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -37627,7 +39316,8 @@ public getAtt(attributeName: string): Reference
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.getAtt.parameter.attributeName\\"></a>
 
@@ -37713,7 +39403,8 @@ CfnRegistryPolicy.isCfnElement(x: any)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"@aws-cdk/aws-ecr.CfnRegistryPolicy.isCfnElement.parameter.x\\"></a>
 
@@ -37785,7 +39476,10 @@ public readonly logicalId: string;
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -37813,7 +39507,8 @@ public readonly ref: string;
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -38000,7 +39695,8 @@ public addDependsOn(target: CfnResource): void
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.addDependsOn.parameter.target\\"></a>
 
@@ -38046,7 +39742,41 @@ public addOverride(path: string, value: any): void
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.addOverride.parameter.path\\"></a>
 
@@ -38054,7 +39784,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -38138,7 +39869,8 @@ public getAtt(attributeName: string): Reference
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.getAtt.parameter.attributeName\\"></a>
 
@@ -38224,7 +39956,8 @@ CfnReplicationConfiguration.isCfnElement(x: any)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"@aws-cdk/aws-ecr.CfnReplicationConfiguration.isCfnElement.parameter.x\\"></a>
 
@@ -38296,7 +40029,10 @@ public readonly logicalId: string;
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -38324,7 +40060,8 @@ public readonly ref: string;
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -38511,7 +40248,8 @@ public addDependsOn(target: CfnResource): void
 
 Indicates that this resource depends on another resource and cannot be provisioned unless the other resource has been successfully provisioned.
 
-This can be used for resources across stacks (or nested stack) boundaries and the dependency will automatically be transferred to the relevant scope.
+This can be used for resources across stacks (or nested stack) boundaries
+and the dependency will automatically be transferred to the relevant scope.
 
 ###### \`target\`<sup>Required</sup> <a name=\\"target\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.addDependsOn.parameter.target\\"></a>
 
@@ -38557,7 +40295,41 @@ public addOverride(path: string, value: any): void
 
 Adds an override to the synthesized CloudFormation resource.
 
-To add a property override, either use \`addPropertyOverride\` or prefix \`path\` with \\"Properties.\\" (i.e. \`Properties.TopicName\`).  If the override is nested, separate each nested level using a dot (.) in the path parameter. If there is an array as part of the nesting, specify the index in the path.  To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the \`\\\\\` itself will need to be escaped.  For example, \`\`\`typescript cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']); cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE'); \`\`\` would add the overrides \`\`\`json \\"Properties\\": {    \\"GlobalSecondaryIndexes\\": [      {        \\"Projection\\": {          \\"NonKeyAttributes\\": [ \\"myattribute\\" ]          ...        }        ...      },      {        \\"ProjectionType\\": \\"INCLUDE\\"        ...      },    ]    ... } \`\`\`
+To add a
+property override, either use \`addPropertyOverride\` or prefix \`path\` with
+\\"Properties.\\" (i.e. \`Properties.TopicName\`).
+
+If the override is nested, separate each nested level using a dot (.) in the path parameter.
+If there is an array as part of the nesting, specify the index in the path.
+
+To include a literal \`.\` in the property name, prefix with a \`\\\\\`. In most
+programming languages you will need to write this as \`\\"\\\\\\\\.\\"\` because the
+\`\\\\\` itself will need to be escaped.
+
+For example,
+\`\`\`typescript
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.0.Projection.NonKeyAttributes', ['myattribute']);
+cfnResource.addOverride('Properties.GlobalSecondaryIndexes.1.ProjectionType', 'INCLUDE');
+\`\`\`
+would add the overrides
+\`\`\`json
+\\"Properties\\": {
+   \\"GlobalSecondaryIndexes\\": [
+     {
+       \\"Projection\\": {
+         \\"NonKeyAttributes\\": [ \\"myattribute\\" ]
+         ...
+       }
+       ...
+     },
+     {
+       \\"ProjectionType\\": \\"INCLUDE\\"
+       ...
+     },
+   ]
+   ...
+}
+\`\`\`
 
 ###### \`path\`<sup>Required</sup> <a name=\\"path\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.addOverride.parameter.path\\"></a>
 
@@ -38565,7 +40337,8 @@ To add a property override, either use \`addPropertyOverride\` or prefix \`path\
 
 The path of the property, you can use dot notation to override values in complex types.
 
-Any intermdediate keys will be created as needed.
+Any intermdediate keys
+will be created as needed.
 
 ---
 
@@ -38649,7 +40422,8 @@ public getAtt(attributeName: string): Reference
 
 Returns a token for an runtime attribute of this resource.
 
-Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility in case there is no generated attribute.
+Ideally, use generated attribute accessors (e.g. \`resource.arn\`), but this can be used for future compatibility
+in case there is no generated attribute.
 
 ###### \`attributeName\`<sup>Required</sup> <a name=\\"attributeName\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.getAtt.parameter.attributeName\\"></a>
 
@@ -38735,7 +40509,8 @@ CfnRepository.isCfnElement(x: any)
 
 Returns \`true\` if a construct is a stack element (i.e. part of the synthesized cloudformation template).
 
-Uses duck-typing instead of \`instanceof\` to allow stack elements from different versions of this library to be included in the same stack.
+Uses duck-typing instead of \`instanceof\` to allow stack elements from different
+versions of this library to be included in the same stack.
 
 ###### \`x\`<sup>Required</sup> <a name=\\"x\\" id=\\"@aws-cdk/aws-ecr.CfnRepository.isCfnElement.parameter.x\\"></a>
 
@@ -38814,7 +40589,10 @@ public readonly logicalId: string;
 
 The logical ID for this CloudFormation stack element.
 
-The logical ID of the element is calculated from the path of the resource node in the construct tree.  To override this value, use \`overrideLogicalId(newLogicalId)\`.
+The logical ID of the element
+is calculated from the path of the resource node in the construct tree.
+
+To override this value, use \`overrideLogicalId(newLogicalId)\`.
 
 ---
 
@@ -38842,7 +40620,8 @@ public readonly ref: string;
 
 Return a string that will be resolved to a CloudFormation \`{ Ref }\` for this element.
 
-If, by any chance, the intrinsic reference of a resource is not a string, you could coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
+If, by any chance, the intrinsic reference of a resource is not a string, you could
+coerce it to an IResolvable through \`Lazy.any({ produce: resource.ref })\`.
 
 ---
 
@@ -39082,7 +40861,13 @@ public applyRemovalPolicy(policy: RemovalPolicy): void
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"@aws-cdk/aws-ecr.Repository.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -39160,7 +40945,8 @@ public onCloudTrailEvent(id: string, options?: OnEventOptions): Rule
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.Repository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -39186,7 +40972,8 @@ public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOpti
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.Repository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -39212,7 +40999,8 @@ public onEvent(id: string, options?: OnEventOptions): Rule
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.Repository.onEvent.parameter.id\\"></a>
 
@@ -39294,7 +41082,8 @@ public addLifecycleRule(rule: LifecycleRule): void
 
 Add a life cycle rule to the repository.
 
-Life cycle rules automatically expire images from the repository that match certain conditions.
+Life cycle rules automatically expire images from the repository that match
+certain conditions.
 
 ###### \`rule\`<sup>Required</sup> <a name=\\"rule\\" id=\\"@aws-cdk/aws-ecr.Repository.addLifecycleRule.parameter.rule\\"></a>
 
@@ -39490,7 +41279,12 @@ public readonly env: ResourceEnvironment;
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -39622,7 +41416,13 @@ public applyRemovalPolicy(policy: RemovalPolicy): void
 
 Apply the given removal policy to this resource.
 
-The Removal Policy controls what happens to this resource when it stops being managed by CloudFormation, either because you've removed it from the CDK application or because you've made a change that requires the resource to be replaced.  The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DELETE\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
 
 ###### \`policy\`<sup>Required</sup> <a name=\\"policy\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.applyRemovalPolicy.parameter.policy\\"></a>
 
@@ -39700,7 +41500,8 @@ public onCloudTrailEvent(id: string, options?: OnEventOptions): Rule
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -39726,7 +41527,8 @@ public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOpti
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -39752,7 +41554,8 @@ public onEvent(id: string, options?: OnEventOptions): Rule
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.RepositoryBase.onEvent.parameter.id\\"></a>
 
@@ -39902,7 +41705,12 @@ public readonly env: ResourceEnvironment;
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 
@@ -40364,7 +42172,14 @@ public readonly rulePriority: number;
 
 Controls the order in which rules are evaluated (low to high).
 
-All rules must have a unique priority, where lower numbers have higher precedence. The first rule that matches is applied to an image.  There can only be one rule with a tagStatus of Any, and it must have the highest rulePriority.  All rules without a specified priority will have incrementing priorities automatically assigned to them, higher than any rules that DO have priorities.
+All rules must have a unique priority, where lower numbers have
+higher precedence. The first rule that matches is applied to an image.
+
+There can only be one rule with a tagStatus of Any, and it must have
+the highest rulePriority.
+
+All rules without a specified priority will have incrementing priorities
+automatically assigned to them, higher than any rules that DO have priorities.
 
 ---
 
@@ -40393,7 +42208,8 @@ public readonly tagStatus: TagStatus;
 
 Select images based on tags.
 
-Only one rule is allowed to select untagged images, and it must have the highest rulePriority.
+Only one rule is allowed to select untagged images, and it must
+have the highest rulePriority.
 
 ---
 
@@ -40445,7 +42261,9 @@ public readonly eventPattern: EventPattern;
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -40538,7 +42356,9 @@ public readonly eventPattern: EventPattern;
 
 Additional restrictions for the event to route to the specified target.
 
-The method that generates the rule probably imposes some type of event filtering. The filtering implied by what you pass here is added on top of that filtering.
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
 
 > [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
 
@@ -41011,7 +42831,8 @@ public onCloudTrailEvent(id: string, options?: OnEventOptions): Rule
 
 Define a CloudWatch event that triggers when something happens to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailEvent.parameter.id\\"></a>
 
@@ -41037,7 +42858,8 @@ public onCloudTrailImagePushed(id: string, options?: OnCloudTrailImagePushedOpti
 
 Defines an AWS CloudWatch event rule that can trigger a target when an image is pushed to this repository.
 
-Requires that there exists at least one CloudTrail Trail in your account that captures the event. This method will not create the Trail.
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onCloudTrailImagePushed.parameter.id\\"></a>
 
@@ -41063,7 +42885,8 @@ public onEvent(id: string, options?: OnEventOptions): Rule
 
 Defines a CloudWatch event rule which triggers for repository events.
 
-Use \`rule.addEventPattern(pattern)\` to specify a filter.
+Use
+\`rule.addEventPattern(pattern)\` to specify a filter.
 
 ###### \`id\`<sup>Required</sup> <a name=\\"id\\" id=\\"@aws-cdk/aws-ecr.IRepository.onEvent.parameter.id\\"></a>
 
@@ -41172,7 +42995,12 @@ public readonly env: ResourceEnvironment;
 
 The environment this resource belongs to.
 
-For resources that are created and managed by the CDK (generally, those created by creating new class instances like Role, Bucket, etc.), this is always the same as the environment of the stack they belong to; however, for imported resources (those obtained from static methods like fromRoleArn, fromBucketName, etc.), that might be different than the stack they were imported into.
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
 
 ---
 

--- a/test/docgen/view/parameter.test.ts
+++ b/test/docgen/view/parameter.test.ts
@@ -42,3 +42,13 @@ test('newlines in "defaults" are removed', () => {
   expect(markdown).toMatchSnapshot();
   expect(markdown).toContain('default option with a newline');
 });
+
+test('newlines in any other than "defaults" are not removed', () => {
+  const transpile = new TypeScriptTranspile();
+  const reflectParameter = findParameter();
+  reflectParameter.spec.docs = { remarks: 'remarks\nwith a newline' };
+  const docgenParameter = new Parameter(transpile, reflectParameter).toJson();
+  const renderer = new MarkdownRenderer({ language: Language.TYPESCRIPT, ...metadata });
+  const markdown = renderer.visitParameter(docgenParameter).render();
+  expect(markdown).toContain('remarks\nwith a newline');
+});


### PR DESCRIPTION
Fixes #642 

The newlines should be removed only from docs.defaults
This commit isolates the newlines removal in a dedicated method which is only used on docs.defaults
Other fields continue to use sanitize() but without any newline removal