### PR TITLE
chore: fix workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       self_mutation_happened: ${{ steps.self_mutation.outputs.self_mutation_happened }}
     env:
       CI: "true"
+      NODE_OPTIONS: --max_old_space_size=4096
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       latest_commit: ${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: "true"
+      NODE_OPTIONS: --max_old_space_size=4096
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -48,6 +48,7 @@ const project = new typescript.TypeScriptProject({
 });
 
 project.github.tryFindWorkflow('release').file.patch(JsonPatch.add('/jobs/release/env/NODE_OPTIONS', '--max_old_space_size=4096'));
+project.github.tryFindWorkflow('build').file.patch(JsonPatch.add('/jobs/build/env/NODE_OPTIONS', '--max_old_space_size=4096'));
 
 const libraryFixtures = ['construct-library'];
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,4 +1,4 @@
-const { typescript } = require('projen');
+const { typescript, JsonPatch } = require('projen');
 
 const project = new typescript.TypeScriptProject({
   name: 'jsii-docgen',
@@ -46,6 +46,8 @@ const project = new typescript.TypeScriptProject({
     },
   },
 });
+
+project.github.tryFindWorkflow('release').file.patch(JsonPatch.add('/jobs/release/env/NODE_OPTIONS', '--max_old_space_size=4096'));
 
 const libraryFixtures = ['construct-library'];
 


### PR DESCRIPTION
The build step in both the build & release workflows is currently failing with the error
```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

This PR attempts to fix that by setting the env variable `NODE_OPTIONS=--max_old_space_size=4096`

Fixes #