### PR TITLE
fix: optional dependencies can break npm install

### DIFF
--- a/src/docgen/view/_npm.ts
+++ b/src/docgen/view/_npm.ts
@@ -52,7 +52,7 @@ export class Npm {
         await this.npmCommandPath(),
         [
           'install',
-          target,
+          JSON.stringify(target),
           ...commonFlags,
           // ensures we are installing devDependencies, too.
           '--include=dev',
@@ -115,7 +115,7 @@ export class Npm {
       if (version == null) {
         continue;
       }
-      result.push(`${name}@${version}`);
+      result.push(JSON.stringify(`${name}@${version}`));
     }
 
     return result;


### PR DESCRIPTION
Optional dependency version specifiers may include white space, `<` and `>`, amonh other things, which break shell parsing of the command arguments if not properly quoted.
