### PR TITLE
chore: fix language option list

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Curreently jsii-docgen supports generating documentation in the following langua
 - TypeScript (`typescript`)
 - Python (`python`)
 - Java (`java`)
-- C# (`csharp` or `dotnet`)
+- C# (`csharp`)
+- Go (`go`)
 
 
 ## CLI Options
@@ -37,7 +38,7 @@ Curreently jsii-docgen supports generating documentation in the following langua
 | :------------------ | :------- | :------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--output`, `-o`    | optional | Output filename (defaults to API.md if format is markdown, and API.json if format is JSON). <br /><br />`jsii-docgen -o ./docs/API.md`       |
 | `--format`, `-f`    | optional | Output format. Can be `markdown` or `json`. <br /><br />`jsii-docgen -f json`                                                                |
-| `--language`, `-l`  | optional | Language to generate documentation for. Can be `typescript`, `python`, `java`, `csharp` or `dotnet`. <br /><br />`jsii-docgen -l typescript` |
+| `--language`, `-l`  | optional | Language to generate documentation for. Can be `typescript`, `python`, `java`, `csharp` or `go`. <br /><br />`jsii-docgen -l typescript` |
 | `--package`, `-p`   | optional | The name@version of an NPM package to document. <br /><br />`jsii-docgen -p my-package`                                                      |
 | `--submodule`, `-s` | optional | Generate docs for a specific submodule or "root". <br /><br />`jsii-docgen -s my-submodule`                                                  |
 


### PR DESCRIPTION
Thanks for this awesome tool!

 I noticed that the language options appeared to be incorrect:

1) `dotnet` doesn't seem to be accepted:

```
$ npx jsii-docgen -l dotnet
...
Invalid values:
  Argument: language, Given: "dotnet", Choices: "typescript", "python", "java", "csharp", "go"
```
2) `go` does appear to be accepted
  
This PR updates the readme to match the behaviour of the tool.