### PR TITLE
fix: support hoisted jsii dependencies

### DIFF
--- a/test/docgen/transpile/transpile.test.ts
+++ b/test/docgen/transpile/transpile.test.ts
@@ -2,7 +2,7 @@ import { Documentation } from '../../../src';
 import { Language } from '../../../src/docgen/transpile/transpile';
 import { Assemblies } from '../assemblies';
 
-jest.setTimeout(30000);
+jest.setTimeout(60 * 1000);
 
 describe('language', () => {
 


### PR DESCRIPTION
Removes copy of the project directory and instead only outputs
transliterated assemblies to the working directory. This avoids
potential problems when generating docs for packages that may have some
dependencies hoisted. IE when building against `aws-cdk-lib` within
`node_modules` and `constructs` is hoisted to the top level
`node_modules` directory as well.

Note: This fixes unit tests for https://github.com/cdklabs/jsii-docgen/pull/644. Full credit goes to Mitchell Valine @MrArnoldPalmer.

Fixes #390