### PR TITLE
feat: support older versions of jsii-rosetta

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,4 +105,5 @@ jobs:
     strategy:
       matrix:
         rosetta:
+          - 5.0.14
           - 5.1.2

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -59,7 +59,7 @@
     },
     {
       "name": "jsii-rosetta",
-      "version": "~5.1.2",
+      "version": "~5.0.14 || ~5.1.2",
       "type": "build"
     },
     {
@@ -90,7 +90,7 @@
     },
     {
       "name": "jsii-rosetta",
-      "version": "~5.1.2",
+      "version": "~5.0.14 || ~5.1.2",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -62,7 +62,8 @@ project.tasks.addEnvironment('JSII_SUPPRESS_UPGRADE_PROMPT', 'true');
 
 new RosettaPeerDependency(project, {
   supportedVersions: {
-    [RosettaVersionLines.V5_0]: false,
+    [RosettaVersionLines.V1_X]: false,
+    [RosettaVersionLines.V5_0]: '~5.0.14',
     [RosettaVersionLines.V5_1]: '~5.1.2',
   },
 });

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-import": "^2.27.5",
     "jest": "^29",
     "jest-junit": "^15",
-    "jsii-rosetta": "~5.1.2",
+    "jsii-rosetta": "~5.0.14 || ~5.1.2",
     "npm-check-updates": "^16",
     "projen": "^0.71.122",
     "standard-version": "^9",
@@ -58,7 +58,7 @@
     "typescript": "~5.1.6"
   },
   "peerDependencies": {
-    "jsii-rosetta": "~5.1.2"
+    "jsii-rosetta": "~5.0.14 || ~5.1.2"
   },
   "dependencies": {
     "@jsii/spec": "^1.84.0",

--- a/projenrc/rosetta.ts
+++ b/projenrc/rosetta.ts
@@ -4,6 +4,7 @@ import { minVersion } from 'semver';
 const JSII_ROSETTA = 'jsii-rosetta';
 
 export enum RosettaVersionLines {
+  V1_X,
   V5_0,
   V5_1,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3818,7 +3818,7 @@ jsii-reflect@^1.84.0:
     oo-ascii-tree "^1.84.0"
     yargs "^16.2.0"
 
-jsii-rosetta@~5.1.2:
+"jsii-rosetta@~5.0.14 || ~5.1.2":
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-5.1.4.tgz#42f6d7c9feff5f70024e070a90dfe5bbe05f4be9"
   integrity sha512-BZkoRsKgPJtBBvQ2FFh+AJxOhQ41enwPUvqlrbAYofsqPzljWM6O2WyYNziXhAG6cIPrIqoQzxzSAQ9VnIXv5A==


### PR DESCRIPTION
Required fixes has been released to `jsii-rosetta@5.0.x` so this is now an acceptable peer dependency.