### PR TITLE
fix(npm): incorrect error when installing a package that was removed from npm

### DIFF
--- a/src/docgen/view/_npm.ts
+++ b/src/docgen/view/_npm.ts
@@ -290,6 +290,7 @@ function assertSuccess(result: CommandResult<ResponseObject>): asserts result is
     case 'E404': // package (or dependency) can't be found on NPM. This can happen if the package depends on a deprecated package (for example).
     case 'EOVERRIDE': // Package contains some version overrides that conflict.
     case 'ERESOLVE': // dependency resolution problem requires a manual intervention (most likely...)
+    case 'ENOVERSIONS': // package has been removed from npm
       throw new UnInstallablePackageError(message);
     default:
       throw new NpmError(message, stdout, code);

--- a/test/docgen/view/_npm.test.ts
+++ b/test/docgen/view/_npm.test.ts
@@ -54,7 +54,7 @@ test('NpmError error (with JSON error code)', async () => {
   }
 });
 
-test('NpmError error (removed package)', async () => {
+test('NpmError error (removed package no code)', async () => {
   // GIVEN
   const npm = new Npm(TMPDIR, () => void 0, 'mock-npm');
 
@@ -65,6 +65,33 @@ test('NpmError error (removed package)', async () => {
       Buffer.from('  "error": {\n'),
       Buffer.from('    "code": null,\n'),
       Buffer.from('    "summary": "Cannot convert undefined or null to object",\n'),
+      Buffer.from('    "detail": ""\n'),
+      Buffer.from('  }\n'),
+      Buffer.from('}\n'),
+    ],
+  });
+  mockSpawn.mockReturnValue(mockChildProcess);
+
+  // THEN
+  try {
+    await npm.install('foo');
+    fail('Expected an NpmError!');
+  } catch (err) {
+    expect(err).toBeInstanceOf(UnInstallablePackageError);
+  }
+});
+
+test('NpmError error (removed package ENOVERSIONS)', async () => {
+  // GIVEN
+  const npm = new Npm(TMPDIR, () => void 0, 'mock-npm');
+
+  // WHEN
+  const mockChildProcess = new MockChildProcess(1, {
+    stdout: [
+      Buffer.from('{\n'),
+      Buffer.from('  "error": {\n'),
+      Buffer.from('    "code": "ENOVERSIONS",\n'),
+      Buffer.from('    "summary": "No versions available for foo",\n'),
       Buffer.from('    "detail": ""\n'),
       Buffer.from('  }\n'),
       Buffer.from('}\n'),


### PR DESCRIPTION
Apparently, in addition to https://github.com/cdklabs/jsii-docgen/pull/821, there is another scenario that signals a package was removed from npm.

This might be an NPM version variation. Either case, we should cover it. 

Detected by seeing messages like these in our construct hub DLQ:

```console
Command \\\"npm install \\\"/tmp/packages-iyRZ9T/package.tgz\\\" --ignore-scripts --no-autit --no-bin-links --no-package-lock --json --include=dev --include=peer --include=optional --save\\\" exited with code 1: No versions available for aws-secure-bucket\",\"name\":\"jsii-docgen.NpmError.ENOVERSIONS\",\"stack\":\"jsii-docgen.NpmError.ENOVERSIONS
```