### PR TITLE
fix: dependencies not loaded in the type system

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,7 +65,6 @@ export async function main() {
     .example('$0', 'Generate documentation for the current module as a single file (auto-resolves node depedencies)')
     .argv;
 
-
   const submodule = args.submodule === 'root' ? undefined : args.submodule;
   const allSubmodules = !args.submodule;
   const readme = args.readme;


### PR DESCRIPTION
When a dependency is not found in a directory nested within the package's root (such as hoisted dependencies in mono-repos), it was not resolved or loaded into the `jsii-reflect` type system, causing errors when any type from such a dependency is needed (e.g: when determining if some class is a `Construct` or not, etc...).

This PR adds the necessary code to proactively attempt resolving dependencies using `require.resolve` and loading them into the type system, so they are available when the doc generator needs their types. The resolution of dependencies may silently fail, in which case the type system will not have the corresponding assembly, but this is only an issue if types from the dependency are needed during doc-gen, and an appropriate error message is generated at that time.

Fixes #1031