### PR TITLE
chore: bump minimum node version to 14.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 12.22.0
+          node-version: 14.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 12.22.0
+          node-version: 14.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 12.22.0
+          node-version: 14.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^12",
+      "version": "^14",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -173,7 +173,7 @@
       "description": "Run tests",
       "steps": [
         {
-          "exec": "jest --passWithNoTests --all --updateSnapshot"
+          "exec": "jest --passWithNoTests --all --updateSnapshot --coverageProvider=v8"
         },
         {
           "spawn": "eslint"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -36,8 +36,7 @@ const project = new typescript.TypeScriptProject({
   },
   autoApproveUpgrades: true,
 
-  minNodeVersion: '12.13.0',
-  workflowNodeVersion: '12.22.0', // required by @typescript-eslint/eslint-plugin@5.5.0
+  minNodeVersion: '14.17.0',
 
   tsconfig: {
     compilerOptions: {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.4.1",
-    "@types/node": "^12",
+    "@types/node": "^14",
     "@types/semver": "^7.3.9",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
@@ -66,7 +66,7 @@
     "yargs": "^16.2.0"
   },
   "engines": {
-    "node": ">= 12.13.0"
+    "node": ">= 14.17.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/src/docgen/view/_npm.ts
+++ b/src/docgen/view/_npm.ts
@@ -143,13 +143,13 @@ export class Npm {
 
 interface CommandResult<T> {
   readonly command: string;
-  readonly exitCode?: number;
-  readonly signal?: NodeJS.Signals;
+  readonly exitCode: number | null;
+  readonly signal: NodeJS.Signals | null;
   readonly stdout: T;
 }
 interface SuccessfulCommandResult<T> extends CommandResult<T> {
   readonly exitCode: 0;
-  readonly signal: undefined;
+  readonly signal: null;
 }
 
 /**
@@ -201,7 +201,7 @@ function assertSuccess(result: CommandResult<ResponseObject>): asserts result is
  * this process results in an error, returns an object that contains the error
  * and the raw chunks.
  */
-function chunksToObject(chunks: readonly Buffer[], encoding = 'utf-8'): ResponseObject {
+function chunksToObject(chunks: readonly Buffer[], encoding: BufferEncoding = 'utf-8'): ResponseObject {
   const raw = Buffer.concat(chunks).toString(encoding);
   try {
     // npm will sometimes print non json log lines even though --json was requested.

--- a/yarn.lock
+++ b/yarn.lock
@@ -815,10 +815,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.31.tgz#a5bb84ecfa27eec5e1c802c6bbf8139bdb163a5d"
   integrity sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==
 
-"@types/node@^12":
-  version "12.20.50"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.50.tgz#14ba5198f1754ffd0472a2f84ab433b45ee0b65e"
-  integrity sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==
+"@types/node@^14":
+  version "14.18.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.16.tgz#878f670ba3f00482bf859b6550b6010610fc54b5"
+  integrity sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
BREAKING CHANGE: jsii-docgen now requires node >= 14.x