### PR TITLE
fix: detect packages removed from npm as "uninstallable"

### DIFF
--- a/src/docgen/view/_npm.ts
+++ b/src/docgen/view/_npm.ts
@@ -184,6 +184,12 @@ function assertSuccess(result: CommandResult<ResponseObject>): asserts result is
     throw new UnInstallablePackageError(summary);
   }
 
+  // happens when a package has been deleted from npm
+  // for example: sns-app-jsii-component
+  if (!code && !detail && typeof(summary) === 'string' && summary.includes('Cannot convert undefined or null to object')) {
+    throw new UnInstallablePackageError(summary);
+  }
+
   switch (code) {
     case 'ERESOLVE': // dependency resolution problem requires a manual intervention (most likely...)
     case 'EOVERRIDE': // Package contains some version overrides that conflict.


### PR DESCRIPTION
If a package is deleted from npm and you try to install it you will receive this error:

```
{
  "error": {
    "code": null,
    "summary": "Cannot convert undefined or null to object",
    "detail": ""
  }
}
```

Detect that error as an "uninstallable" package. This is a pretty non-specific error message so the only risk is that this error message overlaps with a different failure. Hopefully an actual error would have the code and detail populated.

Fixes #