### PR TITLE
fix: detect `E404` as an "uninstallable package" error

### DIFF
--- a/src/docgen/view/_npm.ts
+++ b/src/docgen/view/_npm.ts
@@ -187,6 +187,7 @@ function assertSuccess(result: CommandResult<ResponseObject>): asserts result is
   switch (code) {
     case 'ERESOLVE': // dependency resolution problem requires a manual intervention (most likely...)
     case 'EOVERRIDE': // Package contains some version overrides that conflict.
+    case 'E404': // package (or dependency) can't be found on NPM. This can happen if the package depends on a deprecated package (for example).
       throw new UnInstallablePackageError(message);
     default:
       throw new NpmError(message, stdout, code);


### PR DESCRIPTION
For example, if a package depends on another package that has been deprecated.

```
"error": {
    "Error": "jsii-docgen.NpmError.E404",
    "Cause": "{\"message\":\"Command \\\"npm install /tmp/packages-yuGGLf/package.tgz --ignore-scripts --no-bin-links --no-save --include=dev --no-package-lock --json\\\" exited with code 1: Not Found - GET https://registry.npmjs.org/@stackspot%2fcdk-env-eventbridge - Not found\\n\\n '@stackspot/cdk-env-eventbridge@^0.1.4' is not in this registry.\\n\\nNote that you can also install from a\\ntarball, folder, http url, or git url.\",\"name\":\"jsii-docgen.NpmError.E404\",\"stack\":\"jsii-docgen.NpmError.E404: Command \\\"npm install /tmp/packages-yuGGLf/package.tgz --ignore-scripts --no-bin-links --no-save --include=dev --no-package-lock --json\\\" exited with code 1: Not Found - GET https://registry.npmjs.org/@stackspot%2fcdk-env-eventbridge - Not found\\n\\n '@stackspot/cdk-env-eventbridge@^0.1.4' is not in this registry.\\n\\nNote that you can also install from a\\ntarball, folder, http url, or git url.\\n    at assertSuccess (/bundle/index.js:324218:17)\\n    at Npm.install (/bundle/index.js:324138:16)\\n    at runMicrotasks (<anonymous>)\\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\\n    at async Function.forPackage (/bundle/index.js:324967:9)\\n    at async /bundle/index.js:1208410:20\\n    at async ensureWritableHome (/bundle/index.js:1208583:12)\\n    at async main (/bundle/index.js:1208702:20)\"}"
  }
```

Fixes #