### PR TITLE
chore: use jsii's loadAssemblyFromFile function

### DIFF
--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -1,5 +1,6 @@
 import * as os from 'os';
 import * as path from 'path';
+import { loadAssemblyFromFile, SPEC_FILE_NAME } from '@jsii/spec';
 import * as fs from 'fs-extra';
 import * as glob from 'glob-promise';
 import * as reflect from 'jsii-reflect';
@@ -320,13 +321,13 @@ export class Documentation {
       await fs.copy(this.assembliesDir, workdir);
 
       const ts = new reflect.TypeSystem();
-      for (let dotJsii of await glob.promise(`${workdir}/**/.jsii`)) {
+      for (let dotJsii of await glob.promise(`${workdir}/**/${SPEC_FILE_NAME}`)) {
         // we only transliterate the top level assembly and not the entire type-system.
         // note that the only reason to translate dependant assemblies is to show code examples
         // for expanded python arguments - which we don't to right now anyway.
         // we don't want to make any assumption of the directory structure, so this is the most
         // robuse way to detect the root assembly.
-        const spec = JSON.parse(await fs.readFile(dotJsii, 'utf-8'));
+        const spec = loadAssemblyFromFile(dotJsii);
         if (language && spec.name === this.assemblyName) {
           const packageDir = path.dirname(dotJsii);
           try {
@@ -334,7 +335,7 @@ export class Documentation {
           } catch (e) {
             throw new LanguageNotSupportedError(`Laguage ${language} is not supported for package ${this.assemblyFqn}`);
           }
-          dotJsii = path.join(packageDir, `.jsii.${language}`);
+          dotJsii = path.join(packageDir, `${SPEC_FILE_NAME}.${language}`);
         }
         await ts.load(dotJsii, { validate: options.validate });
       }

--- a/test/docgen/assemblies.ts
+++ b/test/docgen/assemblies.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as spec from '@jsii/spec';
+import { SPEC_FILE_NAME, loadAssemblyFromFile } from '@jsii/spec';
 import * as reflect from 'jsii-reflect';
 
 /**
@@ -42,8 +42,8 @@ export class Assemblies {
     if (stat.isDirectory()) {
       fs.readdirSync(p).forEach((f) => this.addAssemblies(path.join(p, f)));
     } else {
-      if (p.endsWith('.jsii')) {
-        const assembly = JSON.parse(fs.readFileSync(p, { encoding: 'utf8' })) as spec.Assembly;
+      if (p.endsWith(SPEC_FILE_NAME)) {
+        const assembly = loadAssemblyFromFile(p);
         this.ts.addAssembly(new reflect.Assembly(this.ts, assembly));
       }
     }


### PR DESCRIPTION
This isn't possible until the next release of jsii, so it is a draft. But the new `loadAssemblyFromFile` looks soooo much cleaner!