### PR TITLE
feat: support generating docs for mulitple languages and splitting by namespace

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ async function generateForLanguage(docs: Documentation, format: 'md' | 'json', o
       fs.writeFileSync(`${submodule.name}.${submoduleSuffix}`, content.render());
     }
 
-    fs.writeFileSync(`${output ?? 'API'}.${fileSuffix}`, await (await docs.toIndexMarkdown(fileSuffix, options)).render());
+    fs.writeFileSync(`${output ?? 'API'}.${fileSuffix}`, await (await docs.toIndexMarkdown(submoduleSuffix, options)).render());
   } else {
     const content = await (format === 'md' ? docs.toMarkdown(options) : docs.toJson(options));
     fs.writeFileSync(`${output ?? 'API'}.${fileSuffix}`, content.render());

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fs from 'fs/promises';
 import * as yargs from 'yargs';
 import { Language } from './docgen/transpile/transpile';
 import { Documentation } from './index';
@@ -38,13 +38,13 @@ async function generateForLanguage(docs: Documentation, options: GenerateOptions
         header: { title: `\`${submodule.name}\` Submodule`, id: submodule.fqn },
       });
 
-      fs.writeFileSync(`${submodule.name}.${submoduleSuffix}`, content.render());
+      await fs.writeFile(`${submodule.name}.${submoduleSuffix}`, content.render());
     }
 
