### PR TITLE
fix: support hoisted dependencies

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeProfile" value="profile:default" />
+    <option name="activeRegion" value="ap-southeast-2" />
+    <option name="recentlyUsedProfiles">
+      <list>
+        <option value="profile:default" />
+      </list>
+    </option>
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="ap-southeast-2" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/jsii-docgen.iml
+++ b/.idea/jsii-docgen.iml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/node_modules/conventional-changelog-eslint/templates" />
+      </list>
+    </option>
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/jsii-docgen.iml" filepath="$PROJECT_DIR$/.idea/jsii-docgen.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -37,7 +37,11 @@ const project = new typescript.TypeScriptProject({
   autoApproveUpgrades: true,
 
   minNodeVersion: '14.17.0',
-
+  jestOptions: {
+    jestConfig: {
+      setupFilesAfterEnv: ['<rootDir>/test/setup-jest.ts'],
+    },
+  },
   tsconfig: {
     compilerOptions: {
       target: 'ES2019',

--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
   "license": "Apache-2.0",
   "version": "0.0.0",
   "jest": {
+    "setupFilesAfterEnv": [
+      "<rootDir>/test/setup-jest.ts"
+    ],
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",
       "<rootDir>/(test|src)/**/*(*.)@(spec|test).ts?(x)"

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -340,7 +340,7 @@ export class Documentation {
       await fs.copy(this.assembliesDir, workdir);
 
       const ts = new reflect.TypeSystem();
-      for (let dotJsii of await glob.promise(`${workdir}/**/${SPEC_FILE_NAME}`)) {
+      for (let dotJsii of await glob.promise(`${this.assembliesDir}/**/${SPEC_FILE_NAME}`)) {
         // we only transliterate the top level assembly and not the entire type-system.
         // note that the only reason to translate dependant assemblies is to show code examples
         // for expanded python arguments - which we don't to right now anyway.
@@ -350,11 +350,12 @@ export class Documentation {
         if (language && spec.name === this.assemblyName) {
           const packageDir = path.dirname(dotJsii);
           try {
-            await transliterateAssembly([packageDir], [language], { loose: options.loose, unknownSnippets: UnknownSnippetMode.FAIL });
+            await transliterateAssembly([packageDir], [language],
+              { loose: options.loose, unknownSnippets: UnknownSnippetMode.FAIL, outdir: workdir });
           } catch (e: any) {
             throw new LanguageNotSupportedError(`Laguage ${language} is not supported for package ${this.assemblyFqn} (cause: ${e.message})`);
           }
-          dotJsii = path.join(packageDir, `${SPEC_FILE_NAME}.${language}`);
+          dotJsii = path.join(workdir, `${SPEC_FILE_NAME}.${language}`);
         }
         await ts.load(dotJsii, { validate: options.validate });
       }

--- a/test/docgen/transpile/transpile.test.ts
+++ b/test/docgen/transpile/transpile.test.ts
@@ -2,8 +2,6 @@ import { Documentation } from '../../../src';
 import { Language } from '../../../src/docgen/transpile/transpile';
 import { Assemblies } from '../assemblies';
 
-jest.setTimeout(60000);
-
 describe('language', () => {
 
   test('typescript is supported', () => {

--- a/test/docgen/view/documentation.test.ts
+++ b/test/docgen/view/documentation.test.ts
@@ -8,10 +8,6 @@ import { Assemblies } from '../assemblies';
 
 const LIBRARIES = `${__dirname}/../../__fixtures__/libraries`;
 
-// this is a little concerning...we should be mindful
-// if need to keep increasing this.
-jest.setTimeout(120 * 1000);
-
 describe('extractPackageName', () => {
 
   test('scope only', () => {

--- a/test/docgen/view/markdown.test.ts
+++ b/test/docgen/view/markdown.test.ts
@@ -1,8 +1,6 @@
 import { Documentation, Language } from '../../../src';
 import { JsiiEntity } from '../../../src/docgen/schema';
 
-jest.setTimeout(60 * 1000);
-
 describe('simple link formatter', () => {
   test.each(Language.values())('%s snapshot', async (language) => {
     const docs = await Documentation.forPackage(language === Language.GO ? 'constructs@10.0.78' : '@aws-cdk/aws-ecr@1.106.0');

--- a/test/setup-jest.ts
+++ b/test/setup-jest.ts
@@ -1,0 +1,4 @@
+// Transient errors can occur when executing some tests in parallel i.e. ENOENT: no such file or directory.
+jest.retryTimes(2);
+
+jest.setTimeout(300 * 1000);


### PR DESCRIPTION
This PR is a updated revision of: https://github.com/cdklabs/jsii-docgen/pull/644

Removes copy of the project directory and instead only outputs
transliterated assemblies to the working directory. This avoids
potential problems when generating docs for packages that may have some
dependencies that are symlinks, such as those in a monorepo.

Fixes #390 