-    fs.writeFileSync(`${output ?? 'API'}.${fileSuffix}`, await (await docs.toIndexMarkdown(submoduleSuffix, options)).render());
+    await fs.writeFile(`${output ?? 'API'}.${fileSuffix}`, await (await docs.toIndexMarkdown(submoduleSuffix, options)).render());
   } else {
     const content = await (format === 'md' ? docs.toMarkdown(options) : docs.toJson(options));
-    fs.writeFileSync(`${output ?? 'API'}.${fileSuffix}`, content.render());
+    await fs.writeFile(`${output ?? 'API'}.${fileSuffix}`, content.render());
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ type GenerateOptions = {
   output?: string;
 }
 
-async function generateForLanguage(docs: Documentation, options: GenerateOptions,) {
+async function generateForLanguage(docs: Documentation, options: GenerateOptions) {
   const { format, output = 'API' } = options;
   const fileSuffix = format === 'md' ? 'md' : 'json';
   let submoduleSuffix = fileSuffix;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,13 +8,41 @@ type GenerateOptions = {
   language: Language;
   submodule?: string;
   allSubmodules?: boolean;
+  splitBySubmodules?: boolean;
 }
 
 async function generateForLanguage(docs: Documentation, format: 'md' | 'json', options: GenerateOptions, output = 'API') {
-  const content = await (format === 'md' ? docs.toMarkdown(options) : docs.toJson(options));
   const fileSuffix = format === 'md' ? 'md' : 'json';
+  let submoduleSuffix = fileSuffix;
 
-  fs.writeFileSync(`${output ?? 'API'}.${fileSuffix}`, content.render());
+  // e.g. API.typescript as name
+  if (output.includes('.')) {
+    const languageSeperator = output.split('.')[1];
+    submoduleSuffix = `${languageSeperator}.${fileSuffix}`;
+  }
+
+  if (options.splitBySubmodules) {
+    if (format !== 'md') {
+      throw new Error('split-by-submodule is only supported for markdown');
+    }
+
+    const submodules = await docs.listSubmodules();
+    for (const submodule of submodules) {
+      const content = await docs.toMarkdown({
+        ...options,
+        submodule: submodule.name,
+        allSubmodules: false,
+        header: { title: `\`${submodule.name}\` Submodule`, id: submodule.fqn },
+      });
+
+      fs.writeFileSync(`${submodule.name}.${submoduleSuffix}`, content.render());
+    }
+
+    fs.writeFileSync(`${output ?? 'API'}.${fileSuffix}`, await (await docs.toIndexMarkdown(fileSuffix, options)).render());
+  } else {
+    const content = await (format === 'md' ? docs.toMarkdown(options) : docs.toJson(options));
+    fs.writeFileSync(`${output ?? 'API'}.${fileSuffix}`, content.render());
+  }
 }
 
 
@@ -26,16 +54,25 @@ export async function main() {
     .option('language', { array: true, alias: 'l', default: ['typescript'], choices: Language.values().map(x => x.toString()), desc: 'Output language' })
     .option('package', { alias: 'p', type: 'string', required: false, desc: 'The name@version of an NPM package to document', defaultDescription: 'The package in the current directory' })
     .option('submodule', { alias: 's', type: 'string', required: false, desc: 'Generate docs for a specific submodule (or "root")' })
+    .option('split-by-submodule', { type: 'boolean', required: false, desc: 'Generate a separate file for each submodule' })
     .example('$0', 'Generate documentation for the current module as a single file (auto-resolves node depedencies)')
     .argv;
 
 
   const submodule = args.submodule === 'root' ? undefined : args.submodule;
   const allSubmodules = !args.submodule;
+  const splitBySubmodules = args['split-by-submodule'];
   const docs = await (args.package
     ? Documentation.forPackage(args.package)
     : Documentation.forProject(process.cwd()));
-  const options = (lang: string) => ({ readme: false, language: Language.fromString(lang), submodule, allSubmodules });
+
+  const options = (lang: string): GenerateOptions => ({
+    readme: false,
+    language: Language.fromString(lang),
+    submodule,
+    allSubmodules,
+    splitBySubmodules,
+  });
 
   if (args.language.length <= 1) {
     await generateForLanguage(docs, args.format as 'md' | 'json', options(args.language[0]), args.output);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,29 +3,48 @@ import * as yargs from 'yargs';
 import { Language } from './docgen/transpile/transpile';
 import { Documentation } from './index';
 
+type GenerateOptions = {
+  readme?: boolean;
+  language: Language;
+  submodule?: string;
+  allSubmodules?: boolean;
+}
+
+async function generateForLanguage(docs: Documentation, format: 'md' | 'json', options: GenerateOptions, output = 'API') {
+  const content = await (format === 'md' ? docs.toMarkdown(options) : docs.toJson(options));
+  const fileSuffix = format === 'md' ? 'md' : 'json';
+
+  fs.writeFileSync(`${output ?? 'API'}.${fileSuffix}`, content.render());
+}
+
+
 export async function main() {
   const args = yargs
     .usage('Usage: $0')
-    .option('output', { alias: 'o', type: 'string', required: false, desc: 'Output filename (defaults to API.md if format is markdown, and API.json if format is JSON)' })
+    .option('output', { alias: 'o', type: 'string', required: false, desc: 'Output filename, the file type is automatically added. (defaults to API.md if format is markdown, and API.json if format is JSON and one language is passed, API.language.md and API.language.json if multilpe are passed)' })
     .option('format', { alias: 'f', default: 'md', choices: ['md', 'json'], desc: 'Output format, markdown or json' })
-    .option('language', { alias: 'l', default: 'typescript', choices: Language.values().map(x => x.toString()), desc: 'Output language' })
+    .option('language', { array: true, alias: 'l', default: ['typescript'], choices: Language.values().map(x => x.toString()), desc: 'Output language' })
     .option('package', { alias: 'p', type: 'string', required: false, desc: 'The name@version of an NPM package to document', defaultDescription: 'The package in the current directory' })
     .option('submodule', { alias: 's', type: 'string', required: false, desc: 'Generate docs for a specific submodule (or "root")' })
     .example('$0', 'Generate documentation for the current module as a single file (auto-resolves node depedencies)')
     .argv;
 
-  const language = Language.fromString(args.language);
+
   const submodule = args.submodule === 'root' ? undefined : args.submodule;
   const allSubmodules = !args.submodule;
   const docs = await (args.package
     ? Documentation.forPackage(args.package)
     : Documentation.forProject(process.cwd()));
-  const options = { readme: false, language, submodule, allSubmodules };
-  const fileSuffix = args.format === 'md' ? 'md' : 'json';
-  const output = args.output ?? `API.${fileSuffix}`;
+  const options = (lang: string) => ({ readme: false, language: Language.fromString(lang), submodule, allSubmodules });
 
-  const content = await (args.format === 'md' ? docs.toMarkdown(options) : docs.toJson(options));
-  fs.writeFileSync(output, content.render());
+  if (args.language.length <= 1) {
+    await generateForLanguage(docs, args.format as 'md' | 'json', options(args.language[0]), args.output);
+  } else {
+    for (const lang of args.language) {
+      const output = `${args.output ?? 'API'}.${lang}`;
+      await generateForLanguage(docs, args.format as 'md' | 'json', options(lang), output);
+    }
+  }
 }
 
 main().catch(e => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,7 @@ async function generateForLanguage(docs: Documentation, format: 'md' | 'json', o
 export async function main() {
   const args = yargs
     .usage('Usage: $0')
-    .option('output', { alias: 'o', type: 'string', required: false, desc: 'Output filename, the file type is automatically added. (defaults to API.md if format is markdown, and API.json if format is JSON and one language is passed, API.language.md and API.language.json if multilpe are passed)' })
+    .option('output', { alias: 'o', type: 'string', required: false, desc: 'Output filename, the file type is automatically added. Defaults to API.md if format is markdown (-f md) or API.json if format is JSON (-f json). If more than one language is passed, then the language will be included in the filename e.g. API.typescript.md' })
     .option('format', { alias: 'f', default: 'md', choices: ['md', 'json'], desc: 'Output format, markdown or json' })
     .option('language', { array: true, alias: 'l', default: ['typescript'], choices: Language.values().map(x => x.toString()), desc: 'Output language' })
     .option('package', { alias: 'p', type: 'string', required: false, desc: 'The name@version of an NPM package to document', defaultDescription: 'The package in the current directory' })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,9 +9,12 @@ type GenerateOptions = {
   submodule?: string;
   allSubmodules?: boolean;
   splitBySubmodules?: boolean;
+  format?: 'md' | 'json';
+  output?: string;
 }
 
-async function generateForLanguage(docs: Documentation, format: 'md' | 'json', options: GenerateOptions, output = 'API') {
+async function generateForLanguage(docs: Documentation, options: GenerateOptions,) {
+  const { format, output = 'API' } = options;
   const fileSuffix = format === 'md' ? 'md' : 'json';
   let submoduleSuffix = fileSuffix;
 
@@ -66,20 +69,22 @@ export async function main() {
     ? Documentation.forPackage(args.package)
     : Documentation.forProject(process.cwd()));
 
-  const options = (lang: string): GenerateOptions => ({
+  const options = (lang: string, output?: string): GenerateOptions => ({
     readme: false,
     language: Language.fromString(lang),
     submodule,
     allSubmodules,
     splitBySubmodules,
+    format: args.format as 'md' | 'json',
+    output,
   });
 
   if (args.language.length <= 1) {
-    await generateForLanguage(docs, args.format as 'md' | 'json', options(args.language[0]), args.output);
+    await generateForLanguage(docs, options(args.language[0], args.output));
   } else {
     for (const lang of args.language) {
       const output = `${args.output ?? 'API'}.${lang}`;
-      await generateForLanguage(docs, args.format as 'md' | 'json', options(lang), output);
+      await generateForLanguage(docs, options(lang, output));
     }
   }
 }

--- a/src/docgen/render/markdown-render.ts
+++ b/src/docgen/render/markdown-render.ts
@@ -1,6 +1,7 @@
 import { MarkdownDocument } from './markdown-doc';
 import { ApiReferenceSchema, AssemblyMetadataSchema, ClassSchema, ConstructSchema, EnumMemberSchema, EnumSchema, InitializerSchema, InterfaceSchema, JsiiEntity, MethodSchema, ParameterSchema, PropertySchema, Schema, CURRENT_SCHEMA_VERSION, StructSchema, TypeSchema } from '../schema';
 import { Language } from '../transpile/transpile';
+import * as reflect from 'jsii-reflect';
 
 export interface MarkdownFormattingOptions {
   /**
@@ -51,6 +52,9 @@ export interface MarkdownFormattingOptions {
     metadata: AssemblyMetadataSchema,
     linkFormatter: (type: JsiiEntity, metadata: AssemblyMetadataSchema) => string
   ) => string;
+
+
+  readonly header?: {title: string; id: string};
 }
 
 export interface MarkdownRendererOptions extends MarkdownFormattingOptions, AssemblyMetadataSchema {
@@ -99,8 +103,27 @@ export class MarkdownRenderer {
         language: Language.fromString(schema.language),
         ...schema.metadata,
       });
-      documentation.section(renderer.visitApiReference(schema.apiReference));
+
+      documentation.section(renderer.visitApiReference(schema.apiReference, options.header));
     }
+
+    return documentation;
+  }
+
+  public static fromSubmodules(submodules: readonly reflect.Submodule[], fileSuffix: string, options: MarkdownRendererOptions): MarkdownDocument {
+    const documentation = new MarkdownDocument();
+
+    const renderer = new MarkdownRenderer({
+      anchorFormatter: options.anchorFormatter,
+      linkFormatter: options.linkFormatter,
+      typeFormatter: options.typeFormatter,
+      language: options.language,
+      packageName: options.packageName,
+      packageVersion: options.packageVersion,
+    });
+
+    const apiRef = renderer.visitSubmodules(submodules, fileSuffix);
+    documentation.section(apiRef);
 
     return documentation;
   }
@@ -123,10 +146,20 @@ export class MarkdownRenderer {
     };
   }
 
+  public visitSubmodules(submodules: readonly reflect.Submodule[], fileSuffix: string): MarkdownDocument {
+    const md = new MarkdownDocument({ header: { title: 'Submodules' }, id: 'submodules' });
+    md.lines('The following submodules are available:');
+    for (const submodule of submodules) {
+      md.lines(`- [${submodule.name}](./${submodule.name}.${fileSuffix})`);
+    }
+    return md;
+  }
+
   public visitApiReference(
     apiRef: ApiReferenceSchema,
+    header: {title: string; id: string} = { title: 'API Reference', id: 'api-reference' },
   ): MarkdownDocument {
-    const md = new MarkdownDocument({ header: { title: 'API Reference' }, id: 'api-reference' });
+    const md = new MarkdownDocument({ header: { title: header.title }, id: header.id });
     md.section(this.visitConstructs(apiRef.constructs));
     md.section(this.visitStructs(apiRef.structs));
     md.section(this.visitClasses(apiRef.classes));

--- a/src/docgen/render/markdown-render.ts
+++ b/src/docgen/render/markdown-render.ts
@@ -1,7 +1,7 @@
+import * as reflect from 'jsii-reflect';
 import { MarkdownDocument } from './markdown-doc';
 import { ApiReferenceSchema, AssemblyMetadataSchema, ClassSchema, ConstructSchema, EnumMemberSchema, EnumSchema, InitializerSchema, InterfaceSchema, JsiiEntity, MethodSchema, ParameterSchema, PropertySchema, Schema, CURRENT_SCHEMA_VERSION, StructSchema, TypeSchema } from '../schema';
 import { Language } from '../transpile/transpile';
-import * as reflect from 'jsii-reflect';
 
 export interface MarkdownFormattingOptions {
   /**

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -190,6 +190,24 @@ export class Documentation {
   ) {}
 
   /**
+   * List all submodules in the assembly.
+   */
+  public async listSubmodules() {
+    const tsAssembly = await this.createAssembly(undefined, { loose: true, validate: false });
+    return tsAssembly.submodules;
+  }
+
+  public async toIndexMarkdown(fileSuffix:string, options: RenderOptions) {
+    const assembly = await this.createAssembly(undefined, { loose: true, validate: false });
+
+    return MarkdownRenderer.fromSubmodules(await this.listSubmodules(), fileSuffix, {
+      ...options,
+      packageName: assembly.name,
+      packageVersion: assembly.version,
+    });
+  }
+
+  /**
    * Generate markdown.
    */
   public async toJson(options: RenderOptions): Promise<Json<Schema>> {
@@ -260,6 +278,7 @@ export class Documentation {
       anchorFormatter: options.anchorFormatter,
       linkFormatter: options.linkFormatter,
       typeFormatter: options.typeFormatter,
+      header: options.header,
     });
   }
 


### PR DESCRIPTION
This is how the result might look like in the context of cdktf: https://github.com/cdktf/cdktf-provider-random/blob/split-up-docs/API.md

I'm requesting feedback early here, I'll add more docs when you folks are happy with the overall concept.