### PR TITLE
feat: handle nested submodules

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'node:path';
 import * as yargs from 'yargs';
-import { Language } from './docgen/transpile/transpile';
+import { Language, submoduleRelName } from './docgen/transpile/transpile';
 import { Documentation } from './index';
 
 type GenerateOptions = {
@@ -41,12 +41,12 @@ async function generateForLanguage(docs: Documentation, options: GenerateOptions
     for (const submodule of submodules) {
       const content = await docs.toMarkdown({
         ...options,
-        submodule: submodule.name,
+        submoduleFqn: submodule.fqn,
         allSubmodules: false,
-        header: { title: `\`${submodule.name}\` Submodule`, id: submodule.fqn },
+        header: { title: `\`${submoduleRelName(submodule)}\` Submodule`, id: submodule.fqn },
       });
 
-      await fs.writeFile(path.join(outputPath, `${submodule.name}.${submoduleSuffix}`), content.render());
+      await fs.writeFile(path.join(outputPath, `${submoduleRelName(submodule)}.${submoduleSuffix}`), content.render());
     }
 
     await fs.writeFile(`${outputFileName}.${fileSuffix}`, await (await docs.toIndexMarkdown(submoduleSuffix, options)).render());
@@ -102,3 +102,4 @@ main().catch(e => {
   console.error(e);
   process.exit(1);
 });
+

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,7 @@ async function generateForLanguage(docs: Documentation, options: GenerateOptions
     for (const submodule of submodules) {
       const content = await docs.toMarkdown({
         ...options,
-        submoduleFqn: submodule.fqn,
+        submodule: submodule.fqn,
         allSubmodules: false,
         header: { title: `\`${submoduleRelName(submodule)}\` Submodule`, id: submodule.fqn },
       });

--- a/src/docgen/render/markdown-render.ts
+++ b/src/docgen/render/markdown-render.ts
@@ -1,7 +1,7 @@
 import * as reflect from 'jsii-reflect';
 import { MarkdownDocument } from './markdown-doc';
 import { ApiReferenceSchema, AssemblyMetadataSchema, ClassSchema, ConstructSchema, EnumMemberSchema, EnumSchema, InitializerSchema, InterfaceSchema, JsiiEntity, MethodSchema, ParameterSchema, PropertySchema, Schema, CURRENT_SCHEMA_VERSION, StructSchema, TypeSchema } from '../schema';
-import { Language } from '../transpile/transpile';
+import { Language, submoduleRelName } from '../transpile/transpile';
 
 export interface MarkdownFormattingOptions {
   /**
@@ -150,7 +150,7 @@ export class MarkdownRenderer {
     const md = new MarkdownDocument({ header: { title: 'Submodules' }, id: 'submodules' });
     md.lines('The following submodules are available:');
     for (const submodule of submodules) {
-      md.lines(`- [${submodule.name}](./${submodule.name}.${fileSuffix})`);
+      md.lines(`- [${submoduleRelName(submodule)}](./${submoduleRelName(submodule)}.${fileSuffix})`);
     }
     return md;
   }

--- a/src/docgen/transpile/transpile.ts
+++ b/src/docgen/transpile/transpile.ts
@@ -847,7 +847,7 @@ export abstract class TranspileBase implements Transpile {
       // if the type is in a submodule, the submodule name is the first
       // part of the namespace. we construct the full submodule fqn and search for it.
       const submoduleFqn = `${type.assembly.name}.${type.namespace.split('.')[0]}`;
-      const submodules = type.assembly.submodules.filter(
+      const submodules = type.assembly.allSubmodules.filter(
         (s) => s.fqn === submoduleFqn,
       );
 
@@ -893,4 +893,13 @@ export abstract class TranspileBase implements Transpile {
     }
     return 0;
   }
+}
+
+/**
+ * Return the root-relative name for a submodule
+ *
+ * Ex: for a submodule `asm.sub1.sub2`, return `sub1.sub2`.
+ */
+export function submoduleRelName(submodule: reflect.Submodule) {
+  return submodule.fqn.split('.').slice(1).join('.');
 }

--- a/src/docgen/view/api-reference.ts
+++ b/src/docgen/view/api-reference.ts
@@ -26,9 +26,9 @@ export class ApiReference {
     let interfaces: reflect.InterfaceType[];
     let enums: reflect.EnumType[];
     if (allSubmodules ?? false) {
-      classes = this.sortByName([...assembly.classes, ...flatMap(assembly.submodules, submod => [...submod.classes])]);
-      interfaces = this.sortByName([...assembly.interfaces, ...flatMap(assembly.submodules, submod => [...submod.interfaces])]);
-      enums = this.sortByName([...assembly.enums, ...flatMap(assembly.submodules, submod => [...submod.enums])]);
+      classes = this.sortByName([...assembly.classes, ...flatMap(assembly.allSubmodules, submod => [...submod.classes])]);
+      interfaces = this.sortByName([...assembly.interfaces, ...flatMap(assembly.allSubmodules, submod => [...submod.interfaces])]);
+      enums = this.sortByName([...assembly.enums, ...flatMap(assembly.allSubmodules, submod => [...submod.enums])]);
     } else {
       classes = this.sortByName(submodule ? submodule.classes : assembly.classes);
       interfaces = this.sortByName(submodule ? submodule.interfaces : assembly.interfaces);

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -50,16 +50,8 @@ export interface RenderOptions extends TransliterationOptions {
    * Generate documentation only for a specific submodule.
    *
    * @default - Documentation is generated for the root module only.
-   * @deprecated Prefer `submoduleFqn`.
    */
   readonly submodule?: string;
-
-  /**
-   * Generate documentation only for a specific submodule, identified by its FQN
-   *
-   * @default - Documentation is generated for the root module only.
-   */
-  readonly submoduleFqn?: string;
 
   /**
    * Generate a single document with APIs from all assembly submodules
@@ -242,10 +234,7 @@ export class Documentation {
       throw new LanguageNotSupportedError(`Laguage ${language} is not supported for package ${this.assemblyFqn}`);
     }
 
-    if (options?.submoduleFqn && options.submoduleFqn) {
-      throw new Error('Supply at most one of \'submodule\' and \'submoduleFqn\'');
-    }
-    let submoduleStr = options.submoduleFqn ?? options.submodule;
+    let submoduleStr = options.submodule;
 
     if (allSubmodules && submoduleStr) {
       throw new Error('Cannot call toJson with allSubmodules and a specific submodule both selected.');
@@ -339,6 +328,10 @@ export class Documentation {
    * root-relative submodule name as well (`sub1.sub2`).
    */
   private findSubmodule(assembly: reflect.Assembly, submodule: string): reflect.Submodule {
+    // If 'submodule' does not have a '.' in it, we know exactly what is intended.
+
+
+
     const fqnSubs = assembly.allSubmodules.filter(
       (s) => s.fqn === submodule,
     );

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -312,22 +312,29 @@ export class Documentation {
   }
 
   /**
-   * Lookup a submodule by a submodule name.
+   * Lookup a submodule by a submodule name. To look up a nested submodule, encode it as a
+   * dot-separated path, e.g., 'top-level-module.nested-module.another-nested-one'.
    */
   private findSubmodule(assembly: reflect.Assembly, submodule: string): reflect.Submodule {
-    const submodules = assembly.submodules.filter(
-      (s) => s.name === submodule,
-    );
+    type ReflectSubmodules = typeof assembly.submodules;
+    return recurse(submodule.split('.'), assembly.submodules);
 
-    if (submodules.length === 0) {
-      throw new Error(`Submodule ${submodule} not found in assembly ${assembly.name}@${assembly.version}`);
+    function recurse(names: string[], submodules: ReflectSubmodules): reflect.Submodule {
+      const [head, ...tail] = names;
+      const found = submodules.filter(
+        (s) => s.name === head,
+      );
+
+      if (found.length === 0) {
+        throw new Error(`Submodule ${submodule} not found in assembly ${assembly.name}@${assembly.version}`);
+      }
+
+      if (found.length > 1) {
+        throw new Error(`Found multiple submodules with name: ${submodule} in assembly ${assembly.name}@${assembly.version}`);
+      }
+
+      return tail.length === 0 ? found[0] : recurse(tail, found[0].submodules);
     }
-
-    if (submodules.length > 1) {
-      throw new Error(`Found multiple submodules with name: ${submodule} in assembly ${assembly.name}@${assembly.version}`);
-    }
-
-    return submodules[0];
   }
 
   private async createAssembly(

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -328,10 +328,6 @@ export class Documentation {
    * root-relative submodule name as well (`sub1.sub2`).
    */
   private findSubmodule(assembly: reflect.Assembly, submodule: string): reflect.Submodule {
-    // If 'submodule' does not have a '.' in it, we know exactly what is intended.
-
-
-
     const fqnSubs = assembly.allSubmodules.filter(
       (s) => s.fqn === submodule,
     );

--- a/test/__fixtures__/assemblies/cdk-nag@2.27.179/.jsii
+++ b/test/__fixtures__/assemblies/cdk-nag@2.27.179/.jsii
@@ -1,0 +1,6719 @@
+{
+  "author": {
+    "email": "donti@amazon.com",
+    "name": "Arun Donti",
+    "roles": [
+      "author"
+    ]
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.78.0",
+    "constructs": "^10.0.5"
+  },
+  "dependencyClosure": {
+    "@aws-cdk/asset-awscli-v1": {
+      "targets": {
+        "dotnet": {
+          "namespace": "Amazon.CDK.Asset.AwsCliV1",
+          "packageId": "Amazon.CDK.Asset.AwsCliV1"
+        },
+        "go": {
+          "moduleName": "github.com/cdklabs/awscdk-asset-awscli-go",
+          "packageName": "awscliv1"
+        },
+        "java": {
+          "maven": {
+            "artifactId": "cdk-asset-awscli-v1",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.cdk.asset.awscli.v1"
+        },
+        "js": {
+          "npm": "@aws-cdk/asset-awscli-v1"
+        },
+        "python": {
+          "distName": "aws-cdk.asset-awscli-v1",
+          "module": "aws_cdk.asset_awscli_v1"
+        }
+      }
+    },
+    "@aws-cdk/asset-kubectl-v20": {
+      "targets": {
+        "dotnet": {
+          "namespace": "Amazon.CDK.Asset.KubectlV20",
+          "packageId": "Amazon.CDK.Asset.KubectlV20"
+        },
+        "go": {
+          "moduleName": "github.com/cdklabs/awscdk-asset-kubectl-go",
+          "packageName": "kubectlv20"
+        },
+        "java": {
+          "maven": {
+            "artifactId": "cdk-asset-kubectl-v20",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.cdk.asset.kubectl.v20"
+        },
+        "js": {
+          "npm": "@aws-cdk/asset-kubectl-v20"
+        },
+        "python": {
+          "distName": "aws-cdk.asset-kubectl-v20",
+          "module": "aws_cdk.asset_kubectl_v20"
+        }
+      }
+    },
+    "@aws-cdk/asset-node-proxy-agent-v5": {
+      "targets": {
+        "dotnet": {
+          "namespace": "Amazon.CDK.Asset.NodeProxyAgentV5",
+          "packageId": "Amazon.CDK.Asset.NodeProxyAgentV5"
+        },
+        "go": {
+          "moduleName": "github.com/cdklabs/awscdk-asset-node-proxy-agent-go",
+          "packageName": "nodeproxyagentv5"
+        },
+        "java": {
+          "maven": {
+            "artifactId": "cdk-asset-node-proxy-agent-v5",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk.cdk.asset.node.proxy.agent.v5"
+        },
+        "js": {
+          "npm": "@aws-cdk/asset-node-proxy-agent-v5"
+        },
+        "python": {
+          "distName": "aws-cdk.asset-node-proxy-agent-v5",
+          "module": "aws_cdk.asset_node_proxy_agent_v5"
+        }
+      }
+    },
+    "aws-cdk-lib": {
+      "submodules": {
+        "aws-cdk-lib.alexa_ask": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Alexa.Ask"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.alexa.ask"
+            },
+            "python": {
+              "module": "aws_cdk.alexa_ask"
+            }
+          }
+        },
+        "aws-cdk-lib.assertions": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Assertions"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.assertions"
+            },
+            "python": {
+              "module": "aws_cdk.assertions"
+            }
+          }
+        },
+        "aws-cdk-lib.assets": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Assets"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.assets"
+            },
+            "python": {
+              "module": "aws_cdk.assets"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_accessanalyzer": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AccessAnalyzer"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.accessanalyzer"
+            },
+            "python": {
+              "module": "aws_cdk.aws_accessanalyzer"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_acmpca": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ACMPCA"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.acmpca"
+            },
+            "python": {
+              "module": "aws_cdk.aws_acmpca"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_amazonmq": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AmazonMQ"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.amazonmq"
+            },
+            "python": {
+              "module": "aws_cdk.aws_amazonmq"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_amplify": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Amplify"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.amplify"
+            },
+            "python": {
+              "module": "aws_cdk.aws_amplify"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_amplifyuibuilder": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AmplifyUIBuilder"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.amplifyuibuilder"
+            },
+            "python": {
+              "module": "aws_cdk.aws_amplifyuibuilder"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_apigateway": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.APIGateway"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.apigateway"
+            },
+            "python": {
+              "module": "aws_cdk.aws_apigateway"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_apigatewayv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Apigatewayv2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.apigatewayv2"
+            },
+            "python": {
+              "module": "aws_cdk.aws_apigatewayv2"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_appconfig": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AppConfig"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.appconfig"
+            },
+            "python": {
+              "module": "aws_cdk.aws_appconfig"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_appflow": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AppFlow"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.appflow"
+            },
+            "python": {
+              "module": "aws_cdk.aws_appflow"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_appintegrations": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AppIntegrations"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.appintegrations"
+            },
+            "python": {
+              "module": "aws_cdk.aws_appintegrations"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_applicationautoscaling": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ApplicationAutoScaling"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.applicationautoscaling"
+            },
+            "python": {
+              "module": "aws_cdk.aws_applicationautoscaling"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_applicationinsights": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ApplicationInsights"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.applicationinsights"
+            },
+            "python": {
+              "module": "aws_cdk.aws_applicationinsights"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_appmesh": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AppMesh"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.appmesh"
+            },
+            "python": {
+              "module": "aws_cdk.aws_appmesh"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_apprunner": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AppRunner"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.apprunner"
+            },
+            "python": {
+              "module": "aws_cdk.aws_apprunner"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_appstream": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AppStream"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.appstream"
+            },
+            "python": {
+              "module": "aws_cdk.aws_appstream"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_appsync": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AppSync"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.appsync"
+            },
+            "python": {
+              "module": "aws_cdk.aws_appsync"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_aps": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.APS"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.aps"
+            },
+            "python": {
+              "module": "aws_cdk.aws_aps"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_athena": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Athena"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.athena"
+            },
+            "python": {
+              "module": "aws_cdk.aws_athena"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_auditmanager": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AuditManager"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.auditmanager"
+            },
+            "python": {
+              "module": "aws_cdk.aws_auditmanager"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_autoscaling": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AutoScaling"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.autoscaling"
+            },
+            "python": {
+              "module": "aws_cdk.aws_autoscaling"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_autoscaling_common": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AutoScaling.Common"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.autoscaling.common"
+            },
+            "python": {
+              "module": "aws_cdk.aws_autoscaling_common"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_autoscaling_hooktargets": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AutoScaling.HookTargets"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.autoscaling.hooktargets"
+            },
+            "python": {
+              "module": "aws_cdk.aws_autoscaling_hooktargets"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_autoscalingplans": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.AutoScalingPlans"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.autoscalingplans"
+            },
+            "python": {
+              "module": "aws_cdk.aws_autoscalingplans"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_backup": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Backup"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.backup"
+            },
+            "python": {
+              "module": "aws_cdk.aws_backup"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_batch": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Batch"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.batch"
+            },
+            "python": {
+              "module": "aws_cdk.aws_batch"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_billingconductor": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.BillingConductor"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.billingconductor"
+            },
+            "python": {
+              "module": "aws_cdk.aws_billingconductor"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_budgets": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Budgets"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.budgets"
+            },
+            "python": {
+              "module": "aws_cdk.aws_budgets"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_cassandra": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Cassandra"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.cassandra"
+            },
+            "python": {
+              "module": "aws_cdk.aws_cassandra"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ce": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CE"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ce"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ce"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_certificatemanager": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CertificateManager"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.certificatemanager"
+            },
+            "python": {
+              "module": "aws_cdk.aws_certificatemanager"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_chatbot": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Chatbot"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.chatbot"
+            },
+            "python": {
+              "module": "aws_cdk.aws_chatbot"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_cloud9": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Cloud9"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.cloud9"
+            },
+            "python": {
+              "module": "aws_cdk.aws_cloud9"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_cloudformation": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CloudFormation"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.cloudformation"
+            },
+            "python": {
+              "module": "aws_cdk.aws_cloudformation"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_cloudfront": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CloudFront"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.cloudfront"
+            },
+            "python": {
+              "module": "aws_cdk.aws_cloudfront"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_cloudfront.experimental": {},
+        "aws-cdk-lib.aws_cloudfront_origins": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CloudFront.Origins"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.cloudfront.origins"
+            },
+            "python": {
+              "module": "aws_cdk.aws_cloudfront_origins"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_cloudtrail": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CloudTrail"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.cloudtrail"
+            },
+            "python": {
+              "module": "aws_cdk.aws_cloudtrail"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_cloudwatch": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CloudWatch"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.cloudwatch"
+            },
+            "python": {
+              "module": "aws_cdk.aws_cloudwatch"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_cloudwatch_actions": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CloudWatch.Actions"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.cloudwatch.actions"
+            },
+            "python": {
+              "module": "aws_cdk.aws_cloudwatch_actions"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_codeartifact": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CodeArtifact"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.codeartifact"
+            },
+            "python": {
+              "module": "aws_cdk.aws_codeartifact"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_codebuild": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CodeBuild"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.codebuild"
+            },
+            "python": {
+              "module": "aws_cdk.aws_codebuild"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_codecommit": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CodeCommit"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.codecommit"
+            },
+            "python": {
+              "module": "aws_cdk.aws_codecommit"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_codedeploy": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CodeDeploy"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.codedeploy"
+            },
+            "python": {
+              "module": "aws_cdk.aws_codedeploy"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_codeguruprofiler": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CodeGuruProfiler"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.codeguruprofiler"
+            },
+            "python": {
+              "module": "aws_cdk.aws_codeguruprofiler"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_codegurureviewer": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CodeGuruReviewer"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.codegurureviewer"
+            },
+            "python": {
+              "module": "aws_cdk.aws_codegurureviewer"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_codepipeline": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CodePipeline"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.codepipeline"
+            },
+            "python": {
+              "module": "aws_cdk.aws_codepipeline"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_codepipeline_actions": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CodePipeline.Actions"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.codepipeline.actions"
+            },
+            "python": {
+              "module": "aws_cdk.aws_codepipeline_actions"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_codestar": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Codestar"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.codestar"
+            },
+            "python": {
+              "module": "aws_cdk.aws_codestar"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_codestarconnections": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CodeStarConnections"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.codestarconnections"
+            },
+            "python": {
+              "module": "aws_cdk.aws_codestarconnections"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_codestarnotifications": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CodeStarNotifications"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.codestarnotifications"
+            },
+            "python": {
+              "module": "aws_cdk.aws_codestarnotifications"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_cognito": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Cognito"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.cognito"
+            },
+            "python": {
+              "module": "aws_cdk.aws_cognito"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_comprehend": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Comprehend"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.comprehend"
+            },
+            "python": {
+              "module": "aws_cdk.aws_comprehend"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_config": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Config"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.config"
+            },
+            "python": {
+              "module": "aws_cdk.aws_config"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_connect": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Connect"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.connect"
+            },
+            "python": {
+              "module": "aws_cdk.aws_connect"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_connectcampaigns": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ConnectCampaigns"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.connectcampaigns"
+            },
+            "python": {
+              "module": "aws_cdk.aws_connectcampaigns"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_controltower": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ControlTower"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.controltower"
+            },
+            "python": {
+              "module": "aws_cdk.aws_controltower"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_cur": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CUR"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.cur"
+            },
+            "python": {
+              "module": "aws_cdk.aws_cur"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_customerprofiles": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.CustomerProfiles"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.customerprofiles"
+            },
+            "python": {
+              "module": "aws_cdk.aws_customerprofiles"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_databrew": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DataBrew"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.databrew"
+            },
+            "python": {
+              "module": "aws_cdk.aws_databrew"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_datapipeline": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DataPipeline"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.datapipeline"
+            },
+            "python": {
+              "module": "aws_cdk.aws_datapipeline"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_datasync": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DataSync"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.datasync"
+            },
+            "python": {
+              "module": "aws_cdk.aws_datasync"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_dax": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DAX"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.dax"
+            },
+            "python": {
+              "module": "aws_cdk.aws_dax"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_detective": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Detective"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.detective"
+            },
+            "python": {
+              "module": "aws_cdk.aws_detective"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_devicefarm": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DeviceFarm"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.devicefarm"
+            },
+            "python": {
+              "module": "aws_cdk.aws_devicefarm"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_devopsguru": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DevOpsGuru"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.devopsguru"
+            },
+            "python": {
+              "module": "aws_cdk.aws_devopsguru"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_directoryservice": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DirectoryService"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.directoryservice"
+            },
+            "python": {
+              "module": "aws_cdk.aws_directoryservice"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_dlm": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DLM"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.dlm"
+            },
+            "python": {
+              "module": "aws_cdk.aws_dlm"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_dms": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DMS"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.dms"
+            },
+            "python": {
+              "module": "aws_cdk.aws_dms"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_docdb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DocDB"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.docdb"
+            },
+            "python": {
+              "module": "aws_cdk.aws_docdb"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_docdbelastic": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DocDBElastic"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.docdbelastic"
+            },
+            "python": {
+              "module": "aws_cdk.aws_docdbelastic"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_dynamodb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.DynamoDB"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.dynamodb"
+            },
+            "python": {
+              "module": "aws_cdk.aws_dynamodb"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ec2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.EC2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ec2"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ec2"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ecr": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ECR"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ecr"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ecr"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ecr_assets": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Ecr.Assets"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ecr.assets"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ecr_assets"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ecs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ECS"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ecs"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ecs"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ecs_patterns": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ECS.Patterns"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ecs.patterns"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ecs_patterns"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_efs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.EFS"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.efs"
+            },
+            "python": {
+              "module": "aws_cdk.aws_efs"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_eks": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.EKS"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.eks"
+            },
+            "python": {
+              "module": "aws_cdk.aws_eks"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_elasticache": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ElastiCache"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.elasticache"
+            },
+            "python": {
+              "module": "aws_cdk.aws_elasticache"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_elasticbeanstalk": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ElasticBeanstalk"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.elasticbeanstalk"
+            },
+            "python": {
+              "module": "aws_cdk.aws_elasticbeanstalk"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_elasticloadbalancing": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ElasticLoadBalancing"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.elasticloadbalancing"
+            },
+            "python": {
+              "module": "aws_cdk.aws_elasticloadbalancing"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_elasticloadbalancingv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ElasticLoadBalancingV2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.elasticloadbalancingv2"
+            },
+            "python": {
+              "module": "aws_cdk.aws_elasticloadbalancingv2"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_elasticloadbalancingv2_actions": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ElasticLoadBalancingV2.Actions"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.elasticloadbalancingv2.actions"
+            },
+            "python": {
+              "module": "aws_cdk.aws_elasticloadbalancingv2_actions"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_elasticloadbalancingv2_targets": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ElasticLoadBalancingV2.Targets"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.elasticloadbalancingv2.targets"
+            },
+            "python": {
+              "module": "aws_cdk.aws_elasticloadbalancingv2_targets"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_elasticsearch": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Elasticsearch"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.elasticsearch"
+            },
+            "python": {
+              "module": "aws_cdk.aws_elasticsearch"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_emr": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.EMR"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.emr"
+            },
+            "python": {
+              "module": "aws_cdk.aws_emr"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_emrcontainers": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.EMRContainers"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.emrcontainers"
+            },
+            "python": {
+              "module": "aws_cdk.aws_emrcontainers"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_emrserverless": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.EMRServerless"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.emrserverless"
+            },
+            "python": {
+              "module": "aws_cdk.aws_emrserverless"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_events": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Events"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.events"
+            },
+            "python": {
+              "module": "aws_cdk.aws_events"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_events_targets": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Events.Targets"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.events.targets"
+            },
+            "python": {
+              "module": "aws_cdk.aws_events_targets"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_eventschemas": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.EventSchemas"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.eventschemas"
+            },
+            "python": {
+              "module": "aws_cdk.aws_eventschemas"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_evidently": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Evidently"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.evidently"
+            },
+            "python": {
+              "module": "aws_cdk.aws_evidently"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_finspace": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.FinSpace"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.finspace"
+            },
+            "python": {
+              "module": "aws_cdk.aws_finspace"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_fis": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.FIS"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.fis"
+            },
+            "python": {
+              "module": "aws_cdk.aws_fis"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_fms": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.FMS"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.fms"
+            },
+            "python": {
+              "module": "aws_cdk.aws_fms"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_forecast": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Forecast"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.forecast"
+            },
+            "python": {
+              "module": "aws_cdk.aws_forecast"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_frauddetector": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.FraudDetector"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.frauddetector"
+            },
+            "python": {
+              "module": "aws_cdk.aws_frauddetector"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_fsx": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.FSx"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.fsx"
+            },
+            "python": {
+              "module": "aws_cdk.aws_fsx"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_gamelift": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.GameLift"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.gamelift"
+            },
+            "python": {
+              "module": "aws_cdk.aws_gamelift"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_globalaccelerator": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.GlobalAccelerator"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.globalaccelerator"
+            },
+            "python": {
+              "module": "aws_cdk.aws_globalaccelerator"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_globalaccelerator_endpoints": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.GlobalAccelerator.Endpoints"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.globalaccelerator.endpoints"
+            },
+            "python": {
+              "module": "aws_cdk.aws_globalaccelerator_endpoints"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_glue": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Glue"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.glue"
+            },
+            "python": {
+              "module": "aws_cdk.aws_glue"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_grafana": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Grafana"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.grafana"
+            },
+            "python": {
+              "module": "aws_cdk.aws_grafana"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_greengrass": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Greengrass"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.greengrass"
+            },
+            "python": {
+              "module": "aws_cdk.aws_greengrass"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_greengrassv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.GreengrassV2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.greengrassv2"
+            },
+            "python": {
+              "module": "aws_cdk.aws_greengrassv2"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_groundstation": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.GroundStation"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.groundstation"
+            },
+            "python": {
+              "module": "aws_cdk.aws_groundstation"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_guardduty": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.GuardDuty"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.guardduty"
+            },
+            "python": {
+              "module": "aws_cdk.aws_guardduty"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_healthlake": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.HealthLake"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.healthlake"
+            },
+            "python": {
+              "module": "aws_cdk.aws_healthlake"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_iam": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IAM"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.iam"
+            },
+            "python": {
+              "module": "aws_cdk.aws_iam"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_identitystore": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IdentityStore"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.identitystore"
+            },
+            "python": {
+              "module": "aws_cdk.aws_identitystore"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_imagebuilder": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ImageBuilder"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.imagebuilder"
+            },
+            "python": {
+              "module": "aws_cdk.aws_imagebuilder"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_inspector": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Inspector"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.inspector"
+            },
+            "python": {
+              "module": "aws_cdk.aws_inspector"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_inspectorv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.InspectorV2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.inspectorv2"
+            },
+            "python": {
+              "module": "aws_cdk.aws_inspectorv2"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_internetmonitor": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.InternetMonitor"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.internetmonitor"
+            },
+            "python": {
+              "module": "aws_cdk.aws_internetmonitor"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_iot": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IoT"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.iot"
+            },
+            "python": {
+              "module": "aws_cdk.aws_iot"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_iot1click": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IoT1Click"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.iot1click"
+            },
+            "python": {
+              "module": "aws_cdk.aws_iot1click"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_iotanalytics": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IoTAnalytics"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.iotanalytics"
+            },
+            "python": {
+              "module": "aws_cdk.aws_iotanalytics"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_iotcoredeviceadvisor": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IoTCoreDeviceAdvisor"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.iotcoredeviceadvisor"
+            },
+            "python": {
+              "module": "aws_cdk.aws_iotcoredeviceadvisor"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_iotevents": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IoTEvents"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.iotevents"
+            },
+            "python": {
+              "module": "aws_cdk.aws_iotevents"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_iotfleethub": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IoTFleetHub"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.iotfleethub"
+            },
+            "python": {
+              "module": "aws_cdk.aws_iotfleethub"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_iotfleetwise": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IoTFleetWise"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.iotfleetwise"
+            },
+            "python": {
+              "module": "aws_cdk.aws_iotfleetwise"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_iotsitewise": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IoTSiteWise"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.iotsitewise"
+            },
+            "python": {
+              "module": "aws_cdk.aws_iotsitewise"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_iotthingsgraph": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IoTThingsGraph"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.iotthingsgraph"
+            },
+            "python": {
+              "module": "aws_cdk.aws_iotthingsgraph"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_iottwinmaker": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IoTTwinMaker"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.iottwinmaker"
+            },
+            "python": {
+              "module": "aws_cdk.aws_iottwinmaker"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_iotwireless": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IoTWireless"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.iotwireless"
+            },
+            "python": {
+              "module": "aws_cdk.aws_iotwireless"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ivs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Ivs"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ivs"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ivs"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ivschat": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.IVSChat"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ivschat"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ivschat"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_kafkaconnect": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.KafkaConnect"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.kafkaconnect"
+            },
+            "python": {
+              "module": "aws_cdk.aws_kafkaconnect"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_kendra": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Kendra"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.kendra"
+            },
+            "python": {
+              "module": "aws_cdk.aws_kendra"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_kendraranking": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.KendraRanking"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.kendraranking"
+            },
+            "python": {
+              "module": "aws_cdk.aws_kendraranking"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_kinesis": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Kinesis"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.kinesis"
+            },
+            "python": {
+              "module": "aws_cdk.aws_kinesis"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_kinesisanalytics": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.KinesisAnalytics"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.kinesisanalytics"
+            },
+            "python": {
+              "module": "aws_cdk.aws_kinesisanalytics"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_kinesisanalyticsv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.KinesisAnalyticsV2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.kinesisanalyticsv2"
+            },
+            "python": {
+              "module": "aws_cdk.aws_kinesisanalyticsv2"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_kinesisfirehose": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.KinesisFirehose"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.kinesisfirehose"
+            },
+            "python": {
+              "module": "aws_cdk.aws_kinesisfirehose"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_kinesisvideo": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.KinesisVideo"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.kinesisvideo"
+            },
+            "python": {
+              "module": "aws_cdk.aws_kinesisvideo"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_kms": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.KMS"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.kms"
+            },
+            "python": {
+              "module": "aws_cdk.aws_kms"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_lakeformation": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.LakeFormation"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.lakeformation"
+            },
+            "python": {
+              "module": "aws_cdk.aws_lakeformation"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_lambda": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Lambda"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.lambda"
+            },
+            "python": {
+              "module": "aws_cdk.aws_lambda"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_lambda_destinations": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Lambda.Destinations"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.lambda.destinations"
+            },
+            "python": {
+              "module": "aws_cdk.aws_lambda_destinations"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_lambda_event_sources": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Lambda.EventSources"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.lambda.eventsources"
+            },
+            "python": {
+              "module": "aws_cdk.aws_lambda_event_sources"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_lambda_nodejs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Lambda.Nodejs"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.lambda.nodejs"
+            },
+            "python": {
+              "module": "aws_cdk.aws_lambda_nodejs"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_lex": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Lex"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.lex"
+            },
+            "python": {
+              "module": "aws_cdk.aws_lex"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_licensemanager": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.LicenseManager"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.licensemanager"
+            },
+            "python": {
+              "module": "aws_cdk.aws_licensemanager"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_lightsail": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Lightsail"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.lightsail"
+            },
+            "python": {
+              "module": "aws_cdk.aws_lightsail"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_location": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Location"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.location"
+            },
+            "python": {
+              "module": "aws_cdk.aws_location"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_logs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Logs"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.logs"
+            },
+            "python": {
+              "module": "aws_cdk.aws_logs"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_logs_destinations": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Logs.Destinations"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.logs.destinations"
+            },
+            "python": {
+              "module": "aws_cdk.aws_logs_destinations"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_lookoutequipment": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.LookoutEquipment"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.lookoutequipment"
+            },
+            "python": {
+              "module": "aws_cdk.aws_lookoutequipment"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_lookoutmetrics": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.LookoutMetrics"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.lookoutmetrics"
+            },
+            "python": {
+              "module": "aws_cdk.aws_lookoutmetrics"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_lookoutvision": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.LookoutVision"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.lookoutvision"
+            },
+            "python": {
+              "module": "aws_cdk.aws_lookoutvision"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_m2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.M2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.m2"
+            },
+            "python": {
+              "module": "aws_cdk.aws_m2"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_macie": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Macie"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.macie"
+            },
+            "python": {
+              "module": "aws_cdk.aws_macie"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_managedblockchain": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ManagedBlockchain"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.managedblockchain"
+            },
+            "python": {
+              "module": "aws_cdk.aws_managedblockchain"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_mediaconnect": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.MediaConnect"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.mediaconnect"
+            },
+            "python": {
+              "module": "aws_cdk.aws_mediaconnect"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_mediaconvert": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.MediaConvert"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.mediaconvert"
+            },
+            "python": {
+              "module": "aws_cdk.aws_mediaconvert"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_medialive": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.MediaLive"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.medialive"
+            },
+            "python": {
+              "module": "aws_cdk.aws_medialive"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_mediapackage": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.MediaPackage"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.mediapackage"
+            },
+            "python": {
+              "module": "aws_cdk.aws_mediapackage"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_mediastore": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.MediaStore"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.mediastore"
+            },
+            "python": {
+              "module": "aws_cdk.aws_mediastore"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_mediatailor": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.MediaTailor"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.mediatailor"
+            },
+            "python": {
+              "module": "aws_cdk.aws_mediatailor"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_memorydb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.MemoryDB"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.memorydb"
+            },
+            "python": {
+              "module": "aws_cdk.aws_memorydb"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_msk": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.MSK"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.msk"
+            },
+            "python": {
+              "module": "aws_cdk.aws_msk"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_mwaa": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.MWAA"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.mwaa"
+            },
+            "python": {
+              "module": "aws_cdk.aws_mwaa"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_neptune": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Neptune"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.neptune"
+            },
+            "python": {
+              "module": "aws_cdk.aws_neptune"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_networkfirewall": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.NetworkFirewall"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.networkfirewall"
+            },
+            "python": {
+              "module": "aws_cdk.aws_networkfirewall"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_networkmanager": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.NetworkManager"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.networkmanager"
+            },
+            "python": {
+              "module": "aws_cdk.aws_networkmanager"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_nimblestudio": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.NimbleStudio"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.nimblestudio"
+            },
+            "python": {
+              "module": "aws_cdk.aws_nimblestudio"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_oam": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Oam"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.oam"
+            },
+            "python": {
+              "module": "aws_cdk.aws_oam"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_omics": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Omics"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.omics"
+            },
+            "python": {
+              "module": "aws_cdk.aws_omics"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_opensearchserverless": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.OpenSearchServerless"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.opensearchserverless"
+            },
+            "python": {
+              "module": "aws_cdk.aws_opensearchserverless"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_opensearchservice": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.OpenSearchService"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.opensearchservice"
+            },
+            "python": {
+              "module": "aws_cdk.aws_opensearchservice"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_opsworks": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.OpsWorks"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.opsworks"
+            },
+            "python": {
+              "module": "aws_cdk.aws_opsworks"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_opsworkscm": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.OpsWorksCM"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.opsworkscm"
+            },
+            "python": {
+              "module": "aws_cdk.aws_opsworkscm"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_organizations": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Organizations"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.organizations"
+            },
+            "python": {
+              "module": "aws_cdk.aws_organizations"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_panorama": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Panorama"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.panorama"
+            },
+            "python": {
+              "module": "aws_cdk.aws_panorama"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_personalize": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Personalize"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.personalize"
+            },
+            "python": {
+              "module": "aws_cdk.aws_personalize"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_pinpoint": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Pinpoint"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.pinpoint"
+            },
+            "python": {
+              "module": "aws_cdk.aws_pinpoint"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_pinpointemail": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.PinpointEmail"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.pinpointemail"
+            },
+            "python": {
+              "module": "aws_cdk.aws_pinpointemail"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_pipes": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Pipes"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.pipes"
+            },
+            "python": {
+              "module": "aws_cdk.aws_pipes"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_qldb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.QLDB"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.qldb"
+            },
+            "python": {
+              "module": "aws_cdk.aws_qldb"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_quicksight": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.QuickSight"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.quicksight"
+            },
+            "python": {
+              "module": "aws_cdk.aws_quicksight"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ram": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.RAM"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ram"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ram"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_rds": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.RDS"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.rds"
+            },
+            "python": {
+              "module": "aws_cdk.aws_rds"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_redshift": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Redshift"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.redshift"
+            },
+            "python": {
+              "module": "aws_cdk.aws_redshift"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_redshiftserverless": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.RedshiftServerless"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.redshiftserverless"
+            },
+            "python": {
+              "module": "aws_cdk.aws_redshiftserverless"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_refactorspaces": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.RefactorSpaces"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.refactorspaces"
+            },
+            "python": {
+              "module": "aws_cdk.aws_refactorspaces"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_rekognition": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Rekognition"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.rekognition"
+            },
+            "python": {
+              "module": "aws_cdk.aws_rekognition"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_resiliencehub": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ResilienceHub"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.resiliencehub"
+            },
+            "python": {
+              "module": "aws_cdk.aws_resiliencehub"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_resourceexplorer2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ResourceExplorer2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.resourceexplorer2"
+            },
+            "python": {
+              "module": "aws_cdk.aws_resourceexplorer2"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_resourcegroups": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ResourceGroups"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.resourcegroups"
+            },
+            "python": {
+              "module": "aws_cdk.aws_resourcegroups"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_robomaker": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.RoboMaker"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.robomaker"
+            },
+            "python": {
+              "module": "aws_cdk.aws_robomaker"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_rolesanywhere": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.RolesAnywhere"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.rolesanywhere"
+            },
+            "python": {
+              "module": "aws_cdk.aws_rolesanywhere"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_route53": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Route53"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.route53"
+            },
+            "python": {
+              "module": "aws_cdk.aws_route53"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_route53_patterns": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Route53.Patterns"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.route53.patterns"
+            },
+            "python": {
+              "module": "aws_cdk.aws_route53_patterns"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_route53_targets": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Route53.Targets"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.route53.targets"
+            },
+            "python": {
+              "module": "aws_cdk.aws_route53_targets"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_route53recoverycontrol": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Route53RecoveryControl"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.route53recoverycontrol"
+            },
+            "python": {
+              "module": "aws_cdk.aws_route53recoverycontrol"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_route53recoveryreadiness": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Route53RecoveryReadiness"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.route53recoveryreadiness"
+            },
+            "python": {
+              "module": "aws_cdk.aws_route53recoveryreadiness"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_route53resolver": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Route53Resolver"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.route53resolver"
+            },
+            "python": {
+              "module": "aws_cdk.aws_route53resolver"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_rum": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.RUM"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.rum"
+            },
+            "python": {
+              "module": "aws_cdk.aws_rum"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_s3": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.S3"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.s3"
+            },
+            "python": {
+              "module": "aws_cdk.aws_s3"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_s3_assets": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.S3.Assets"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.s3.assets"
+            },
+            "python": {
+              "module": "aws_cdk.aws_s3_assets"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_s3_deployment": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.S3.Deployment"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.s3.deployment"
+            },
+            "python": {
+              "module": "aws_cdk.aws_s3_deployment"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_s3_notifications": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.S3.Notifications"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.s3.notifications"
+            },
+            "python": {
+              "module": "aws_cdk.aws_s3_notifications"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_s3objectlambda": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.S3ObjectLambda"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.s3objectlambda"
+            },
+            "python": {
+              "module": "aws_cdk.aws_s3objectlambda"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_s3outposts": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.S3Outposts"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.s3outposts"
+            },
+            "python": {
+              "module": "aws_cdk.aws_s3outposts"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_sagemaker": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Sagemaker"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.sagemaker"
+            },
+            "python": {
+              "module": "aws_cdk.aws_sagemaker"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_sam": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SAM"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.sam"
+            },
+            "python": {
+              "module": "aws_cdk.aws_sam"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_scheduler": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Scheduler"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.scheduler"
+            },
+            "python": {
+              "module": "aws_cdk.aws_scheduler"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_sdb": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SDB"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.sdb"
+            },
+            "python": {
+              "module": "aws_cdk.aws_sdb"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_secretsmanager": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SecretsManager"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.secretsmanager"
+            },
+            "python": {
+              "module": "aws_cdk.aws_secretsmanager"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_securityhub": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SecurityHub"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.securityhub"
+            },
+            "python": {
+              "module": "aws_cdk.aws_securityhub"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_servicecatalog": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Servicecatalog"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.servicecatalog"
+            },
+            "python": {
+              "module": "aws_cdk.aws_servicecatalog"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_servicecatalogappregistry": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Servicecatalogappregistry"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.servicecatalogappregistry"
+            },
+            "python": {
+              "module": "aws_cdk.aws_servicecatalogappregistry"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_servicediscovery": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.ServiceDiscovery"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.servicediscovery"
+            },
+            "python": {
+              "module": "aws_cdk.aws_servicediscovery"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ses": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SES"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ses"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ses"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ses_actions": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SES.Actions"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ses.actions"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ses_actions"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_signer": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Signer"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.signer"
+            },
+            "python": {
+              "module": "aws_cdk.aws_signer"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_simspaceweaver": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SimSpaceWeaver"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.simspaceweaver"
+            },
+            "python": {
+              "module": "aws_cdk.aws_simspaceweaver"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_sns": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SNS"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.sns"
+            },
+            "python": {
+              "module": "aws_cdk.aws_sns"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_sns_subscriptions": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SNS.Subscriptions"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.sns.subscriptions"
+            },
+            "python": {
+              "module": "aws_cdk.aws_sns_subscriptions"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_sqs": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SQS"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.sqs"
+            },
+            "python": {
+              "module": "aws_cdk.aws_sqs"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ssm": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SSM"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ssm"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ssm"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ssmcontacts": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SSMContacts"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ssmcontacts"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ssmcontacts"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_ssmincidents": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SSMIncidents"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.ssmincidents"
+            },
+            "python": {
+              "module": "aws_cdk.aws_ssmincidents"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_sso": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SSO"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.sso"
+            },
+            "python": {
+              "module": "aws_cdk.aws_sso"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_stepfunctions": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.StepFunctions"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.stepfunctions"
+            },
+            "python": {
+              "module": "aws_cdk.aws_stepfunctions"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_stepfunctions_tasks": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.StepFunctions.Tasks"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.stepfunctions.tasks"
+            },
+            "python": {
+              "module": "aws_cdk.aws_stepfunctions_tasks"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_supportapp": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SupportApp"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.supportapp"
+            },
+            "python": {
+              "module": "aws_cdk.aws_supportapp"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_synthetics": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Synthetics"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.synthetics"
+            },
+            "python": {
+              "module": "aws_cdk.aws_synthetics"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_systemsmanagersap": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.SystemsManagerSAP"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.systemsmanagersap"
+            },
+            "python": {
+              "module": "aws_cdk.aws_systemsmanagersap"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_timestream": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Timestream"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.timestream"
+            },
+            "python": {
+              "module": "aws_cdk.aws_timestream"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_transfer": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Transfer"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.transfer"
+            },
+            "python": {
+              "module": "aws_cdk.aws_transfer"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_voiceid": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.VoiceID"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.voiceid"
+            },
+            "python": {
+              "module": "aws_cdk.aws_voiceid"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_vpclattice": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.VpcLattice"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.vpclattice"
+            },
+            "python": {
+              "module": "aws_cdk.aws_vpclattice"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_waf": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.WAF"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.waf"
+            },
+            "python": {
+              "module": "aws_cdk.aws_waf"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_wafregional": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.WAFRegional"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.waf.regional"
+            },
+            "python": {
+              "module": "aws_cdk.aws_wafregional"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_wafv2": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.WAFv2"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.wafv2"
+            },
+            "python": {
+              "module": "aws_cdk.aws_wafv2"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_wisdom": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.Wisdom"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.wisdom"
+            },
+            "python": {
+              "module": "aws_cdk.aws_wisdom"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_workspaces": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.WorkSpaces"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.workspaces"
+            },
+            "python": {
+              "module": "aws_cdk.aws_workspaces"
+            }
+          }
+        },
+        "aws-cdk-lib.aws_xray": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.AWS.XRay"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.services.xray"
+            },
+            "python": {
+              "module": "aws_cdk.aws_xray"
+            }
+          }
+        },
+        "aws-cdk-lib.cloud_assembly_schema": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.CloudAssembly.Schema"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.cloudassembly.schema"
+            },
+            "python": {
+              "module": "aws_cdk.cloud_assembly_schema"
+            }
+          }
+        },
+        "aws-cdk-lib.cloudformation_include": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.CloudFormation.Include"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.cloudformation.include"
+            },
+            "python": {
+              "module": "aws_cdk.cloudformation_include"
+            }
+          }
+        },
+        "aws-cdk-lib.custom_resources": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.CustomResources"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.customresources"
+            },
+            "python": {
+              "module": "aws_cdk.custom_resources"
+            }
+          }
+        },
+        "aws-cdk-lib.cx_api": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.CXAPI"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.cxapi"
+            },
+            "python": {
+              "module": "aws_cdk.cx_api"
+            }
+          }
+        },
+        "aws-cdk-lib.lambda_layer_awscli": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.LambdaLayer.AwsCli"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.lambdalayer.awscli"
+            },
+            "python": {
+              "module": "aws_cdk.lambda_layer_awscli"
+            }
+          }
+        },
+        "aws-cdk-lib.lambda_layer_kubectl": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.LambdaLayer.Kubectl"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.lambdalayer.kubectl"
+            },
+            "python": {
+              "module": "aws_cdk.lambda_layer_kubectl"
+            }
+          }
+        },
+        "aws-cdk-lib.lambda_layer_node_proxy_agent": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.LambdaLayer.NodeProxyAgent"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.lambda.layer.node.proxy.agent"
+            },
+            "python": {
+              "module": "aws_cdk.lambda_layer_node_proxy_agent"
+            }
+          }
+        },
+        "aws-cdk-lib.pipelines": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Pipelines"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.pipelines"
+            },
+            "python": {
+              "module": "aws_cdk.pipelines"
+            }
+          }
+        },
+        "aws-cdk-lib.region_info": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.RegionInfo"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.regioninfo"
+            },
+            "python": {
+              "module": "aws_cdk.region_info"
+            }
+          }
+        },
+        "aws-cdk-lib.triggers": {
+          "targets": {
+            "dotnet": {
+              "namespace": "Amazon.CDK.Triggers"
+            },
+            "java": {
+              "package": "software.amazon.awscdk.triggers"
+            },
+            "python": {
+              "module": "aws_cdk.triggers"
+            }
+          }
+        }
+      },
+      "targets": {
+        "dotnet": {
+          "iconUrl": "https://raw.githubusercontent.com/aws/aws-cdk/main/logo/default-256-dark.png",
+          "namespace": "Amazon.CDK",
+          "packageId": "Amazon.CDK.Lib"
+        },
+        "go": {
+          "moduleName": "github.com/aws/aws-cdk-go",
+          "packageName": "awscdk"
+        },
+        "java": {
+          "maven": {
+            "artifactId": "aws-cdk-lib",
+            "groupId": "software.amazon.awscdk"
+          },
+          "package": "software.amazon.awscdk"
+        },
+        "js": {
+          "npm": "aws-cdk-lib"
+        },
+        "python": {
+          "distName": "aws-cdk-lib",
+          "module": "aws_cdk"
+        }
+      }
+    },
+    "constructs": {
+      "targets": {
+        "dotnet": {
+          "namespace": "Constructs",
+          "packageId": "Constructs"
+        },
+        "go": {
+          "moduleName": "github.com/aws/constructs-go"
+        },
+        "java": {
+          "maven": {
+            "artifactId": "constructs",
+            "groupId": "software.constructs"
+          },
+          "package": "software.constructs"
+        },
+        "js": {
+          "npm": "constructs"
+        },
+        "python": {
+          "distName": "constructs",
+          "module": "constructs"
+        }
+      }
+    }
+  },
+  "description": "Check CDK v2 applications for best practices using a combination on available rule packs.",
+  "docs": {
+    "stability": "stable"
+  },
+  "homepage": "https://github.com/cdklabs/cdk-nag.git",
+  "jsiiVersion": "1.86.1 (build defb235)",
+  "keywords": [
+    "cdk"
+  ],
+  "license": "Apache-2.0",
+  "metadata": {
+    "jsii": {
+      "pacmak": {
+        "hasDefaultInterfaces": true
+      }
+    },
+    "tscRootDir": "src"
+  },
+  "name": "cdk-nag",
+  "readme": {
+    "markdown": "<!--\nCopyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\nSPDX-License-Identifier: Apache-2.0\n-->\n\n# cdk-nag\n\n[![PyPI version](https://img.shields.io/pypi/v/cdk-nag)](https://pypi.org/project/cdk-nag/)\n[![npm version](https://img.shields.io/npm/v/cdk-nag)](https://www.npmjs.com/package/cdk-nag)\n[![Maven version](https://img.shields.io/maven-central/v/io.github.cdklabs/cdknag)](https://search.maven.org/search?q=a:cdknag)\n[![NuGet version](https://img.shields.io/nuget/v/Cdklabs.CdkNag)](https://www.nuget.org/packages/Cdklabs.CdkNag)\n[![Go version](https://img.shields.io/github/go-mod/go-version/cdklabs/cdk-nag-go?color=blue&filename=cdknag%2Fgo.mod)](https://github.com/cdklabs/cdk-nag-go)\n\n[![View on Construct Hub](https://constructs.dev/badge?package=cdk-nag)](https://constructs.dev/packages/cdk-nag)\n\nCheck CDK applications or [CloudFormation templates](#using-on-cloudformation-templates) for best practices using a combination of available rule packs. Inspired by [cfn_nag](https://github.com/stelligent/cfn_nag).\n\nCheck out [this blog post](https://aws.amazon.com/blogs/devops/manage-application-security-and-compliance-with-the-aws-cloud-development-kit-and-cdk-nag/) for a guided overview!\n\n![demo](cdk_nag.gif)\n\n## Available Rules and Packs\n\nSee [RULES](./RULES.md) for more information on all the available packs.\n\n1. [AWS Solutions](./RULES.md#awssolutions)\n2. [HIPAA Security](./RULES.md#hipaa-security)\n3. [NIST 800-53 rev 4](./RULES.md#nist-800-53-rev-4)\n4. [NIST 800-53 rev 5](./RULES.md#nist-800-53-rev-5)\n5. [PCI DSS 3.2.1](./RULES.md#pci-dss-321)\n\n[RULES](./RULES.md) also includes a collection of [additional rules](./RULES.md#additional-rules) that are not currently included in any of the pre-built NagPacks, but are still available for inclusion in custom NagPacks.\n\nRead the [NagPack developer docs](./docs/NagPack.md) if you are interested in creating your own pack.\n\n## Usage\n\nFor a full list of options See `NagPackProps` in the [API.md](./API.md#struct-nagpackprops)\n\n<details>\n<summary>Including in an application</summary>\n\n```typescript\nimport { App, Aspects } from 'aws-cdk-lib';\nimport { CdkTestStack } from '../lib/cdk-test-stack';\nimport { AwsSolutionsChecks } from 'cdk-nag';\n\nconst app = new App();\nnew CdkTestStack(app, 'CdkNagDemo');\n// Simple rule informational messages\nAspects.of(app).add(new AwsSolutionsChecks());\n// Additional explanations on the purpose of triggered rules\n// Aspects.of(stack).add(new AwsSolutionsChecks({ verbose: true }));\n```\n\n</details>\n\n## Suppressing a Rule\n\n<details>\n  <summary>Example 1) Default Construct</summary>\n\n```typescript\nimport { SecurityGroup, Vpc, Peer, Port } from 'aws-cdk-lib/aws-ec2';\nimport { Stack, StackProps } from 'aws-cdk-lib';\nimport { Construct } from 'constructs';\nimport { NagSuppressions } from 'cdk-nag';\n\nexport class CdkTestStack extends Stack {\n  constructor(scope: Construct, id: string, props?: StackProps) {\n    super(scope, id, props);\n    const test = new SecurityGroup(this, 'test', {\n      vpc: new Vpc(this, 'vpc'),\n    });\n    test.addIngressRule(Peer.anyIpv4(), Port.allTraffic());\n    NagSuppressions.addResourceSuppressions(test, [\n      { id: 'AwsSolutions-EC23', reason: 'lorem ipsum' },\n    ]);\n  }\n}\n```\n\n</details>\n\n<details>\n  <summary>Example 2) On Multiple Constructs</summary>\n\n```typescript\nimport { SecurityGroup, Vpc, Peer, Port } from 'aws-cdk-lib/aws-ec2';\nimport { Stack, StackProps } from 'aws-cdk-lib';\nimport { Construct } from 'constructs';\nimport { NagSuppressions } from 'cdk-nag';\n\nexport class CdkTestStack extends Stack {\n  constructor(scope: Construct, id: string, props?: StackProps) {\n    super(scope, id, props);\n    const vpc = new Vpc(this, 'vpc');\n    const test1 = new SecurityGroup(this, 'test', { vpc });\n    test1.addIngressRule(Peer.anyIpv4(), Port.allTraffic());\n    const test2 = new SecurityGroup(this, 'test', { vpc });\n    test2.addIngressRule(Peer.anyIpv4(), Port.allTraffic());\n    NagSuppressions.addResourceSuppressions(\n      [test1, test2],\n      [{ id: 'AwsSolutions-EC23', reason: 'lorem ipsum' }]\n    );\n  }\n}\n```\n\n</details>\n\n<details>\n  <summary>Example 3) Child Constructs</summary>\n\n```typescript\nimport { User, PolicyStatement } from 'aws-cdk-lib/aws-iam';\nimport { Stack, StackProps } from 'aws-cdk-lib';\nimport { Construct } from 'constructs';\nimport { NagSuppressions } from 'cdk-nag';\n\nexport class CdkTestStack extends Stack {\n  constructor(scope: Construct, id: string, props?: StackProps) {\n    super(scope, id, props);\n    const user = new User(this, 'rUser');\n    user.addToPolicy(\n      new PolicyStatement({\n        actions: ['s3:PutObject'],\n        resources: ['arn:aws:s3:::bucket_name/*'],\n      })\n    );\n    // Enable adding suppressions to child constructs\n    NagSuppressions.addResourceSuppressions(\n      user,\n      [\n        {\n          id: 'AwsSolutions-IAM5',\n          reason: 'lorem ipsum',\n          appliesTo: ['Resource::arn:aws:s3:::bucket_name/*'], // optional\n        },\n      ],\n      true\n    );\n  }\n}\n```\n\n</details>\n\n<details>\n  <summary>Example 4) Stack Level </summary>\n\n```typescript\nimport { App, Aspects } from 'aws-cdk-lib';\nimport { CdkTestStack } from '../lib/cdk-test-stack';\nimport { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';\n\nconst app = new App();\nconst stack = new CdkTestStack(app, 'CdkNagDemo');\nAspects.of(app).add(new AwsSolutionsChecks());\nNagSuppressions.addStackSuppressions(stack, [\n  { id: 'AwsSolutions-EC23', reason: 'lorem ipsum' },\n]);\n```\n\n</details>\n\n<details>\n  <summary>Example 5) Construct path</summary>\n\nIf you received the following error on synth/deploy\n\n```bash\n[Error at /StackName/Custom::CDKBucketDeployment8675309/ServiceRole/Resource] AwsSolutions-IAM4: The IAM user, role, or group uses AWS managed policies\n```\n\n```typescript\nimport { Bucket } from 'aws-cdk-lib/aws-s3';\nimport { BucketDeployment } from 'aws-cdk-lib/aws-s3-deployment';\nimport { Stack, StackProps } from 'aws-cdk-lib';\nimport { Construct } from 'constructs';\nimport { NagSuppressions } from 'cdk-nag';\n\nexport class CdkTestStack extends Stack {\n  constructor(scope: Construct, id: string, props?: StackProps) {\n    super(scope, id, props);\n    new BucketDeployment(this, 'rDeployment', {\n      sources: [],\n      destinationBucket: Bucket.fromBucketName(this, 'rBucket', 'foo'),\n    });\n    NagSuppressions.addResourceSuppressionsByPath(\n      this,\n      '/StackName/Custom::CDKBucketDeployment8675309/ServiceRole/Resource',\n      [{ id: 'AwsSolutions-IAM4', reason: 'at least 10 characters' }]\n    );\n  }\n}\n```\n\n</details>\n\n<details>\n  <summary>Example 6) Granular Suppressions of findings</summary>\n\nCertain rules support granular suppressions of `findings`. If you received the following errors on synth/deploy\n\n```bash\n[Error at /StackName/rFirstUser/DefaultPolicy/Resource] AwsSolutions-IAM5[Action::s3:*]: The IAM entity contains wildcard permissions and does not have a cdk-nag rule suppression with evidence for those permission.\n[Error at /StackName/rFirstUser/DefaultPolicy/Resource] AwsSolutions-IAM5[Resource::*]: The IAM entity contains wildcard permissions and does not have a cdk-nag rule suppression with evidence for those permission.\n[Error at /StackName/rSecondUser/DefaultPolicy/Resource] AwsSolutions-IAM5[Action::s3:*]: The IAM entity contains wildcard permissions and does not have a cdk-nag rule suppression with evidence for those permission.\n[Error at /StackName/rSecondUser/DefaultPolicy/Resource] AwsSolutions-IAM5[Resource::*]: The IAM entity contains wildcard permissions and does not have a cdk-nag rule suppression with evidence for those permission.\n```\n\nBy applying the following suppressions\n\n```typescript\nimport { User } from 'aws-cdk-lib/aws-iam';\nimport { Stack, StackProps } from 'aws-cdk-lib';\nimport { Construct } from 'constructs';\nimport { NagSuppressions } from 'cdk-nag';\n\nexport class CdkTestStack extends Stack {\n  constructor(scope: Construct, id: string, props?: StackProps) {\n    super(scope, id, props);\n    const firstUser = new User(this, 'rFirstUser');\n    firstUser.addToPolicy(\n      new PolicyStatement({\n        actions: ['s3:*'],\n        resources: ['*'],\n      })\n    );\n    const secondUser = new User(this, 'rSecondUser');\n    secondUser.addToPolicy(\n      new PolicyStatement({\n        actions: ['s3:*'],\n        resources: ['*'],\n      })\n    );\n    const thirdUser = new User(this, 'rSecondUser');\n    thirdUser.addToPolicy(\n      new PolicyStatement({\n        actions: ['sqs:CreateQueue'],\n        resources: [`arn:aws:sqs:${this.region}:${this.account}:*`],\n      })\n    );\n    NagSuppressions.addResourceSuppressions(\n      firstUser,\n      [\n        {\n          id: 'AwsSolutions-IAM5',\n          reason:\n            \"Only suppress AwsSolutions-IAM5 's3:*' finding on First User.\",\n          appliesTo: ['Action::s3:*'],\n        },\n      ],\n      true\n    );\n    NagSuppressions.addResourceSuppressions(\n      secondUser,\n      [\n        {\n          id: 'AwsSolutions-IAM5',\n          reason: 'Suppress all AwsSolutions-IAM5 findings on Second User.',\n        },\n      ],\n      true\n    );\n    NagSuppressions.addResourceSuppressions(\n      thirdUser,\n      [\n        {\n          id: 'AwsSolutions-IAM5',\n          reason: 'Suppress AwsSolutions-IAM5 on the SQS resource.',\n          appliesTo: [\n            {\n              regex: '/^Resource::arn:aws:sqs:(.*):\\\\*$/g',\n            },\n          ],\n        },\n      ],\n      true\n    );\n  }\n}\n```\n\nYou would see the following error on synth/deploy\n\n```bash\n[Error at /StackName/rFirstUser/DefaultPolicy/Resource] AwsSolutions-IAM5[Resource::*]: The IAM entity contains wildcard permissions and does not have a cdk-nag rule suppression with evidence for those permission.\n```\n\n</details>\n\n## Suppressing `aws-cdk-lib/pipelines` Violations\n\nThe [aws-cdk-lib/pipelines.CodePipeline](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.pipelines.CodePipeline.html) construct and its child constructs are not guaranteed to be \"Visited\" by `Aspects`, as they are not added during the \"Construction\" phase of the [cdk lifecycle](https://docs.aws.amazon.com/cdk/v2/guide/apps.html#lifecycle). Because of this behavior, you may experience problems such as rule violations not appearing or the inability to suppress violations on these constructs.\n\nYou can remediate these rule violation and suppression problems by forcing the pipeline construct creation forward by calling `.buildPipeline()` on your `CodePipeline` object. Otherwise you may see errors such as:\n\n```\nError: Suppression path \"/this/construct/path\" did not match any resource. This can occur when a resource does not exist or if a suppression is applied before a resource is created.\n```\n\nSee [this issue](https://github.com/aws/aws-cdk/issues/18440) for more information.\n\n<details>\n  <summary>Example) Supressing Violations in Pipelines</summary>\n\n`example-app.ts`\n\n```ts\nimport { App, Aspects } from 'aws-cdk-lib';\nimport { AwsSolutionsChecks } from 'cdk-nag';\nimport { ExamplePipeline } from '../lib/example-pipeline';\n\nconst app = new App();\nnew ExamplePipeline(app, 'example-cdk-pipeline');\nAspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));\napp.synth();\n```\n\n`example-pipeline.ts`\n\n```ts\nimport { Stack, StackProps } from 'aws-cdk-lib';\nimport { Repository } from 'aws-cdk-lib/aws-codecommit';\nimport {\n  CodePipeline,\n  CodePipelineSource,\n  ShellStep,\n} from 'aws-cdk-lib/pipelines';\nimport { NagSuppressions } from 'cdk-nag';\nimport { Construct } from 'constructs';\n\nexport class ExamplePipeline extends Stack {\n  constructor(scope: Construct, id: string, props?: StackProps) {\n    super(scope, id, props);\n\n    const exampleSynth = new ShellStep('ExampleSynth', {\n      commands: ['yarn build --frozen-lockfile'],\n      input: CodePipelineSource.codeCommit(\n        new Repository(this, 'ExampleRepo', { repositoryName: 'ExampleRepo' }),\n        'main'\n      ),\n    });\n\n    const ExamplePipeline = new CodePipeline(this, 'ExamplePipeline', {\n      synth: exampleSynth,\n    });\n\n    // Force the pipeline construct creation forward before applying suppressions.\n    // @See https://github.com/aws/aws-cdk/issues/18440\n    ExamplePipeline.buildPipeline();\n\n    // The path suppression will error if you comment out \"ExamplePipeline.buildPipeline();\"\"\n    NagSuppressions.addResourceSuppressionsByPath(\n      this,\n      '/example-cdk-pipeline/ExamplePipeline/Pipeline/ArtifactsBucket/Resource',\n      [\n        {\n          id: 'AwsSolutions-S1',\n          reason: 'Because I said so',\n        },\n      ]\n    );\n  }\n}\n```\n\n</details>\n\n## Rules and Property Overrides\n\nIn some cases L2 Constructs do not have a native option to remediate an issue and must be fixed via [Raw Overrides](https://docs.aws.amazon.com/cdk/latest/guide/cfn_layer.html#cfn_layer_raw). Since raw overrides take place after template synthesis these fixes are not caught by cdk-nag. In this case you should remediate the issue and suppress the issue like in the following example.\n\n<details>\n  <summary>Example) Property Overrides</summary>\n\n```ts\nimport {\n  Instance,\n  InstanceType,\n  InstanceClass,\n  MachineImage,\n  Vpc,\n  CfnInstance,\n} from 'aws-cdk-lib/aws-ec2';\nimport { Stack, StackProps } from 'aws-cdk-lib';\nimport { Construct } from 'constructs';\nimport { NagSuppressions } from 'cdk-nag';\n\nexport class CdkTestStack extends Stack {\n  constructor(scope: Construct, id: string, props?: StackProps) {\n    super(scope, id, props);\n    const instance = new Instance(this, 'rInstance', {\n      vpc: new Vpc(this, 'rVpc'),\n      instanceType: new InstanceType(InstanceClass.T3),\n      machineImage: MachineImage.latestAmazonLinux(),\n    });\n    const cfnIns = instance.node.defaultChild as CfnInstance;\n    cfnIns.addPropertyOverride('DisableApiTermination', true);\n    NagSuppressions.addResourceSuppressions(instance, [\n      {\n        id: 'AwsSolutions-EC29',\n        reason: 'Remediated through property override.',\n      },\n    ]);\n  }\n}\n```\n\n</details>\n\n## Conditionally Ignoring Suppressions\n\nYou can optionally create a condition that prevents certain rules from being suppressed. You can create conditions for any variety of reasons. Examples include a condition that always ignores a suppression, a condition that ignores a suppression based on the date, a condition that ignores a suppression based on the reason. You can read [the developer docs](./docs/IgnoreSuppressionConditions.md) for more information on creating your own conditions.\n\n<details>\n  <summary>Example) Using the pre-built `SuppressionIgnoreErrors` class to ignore suppressions on any `Error` level rules.</summary>\n\n```ts\nimport { App, Aspects } from 'aws-cdk-lib';\nimport { CdkTestStack } from '../lib/cdk-test-stack';\nimport { AwsSolutionsChecks, SuppressionIgnoreErrors } from 'cdk-nag';\n\nconst app = new App();\nnew CdkTestStack(app, 'CdkNagDemo');\n// Ignore Suppressions on any errors\nAspects.of(app).add(\n  new AwsSolutionsChecks({\n    suppressionIgnoreCondition: new SuppressionIgnoreErrors(),\n  })\n);\n```\n\n</details>\n\n## Customizing Logging\n\n`NagLogger`s give `NagPack` authors and users the ability to create their own custom reporting mechanisms. All pre-built `NagPacks`come with the `AnnotationsLogger`and the `NagReportLogger` (with CSV reports) enabled by default.\n\nSee the [NagLogger](./docs/NagLogger.md) developer docs for more information.\n\n<details>\n  <summary>Example) Adding the `ExtremelyHelpfulConsoleLogger` example from the NagLogger docs</summary>\n\n```ts\nimport { App, Aspects } from 'aws-cdk-lib';\nimport { CdkTestStack } from '../lib/cdk-test-stack';\nimport { ExtremelyHelpfulConsoleLogger } from './docs/NagLogger';\nimport { AwsSolutionsChecks } from 'cdk-nag';\n\nconst app = new App();\nnew CdkTestStack(app, 'CdkNagDemo');\nAspects.of(app).add(\n  new AwsSolutionsChecks({\n    additionalLoggers: [new ExtremelyHelpfulConsoleLogger()],\n  })\n);\n```\n\n</details>\n\n## Using on CloudFormation templates\n\nYou can use cdk-nag on existing CloudFormation templates by using the [cloudformation-include](https://docs.aws.amazon.com/cdk/latest/guide/use_cfn_template.html#use_cfn_template_install) module.\n\n<details>\n  <summary>Example 1) CloudFormation template with suppression</summary>\n\nSample CloudFormation template with suppression\n\n```json\n{\n  \"Resources\": {\n    \"rBucket\": {\n      \"Type\": \"AWS::S3::Bucket\",\n      \"Properties\": {\n        \"BucketName\": \"some-bucket-name\"\n      },\n      \"Metadata\": {\n        \"cdk_nag\": {\n          \"rules_to_suppress\": [\n            {\n              \"id\": \"AwsSolutions-S1\",\n              \"reason\": \"at least 10 characters\"\n            }\n          ]\n        }\n      }\n    }\n  }\n}\n```\n\nSample App\n\n```typescript\nimport { App, Aspects } from 'aws-cdk-lib';\nimport { CdkTestStack } from '../lib/cdk-test-stack';\nimport { AwsSolutionsChecks } from 'cdk-nag';\n\nconst app = new App();\nnew CdkTestStack(app, 'CdkNagDemo');\nAspects.of(app).add(new AwsSolutionsChecks());\n```\n\nSample Stack with imported template\n\n```typescript\nimport { CfnInclude } from 'aws-cdk-lib/cloudformation-include';\nimport { NagSuppressions } from 'cdk-nag';\nimport { Stack, StackProps } from 'aws-cdk-lib';\nimport { Construct } from 'constructs';\n\nexport class CdkTestStack extends Stack {\n  constructor(scope: Construct, id: string, props?: StackProps) {\n    super(scope, id, props);\n    new CfnInclude(this, 'Template', {\n      templateFile: 'my-template.json',\n    });\n    // Add any additional suppressions\n    NagSuppressions.addResourceSuppressionsByPath(\n      this,\n      '/CdkNagDemo/Template/rBucket',\n      [\n        {\n          id: 'AwsSolutions-S2',\n          reason: 'at least 10 characters',\n        },\n      ]\n    );\n  }\n}\n```\n\n</details>\n\n<details>\n  <summary>Example 2) CloudFormation template with granular suppressions</summary>\n\nSample CloudFormation template with suppression\n\n```json\n{\n  \"Resources\": {\n    \"myPolicy\": {\n      \"Type\": \"AWS::IAM::Policy\",\n      \"Properties\": {\n        \"PolicyDocument\": {\n          \"Statement\": [\n            {\n              \"Action\": [\n                \"kms:Decrypt\",\n                \"kms:DescribeKey\",\n                \"kms:Encrypt\",\n                \"kms:ReEncrypt*\",\n                \"kms:GenerateDataKey*\"\n              ],\n              \"Effect\": \"Allow\",\n              \"Resource\": [\"some-key-arn\"]\n            }\n          ],\n          \"Version\": \"2012-10-17\"\n        }\n      },\n      \"Metadata\": {\n        \"cdk_nag\": {\n          \"rules_to_suppress\": [\n            {\n              \"id\": \"AwsSolutions-IAM5\",\n              \"reason\": \"Allow key data access\",\n              \"applies_to\": [\n                \"Action::kms:ReEncrypt*\",\n                \"Action::kms:GenerateDataKey*\"\n              ]\n            }\n          ]\n        }\n      }\n    }\n  }\n}\n```\n\nSample App\n\n```typescript\nimport { App, Aspects } from 'aws-cdk-lib';\nimport { CdkTestStack } from '../lib/cdk-test-stack';\nimport { AwsSolutionsChecks } from 'cdk-nag';\n\nconst app = new App();\nnew CdkTestStack(app, 'CdkNagDemo');\nAspects.of(app).add(new AwsSolutionsChecks());\n```\n\nSample Stack with imported template\n\n```typescript\nimport { CfnInclude } from 'aws-cdk-lib/cloudformation-include';\nimport { NagSuppressions } from 'cdk-nag';\nimport { Stack, StackProps } from 'aws-cdk-lib';\nimport { Construct } from 'constructs';\n\nexport class CdkTestStack extends Stack {\n  constructor(scope: Construct, id: string, props?: StackProps) {\n    super(scope, id, props);\n    new CfnInclude(this, 'Template', {\n      templateFile: 'my-template.json',\n    });\n    // Add any additional suppressions\n    NagSuppressions.addResourceSuppressionsByPath(\n      this,\n      '/CdkNagDemo/Template/myPolicy',\n      [\n        {\n          id: 'AwsSolutions-IAM5',\n          reason: 'Allow key data access',\n          appliesTo: ['Action::kms:ReEncrypt*', 'Action::kms:GenerateDataKey*'],\n        },\n      ]\n    );\n  }\n}\n```\n\n</details>\n\n## Contributing\n\nSee [CONTRIBUTING](./CONTRIBUTING.md) for more information.\n\n## License\n\nThis project is licensed under the Apache-2.0 License.\n"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cdklabs/cdk-nag.git"
+  },
+  "schema": "jsii/0.10.0",
+  "submodules": {
+    "cdk-nag.rules": {
+      "locationInModule": {
+        "filename": "src/index.ts",
+        "line": 16
+      },
+      "symbolId": "src/rules/index:"
+    },
+    "cdk-nag.rules.apigw": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 5
+      },
+      "symbolId": "src/rules/apigw/index:"
+    },
+    "cdk-nag.rules.appsync": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 6
+      },
+      "symbolId": "src/rules/appsync/index:"
+    },
+    "cdk-nag.rules.athena": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 7
+      },
+      "symbolId": "src/rules/athena/index:"
+    },
+    "cdk-nag.rules.autoscaling": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 8
+      },
+      "symbolId": "src/rules/autoscaling/index:"
+    },
+    "cdk-nag.rules.cloud9": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 9
+      },
+      "symbolId": "src/rules/cloud9/index:"
+    },
+    "cdk-nag.rules.cloudfront": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 10
+      },
+      "symbolId": "src/rules/cloudfront/index:"
+    },
+    "cdk-nag.rules.cloudtrail": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 11
+      },
+      "symbolId": "src/rules/cloudtrail/index:"
+    },
+    "cdk-nag.rules.cloudwatch": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 12
+      },
+      "symbolId": "src/rules/cloudwatch/index:"
+    },
+    "cdk-nag.rules.codebuild": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 13
+      },
+      "symbolId": "src/rules/codebuild/index:"
+    },
+    "cdk-nag.rules.cognito": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 14
+      },
+      "symbolId": "src/rules/cognito/index:"
+    },
+    "cdk-nag.rules.dms": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 15
+      },
+      "symbolId": "src/rules/dms/index:"
+    },
+    "cdk-nag.rules.documentdb": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 16
+      },
+      "symbolId": "src/rules/documentdb/index:"
+    },
+    "cdk-nag.rules.dynamodb": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 17
+      },
+      "symbolId": "src/rules/dynamodb/index:"
+    },
+    "cdk-nag.rules.ec2": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 18
+      },
+      "symbolId": "src/rules/ec2/index:"
+    },
+    "cdk-nag.rules.ecr": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 19
+      },
+      "symbolId": "src/rules/ecr/index:"
+    },
+    "cdk-nag.rules.ecs": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 20
+      },
+      "symbolId": "src/rules/ecs/index:"
+    },
+    "cdk-nag.rules.efs": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 22
+      },
+      "symbolId": "src/rules/efs/index:"
+    },
+    "cdk-nag.rules.eks": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 21
+      },
+      "symbolId": "src/rules/eks/index:"
+    },
+    "cdk-nag.rules.elasticache": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 23
+      },
+      "symbolId": "src/rules/elasticache/index:"
+    },
+    "cdk-nag.rules.elasticbeanstalk": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 24
+      },
+      "symbolId": "src/rules/elasticbeanstalk/index:"
+    },
+    "cdk-nag.rules.elb": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 25
+      },
+      "symbolId": "src/rules/elb/index:"
+    },
+    "cdk-nag.rules.emr": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 26
+      },
+      "symbolId": "src/rules/emr/index:"
+    },
+    "cdk-nag.rules.eventbridge": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 27
+      },
+      "symbolId": "src/rules/eventbridge/index:"
+    },
+    "cdk-nag.rules.glue": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 28
+      },
+      "symbolId": "src/rules/glue/index:"
+    },
+    "cdk-nag.rules.iam": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 29
+      },
+      "symbolId": "src/rules/iam/index:"
+    },
+    "cdk-nag.rules.kinesis": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 30
+      },
+      "symbolId": "src/rules/kinesis/index:"
+    },
+    "cdk-nag.rules.kms": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 31
+      },
+      "symbolId": "src/rules/kms/index:"
+    },
+    "cdk-nag.rules.lambda": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 32
+      },
+      "symbolId": "src/rules/lambda/index:"
+    },
+    "cdk-nag.rules.lex": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 33
+      },
+      "symbolId": "src/rules/lex/index:"
+    },
+    "cdk-nag.rules.mediastore": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 34
+      },
+      "symbolId": "src/rules/mediastore/index:"
+    },
+    "cdk-nag.rules.msk": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 35
+      },
+      "symbolId": "src/rules/msk/index:"
+    },
+    "cdk-nag.rules.neptune": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 36
+      },
+      "symbolId": "src/rules/neptune/index:"
+    },
+    "cdk-nag.rules.opensearch": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 37
+      },
+      "symbolId": "src/rules/opensearch/index:"
+    },
+    "cdk-nag.rules.quicksight": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 38
+      },
+      "symbolId": "src/rules/quicksight/index:"
+    },
+    "cdk-nag.rules.rds": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 39
+      },
+      "symbolId": "src/rules/rds/index:"
+    },
+    "cdk-nag.rules.redshift": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 40
+      },
+      "symbolId": "src/rules/redshift/index:"
+    },
+    "cdk-nag.rules.s3": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 41
+      },
+      "symbolId": "src/rules/s3/index:"
+    },
+    "cdk-nag.rules.sagemaker": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 42
+      },
+      "symbolId": "src/rules/sagemaker/index:"
+    },
+    "cdk-nag.rules.secretsmanager": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 43
+      },
+      "symbolId": "src/rules/secretsmanager/index:"
+    },
+    "cdk-nag.rules.sns": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 44
+      },
+      "symbolId": "src/rules/sns/index:"
+    },
+    "cdk-nag.rules.sqs": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 45
+      },
+      "symbolId": "src/rules/sqs/index:"
+    },
+    "cdk-nag.rules.stepfunctions": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 46
+      },
+      "symbolId": "src/rules/stepfunctions/index:"
+    },
+    "cdk-nag.rules.timestream": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 47
+      },
+      "symbolId": "src/rules/timestream/index:"
+    },
+    "cdk-nag.rules.vpc": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 48
+      },
+      "symbolId": "src/rules/vpc/index:"
+    },
+    "cdk-nag.rules.waf": {
+      "locationInModule": {
+        "filename": "src/rules/index.ts",
+        "line": 49
+      },
+      "symbolId": "src/rules/waf/index:"
+    }
+  },
+  "targets": {
+    "dotnet": {
+      "namespace": "Cdklabs.CdkNag",
+      "packageId": "Cdklabs.CdkNag"
+    },
+    "go": {
+      "moduleName": "github.com/cdklabs/cdk-nag-go"
+    },
+    "java": {
+      "maven": {
+        "artifactId": "cdknag",
+        "groupId": "io.github.cdklabs"
+      },
+      "package": "io.github.cdklabs.cdknag"
+    },
+    "js": {
+      "npm": "cdk-nag"
+    },
+    "python": {
+      "distName": "cdk-nag",
+      "module": "cdk_nag"
+    }
+  },
+  "types": {
+    "cdk-nag.AnnotationLogger": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "A NagLogger that outputs to the CDK Annotations system."
+      },
+      "fqn": "cdk-nag.AnnotationLogger",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "src/nag-logger.ts",
+          "line": 124
+        },
+        "parameters": [
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "cdk-nag.AnnotationLoggerProps"
+            }
+          }
+        ]
+      },
+      "interfaces": [
+        "cdk-nag.INagLogger"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 120
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 184
+          },
+          "name": "createMessage",
+          "parameters": [
+            {
+              "name": "ruleId",
+              "type": {
+                "primitive": "string"
+              }
+            },
+            {
+              "name": "findingId",
+              "type": {
+                "primitive": "string"
+              }
+            },
+            {
+              "name": "ruleInfo",
+              "type": {
+                "primitive": "string"
+              }
+            },
+            {
+              "name": "ruleExplanation",
+              "type": {
+                "primitive": "string"
+              }
+            },
+            {
+              "name": "verbose",
+              "type": {
+                "primitive": "boolean"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a CfnResource passes the compliance check for a given rule."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 128
+          },
+          "name": "onCompliance",
+          "overrides": "cdk-nag.INagLogger",
+          "parameters": [
+            {
+              "name": "_data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerComplianceData"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a rule throws an error during while validating a CfnResource for compliance."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 157
+          },
+          "name": "onError",
+          "overrides": "cdk-nag.INagLogger",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerErrorData"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a CfnResource does not pass the compliance check for a given rule and the the rule violation is not suppressed by the user."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 131
+          },
+          "name": "onNonCompliance",
+          "overrides": "cdk-nag.INagLogger",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerNonComplianceData"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a rule does not apply to the given CfnResource."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 180
+          },
+          "name": "onNotApplicable",
+          "overrides": "cdk-nag.INagLogger",
+          "parameters": [
+            {
+              "name": "_data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerNotApplicableData"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a CfnResource does not pass the compliance check for a given rule and the rule violation is suppressed by the user."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 145
+          },
+          "name": "onSuppressed",
+          "overrides": "cdk-nag.INagLogger",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerSuppressedData"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a rule throws an error during while validating a CfnResource for compliance and the error is suppressed."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 168
+          },
+          "name": "onSuppressedError",
+          "overrides": "cdk-nag.INagLogger",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerSuppressedErrorData"
+              }
+            }
+          ]
+        }
+      ],
+      "name": "AnnotationLogger",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 123
+          },
+          "name": "logIgnores",
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 122
+          },
+          "name": "verbose",
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 121
+          },
+          "name": "suppressionId",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ],
+      "symbolId": "src/nag-logger:AnnotationLogger"
+    },
+    "cdk-nag.AnnotationLoggerProps": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Props for the AnnotationLogger."
+      },
+      "fqn": "cdk-nag.AnnotationLoggerProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 106
+      },
+      "name": "AnnotationLoggerProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Whether or not to log suppressed rule violations as informational messages (default: false)."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 115
+          },
+          "name": "logIgnores",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 110
+          },
+          "name": "verbose",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        }
+      ],
+      "symbolId": "src/nag-logger:AnnotationLoggerProps"
+    },
+    "cdk-nag.AwsSolutionsChecks": {
+      "assembly": "cdk-nag",
+      "base": "cdk-nag.NagPack",
+      "docs": {
+        "stability": "stable",
+        "summary": "Check Best practices based on AWS Solutions Security Matrix."
+      },
+      "fqn": "cdk-nag.AwsSolutionsChecks",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "src/packs/aws-solutions.ts",
+          "line": 194
+        },
+        "parameters": [
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "cdk-nag.NagPackProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/packs/aws-solutions.ts",
+        "line": 193
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "All aspects can visit an IConstruct."
+          },
+          "locationInModule": {
+            "filename": "src/packs/aws-solutions.ts",
+            "line": 198
+          },
+          "name": "visit",
+          "overrides": "cdk-nag.NagPack",
+          "parameters": [
+            {
+              "name": "node",
+              "type": {
+                "fqn": "constructs.IConstruct"
+              }
+            }
+          ]
+        }
+      ],
+      "name": "AwsSolutionsChecks",
+      "symbolId": "src/packs/aws-solutions:AwsSolutionsChecks"
+    },
+    "cdk-nag.HIPAASecurityChecks": {
+      "assembly": "cdk-nag",
+      "base": "cdk-nag.NagPack",
+      "docs": {
+        "remarks": "Based on the HIPAA Security AWS operational best practices: https://docs.aws.amazon.com/config/latest/developerguide/operational-best-practices-for-hipaa_security.html",
+        "stability": "stable",
+        "summary": "Check for HIPAA Security compliance."
+      },
+      "fqn": "cdk-nag.HIPAASecurityChecks",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "src/packs/hipaa-security.ts",
+          "line": 141
+        },
+        "parameters": [
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "cdk-nag.NagPackProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/packs/hipaa-security.ts",
+        "line": 140
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "All aspects can visit an IConstruct."
+          },
+          "locationInModule": {
+            "filename": "src/packs/hipaa-security.ts",
+            "line": 146
+          },
+          "name": "visit",
+          "overrides": "cdk-nag.NagPack",
+          "parameters": [
+            {
+              "name": "node",
+              "type": {
+                "fqn": "constructs.IConstruct"
+              }
+            }
+          ]
+        }
+      ],
+      "name": "HIPAASecurityChecks",
+      "symbolId": "src/packs/hipaa-security:HIPAASecurityChecks"
+    },
+    "cdk-nag.IApplyRule": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Interface for JSII interoperability for passing parameters and the Rule Callback to @applyRule method."
+      },
+      "fqn": "cdk-nag.IApplyRule",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-pack.ts",
+        "line": 67
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "The callback to the rule."
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 96
+          },
+          "name": "rule",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "The CfnResource to check."
+              },
+              "name": "node",
+              "type": {
+                "fqn": "aws-cdk-lib.CfnResource"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "union": {
+                "types": [
+                  {
+                    "fqn": "cdk-nag.NagRuleCompliance"
+                  },
+                  {
+                    "collection": {
+                      "elementtype": {
+                        "primitive": "string"
+                      },
+                      "kind": "array"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "name": "IApplyRule",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Why the rule exists."
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 79
+          },
+          "name": "explanation",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Why the rule was triggered."
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 75
+          },
+          "name": "info",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "The annotations message level to apply to the rule if triggered."
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 83
+          },
+          "name": "level",
+          "type": {
+            "fqn": "cdk-nag.NagMessageLevel"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "The CfnResource to check."
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 91
+          },
+          "name": "node",
+          "type": {
+            "fqn": "aws-cdk-lib.CfnResource"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "A condition in which a suppression should be ignored."
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 87
+          },
+          "name": "ignoreSuppressionCondition",
+          "optional": true,
+          "type": {
+            "fqn": "cdk-nag.INagSuppressionIgnore"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Override for the suffix of the Rule ID for this rule."
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 71
+          },
+          "name": "ruleSuffixOverride",
+          "optional": true,
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ],
+      "symbolId": "src/nag-pack:IApplyRule"
+    },
+    "cdk-nag.INagLogger": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Interface for creating NagSuppression Ignores."
+      },
+      "fqn": "cdk-nag.INagLogger",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 76
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a CfnResource passes the compliance check for a given rule."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 80
+          },
+          "name": "onCompliance",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerComplianceData"
+              }
+            }
+          ]
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a rule throws an error during while validating a CfnResource for compliance."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 92
+          },
+          "name": "onError",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerErrorData"
+              }
+            }
+          ]
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a CfnResource does not pass the compliance check for a given rule and the the rule violation is not suppressed by the user."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 84
+          },
+          "name": "onNonCompliance",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerNonComplianceData"
+              }
+            }
+          ]
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a rule does not apply to the given CfnResource."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 100
+          },
+          "name": "onNotApplicable",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerNotApplicableData"
+              }
+            }
+          ]
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a CfnResource does not pass the compliance check for a given rule and the rule violation is suppressed by the user."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 88
+          },
+          "name": "onSuppressed",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerSuppressedData"
+              }
+            }
+          ]
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a rule throws an error during while validating a CfnResource for compliance and the error is suppressed."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 96
+          },
+          "name": "onSuppressedError",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerSuppressedErrorData"
+              }
+            }
+          ]
+        }
+      ],
+      "name": "INagLogger",
+      "symbolId": "src/nag-logger:INagLogger"
+    },
+    "cdk-nag.INagSuppressionIgnore": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Interface for creating NagSuppression Ignores."
+      },
+      "fqn": "cdk-nag.INagSuppressionIgnore",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/ignore-suppression-conditions.ts",
+        "line": 27
+      },
+      "methods": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/ignore-suppression-conditions.ts",
+            "line": 28
+          },
+          "name": "createMessage",
+          "parameters": [
+            {
+              "name": "input",
+              "type": {
+                "fqn": "cdk-nag.SuppressionIgnoreInput"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "INagSuppressionIgnore",
+      "symbolId": "src/ignore-suppression-conditions:INagSuppressionIgnore"
+    },
+    "cdk-nag.NIST80053R4Checks": {
+      "assembly": "cdk-nag",
+      "base": "cdk-nag.NagPack",
+      "docs": {
+        "remarks": "Based on the NIST 800-53 rev 4 AWS operational best practices: https://docs.aws.amazon.com/config/latest/developerguide/operational-best-practices-for-nist-800-53_rev_4.html",
+        "stability": "stable",
+        "summary": "Check for NIST 800-53 rev 4 compliance."
+      },
+      "fqn": "cdk-nag.NIST80053R4Checks",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "src/packs/nist-800-53-r4.ts",
+          "line": 115
+        },
+        "parameters": [
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "cdk-nag.NagPackProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/packs/nist-800-53-r4.ts",
+        "line": 114
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "All aspects can visit an IConstruct."
+          },
+          "locationInModule": {
+            "filename": "src/packs/nist-800-53-r4.ts",
+            "line": 120
+          },
+          "name": "visit",
+          "overrides": "cdk-nag.NagPack",
+          "parameters": [
+            {
+              "name": "node",
+              "type": {
+                "fqn": "constructs.IConstruct"
+              }
+            }
+          ]
+        }
+      ],
+      "name": "NIST80053R4Checks",
+      "symbolId": "src/packs/nist-800-53-r4:NIST80053R4Checks"
+    },
+    "cdk-nag.NIST80053R5Checks": {
+      "assembly": "cdk-nag",
+      "base": "cdk-nag.NagPack",
+      "docs": {
+        "remarks": "Based on the NIST 800-53 rev 5 AWS operational best practices: https://docs.aws.amazon.com/config/latest/developerguide/operational-best-practices-for-nist-800-53_rev_5.html",
+        "stability": "stable",
+        "summary": "Check for NIST 800-53 rev 5 compliance."
+      },
+      "fqn": "cdk-nag.NIST80053R5Checks",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "src/packs/nist-800-53-r5.ts",
+          "line": 134
+        },
+        "parameters": [
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "cdk-nag.NagPackProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/packs/nist-800-53-r5.ts",
+        "line": 133
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "All aspects can visit an IConstruct."
+          },
+          "locationInModule": {
+            "filename": "src/packs/nist-800-53-r5.ts",
+            "line": 138
+          },
+          "name": "visit",
+          "overrides": "cdk-nag.NagPack",
+          "parameters": [
+            {
+              "name": "node",
+              "type": {
+                "fqn": "constructs.IConstruct"
+              }
+            }
+          ]
+        }
+      ],
+      "name": "NIST80053R5Checks",
+      "symbolId": "src/packs/nist-800-53-r5:NIST80053R5Checks"
+    },
+    "cdk-nag.NagLoggerBaseData": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Shared data for all INagLogger methods."
+      },
+      "fqn": "cdk-nag.NagLoggerBaseData",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 25
+      },
+      "name": "NagLoggerBaseData",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 26
+          },
+          "name": "nagPackName",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 27
+          },
+          "name": "resource",
+          "type": {
+            "fqn": "aws-cdk-lib.CfnResource"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 30
+          },
+          "name": "ruleExplanation",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 28
+          },
+          "name": "ruleId",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 29
+          },
+          "name": "ruleInfo",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 31
+          },
+          "name": "ruleLevel",
+          "type": {
+            "fqn": "cdk-nag.NagMessageLevel"
+          }
+        }
+      ],
+      "symbolId": "src/nag-logger:NagLoggerBaseData"
+    },
+    "cdk-nag.NagLoggerComplianceData": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Data for onCompliance method of an INagLogger."
+      },
+      "fqn": "cdk-nag.NagLoggerComplianceData",
+      "interfaces": [
+        "cdk-nag.NagLoggerBaseData"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 37
+      },
+      "name": "NagLoggerComplianceData",
+      "symbolId": "src/nag-logger:NagLoggerComplianceData"
+    },
+    "cdk-nag.NagLoggerErrorData": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Data for onError method of an INagLogger."
+      },
+      "fqn": "cdk-nag.NagLoggerErrorData",
+      "interfaces": [
+        "cdk-nag.NagLoggerBaseData"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 57
+      },
+      "name": "NagLoggerErrorData",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 58
+          },
+          "name": "errorMessage",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ],
+      "symbolId": "src/nag-logger:NagLoggerErrorData"
+    },
+    "cdk-nag.NagLoggerNonComplianceData": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Data for onNonCompliance method of an INagLogger."
+      },
+      "fqn": "cdk-nag.NagLoggerNonComplianceData",
+      "interfaces": [
+        "cdk-nag.NagLoggerBaseData"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 42
+      },
+      "name": "NagLoggerNonComplianceData",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 43
+          },
+          "name": "findingId",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ],
+      "symbolId": "src/nag-logger:NagLoggerNonComplianceData"
+    },
+    "cdk-nag.NagLoggerNotApplicableData": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Data for onNotApplicable method of an INagLogger."
+      },
+      "fqn": "cdk-nag.NagLoggerNotApplicableData",
+      "interfaces": [
+        "cdk-nag.NagLoggerBaseData"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 71
+      },
+      "name": "NagLoggerNotApplicableData",
+      "symbolId": "src/nag-logger:NagLoggerNotApplicableData"
+    },
+    "cdk-nag.NagLoggerSuppressedData": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Data for onSuppressed method of an INagLogger."
+      },
+      "fqn": "cdk-nag.NagLoggerSuppressedData",
+      "interfaces": [
+        "cdk-nag.NagLoggerNonComplianceData"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 49
+      },
+      "name": "NagLoggerSuppressedData",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 50
+          },
+          "name": "suppressionReason",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ],
+      "symbolId": "src/nag-logger:NagLoggerSuppressedData"
+    },
+    "cdk-nag.NagLoggerSuppressedErrorData": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Data for onSuppressedError method of an INagLogger."
+      },
+      "fqn": "cdk-nag.NagLoggerSuppressedErrorData",
+      "interfaces": [
+        "cdk-nag.NagLoggerErrorData"
+      ],
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 64
+      },
+      "name": "NagLoggerSuppressedErrorData",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 65
+          },
+          "name": "errorSuppressionReason",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ],
+      "symbolId": "src/nag-logger:NagLoggerSuppressedErrorData"
+    },
+    "cdk-nag.NagMessageLevel": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "The severity level of the rule."
+      },
+      "fqn": "cdk-nag.NagMessageLevel",
+      "kind": "enum",
+      "locationInModule": {
+        "filename": "src/nag-rules.ts",
+        "line": 12
+      },
+      "members": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "name": "WARN"
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "name": "ERROR"
+        }
+      ],
+      "name": "NagMessageLevel",
+      "symbolId": "src/nag-rules:NagMessageLevel"
+    },
+    "cdk-nag.NagPack": {
+      "abstract": true,
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Base class for all rule packs."
+      },
+      "fqn": "cdk-nag.NagPack",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "src/nag-pack.ts",
+          "line": 108
+        },
+        "parameters": [
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "cdk-nag.NagPackProps"
+            }
+          }
+        ]
+      },
+      "interfaces": [
+        "aws-cdk-lib.IAspect"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/nag-pack.ts",
+        "line": 102
+      },
+      "methods": [
+        {
+          "docs": {
+            "custom": {
+              "IApplyRule": "interface with rule details."
+            },
+            "stability": "stable",
+            "summary": "Create a rule to be used in the NagPack."
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 140
+          },
+          "name": "applyRule",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "The."
+              },
+              "name": "params",
+              "type": {
+                "fqn": "cdk-nag.IApplyRule"
+              }
+            }
+          ],
+          "protected": true
+        },
+        {
+          "docs": {
+            "returns": "The reason the rule was ignored, or an empty string.",
+            "stability": "stable",
+            "summary": "Check whether a specific rule should be ignored."
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 234
+          },
+          "name": "ignoreRule",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "The suppressions listed in the cdk-nag metadata."
+              },
+              "name": "suppressions",
+              "type": {
+                "collection": {
+                  "elementtype": {
+                    "fqn": "cdk-nag.NagPackSuppression"
+                  },
+                  "kind": "array"
+                }
+              }
+            },
+            {
+              "docs": {
+                "summary": "The id of the rule to ignore."
+              },
+              "name": "ruleId",
+              "type": {
+                "primitive": "string"
+              }
+            },
+            {
+              "docs": {
+                "summary": "The id of the finding that is being checked."
+              },
+              "name": "findingId",
+              "type": {
+                "primitive": "string"
+              }
+            },
+            {
+              "docs": {
+                "summary": "The resource being evaluated."
+              },
+              "name": "resource",
+              "type": {
+                "fqn": "aws-cdk-lib.CfnResource"
+              }
+            },
+            {
+              "name": "level",
+              "type": {
+                "fqn": "cdk-nag.NagMessageLevel"
+              }
+            },
+            {
+              "name": "ignoreSuppressionCondition",
+              "optional": true,
+              "type": {
+                "fqn": "cdk-nag.INagSuppressionIgnore"
+              }
+            }
+          ],
+          "protected": true,
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "All aspects can visit an IConstruct."
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 134
+          },
+          "name": "visit",
+          "overrides": "aws-cdk-lib.IAspect",
+          "parameters": [
+            {
+              "name": "node",
+              "type": {
+                "fqn": "constructs.IConstruct"
+              }
+            }
+          ]
+        }
+      ],
+      "name": "NagPack",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 127
+          },
+          "name": "readPackName",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 103
+          },
+          "name": "loggers",
+          "protected": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "cdk-nag.INagLogger"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 104
+          },
+          "name": "packName",
+          "protected": true,
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 106
+          },
+          "name": "packGlobalSuppressionIgnore",
+          "optional": true,
+          "protected": true,
+          "type": {
+            "fqn": "cdk-nag.INagSuppressionIgnore"
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 105
+          },
+          "name": "userGlobalSuppressionIgnore",
+          "optional": true,
+          "protected": true,
+          "type": {
+            "fqn": "cdk-nag.INagSuppressionIgnore"
+          }
+        }
+      ],
+      "symbolId": "src/nag-pack:NagPack"
+    },
+    "cdk-nag.NagPackProps": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Interface for creating a NagPack."
+      },
+      "fqn": "cdk-nag.NagPackProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-pack.ts",
+        "line": 32
+      },
+      "name": "NagPackProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Additional NagLoggers for logging rule validation outputs."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 61
+          },
+          "name": "additionalLoggers",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "cdk-nag.INagLogger"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Whether or not to log suppressed rule violations as informational messages (default: false)."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 41
+          },
+          "name": "logIgnores",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "If reports are enabled, the output formats of compliance reports in the App's output directory (default: only CSV)."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 51
+          },
+          "name": "reportFormats",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "cdk-nag.NagReportFormat"
+              },
+              "kind": "array"
+            }
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Whether or not to generate compliance reports for applied Stacks in the App's output directory (default: true)."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 46
+          },
+          "name": "reports",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Conditionally prevent rules from being suppressed (default: no user provided condition)."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 56
+          },
+          "name": "suppressionIgnoreCondition",
+          "optional": true,
+          "type": {
+            "fqn": "cdk-nag.INagSuppressionIgnore"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false)."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-pack.ts",
+            "line": 36
+          },
+          "name": "verbose",
+          "optional": true,
+          "type": {
+            "primitive": "boolean"
+          }
+        }
+      ],
+      "symbolId": "src/nag-pack:NagPackProps"
+    },
+    "cdk-nag.NagPackSuppression": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Interface for creating a rule suppression."
+      },
+      "fqn": "cdk-nag.NagPackSuppression",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/models/nag-suppression.ts",
+        "line": 9
+      },
+      "name": "NagPackSuppression",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "The id of the rule to ignore."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/models/nag-suppression.ts",
+            "line": 13
+          },
+          "name": "id",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "The reason to ignore the rule (minimum 10 characters)."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/models/nag-suppression.ts",
+            "line": 17
+          },
+          "name": "reason",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "Rule specific granular suppressions."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/models/nag-suppression.ts",
+            "line": 21
+          },
+          "name": "appliesTo",
+          "optional": true,
+          "type": {
+            "collection": {
+              "elementtype": {
+                "union": {
+                  "types": [
+                    {
+                      "primitive": "string"
+                    },
+                    {
+                      "fqn": "cdk-nag.RegexAppliesTo"
+                    }
+                  ]
+                }
+              },
+              "kind": "array"
+            }
+          }
+        }
+      ],
+      "symbolId": "src/models/nag-suppression:NagPackSuppression"
+    },
+    "cdk-nag.NagReportFormat": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Possible output formats of the NagReport."
+      },
+      "fqn": "cdk-nag.NagReportFormat",
+      "kind": "enum",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 214
+      },
+      "members": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "name": "CSV"
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "name": "JSON"
+        }
+      ],
+      "name": "NagReportFormat",
+      "symbolId": "src/nag-logger:NagReportFormat"
+    },
+    "cdk-nag.NagReportLine": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable"
+      },
+      "fqn": "cdk-nag.NagReportLine",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 202
+      },
+      "name": "NagReportLine",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 205
+          },
+          "name": "compliance",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 206
+          },
+          "name": "exceptionReason",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 204
+          },
+          "name": "resourceId",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 203
+          },
+          "name": "ruleId",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 208
+          },
+          "name": "ruleInfo",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 207
+          },
+          "name": "ruleLevel",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ],
+      "symbolId": "src/nag-logger:NagReportLine"
+    },
+    "cdk-nag.NagReportLogger": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "A NagLogger that creates compliance reports."
+      },
+      "fqn": "cdk-nag.NagReportLogger",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "src/nag-logger.ts",
+          "line": 232
+        },
+        "parameters": [
+          {
+            "name": "props",
+            "type": {
+              "fqn": "cdk-nag.NagReportLoggerProps"
+            }
+          }
+        ]
+      },
+      "interfaces": [
+        "cdk-nag.INagLogger"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 229
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 272
+          },
+          "name": "getFormatStacks",
+          "parameters": [
+            {
+              "name": "format",
+              "type": {
+                "fqn": "cdk-nag.NagReportFormat"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "collection": {
+                "elementtype": {
+                  "primitive": "string"
+                },
+                "kind": "array"
+              }
+            }
+          }
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Initialize the report for the rule pack's compliance report for the resource's Stack if it doesn't exist."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 280
+          },
+          "name": "initializeStackReport",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerBaseData"
+              }
+            }
+          ],
+          "protected": true
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a CfnResource passes the compliance check for a given rule."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 239
+          },
+          "name": "onCompliance",
+          "overrides": "cdk-nag.INagLogger",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerComplianceData"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a rule throws an error during while validating a CfnResource for compliance."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 254
+          },
+          "name": "onError",
+          "overrides": "cdk-nag.INagLogger",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerErrorData"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a CfnResource does not pass the compliance check for a given rule and the the rule violation is not suppressed by the user."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 243
+          },
+          "name": "onNonCompliance",
+          "overrides": "cdk-nag.INagLogger",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerNonComplianceData"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a rule does not apply to the given CfnResource."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 268
+          },
+          "name": "onNotApplicable",
+          "overrides": "cdk-nag.INagLogger",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerNotApplicableData"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a CfnResource does not pass the compliance check for a given rule and the rule violation is suppressed by the user."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 247
+          },
+          "name": "onSuppressed",
+          "overrides": "cdk-nag.INagLogger",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerSuppressedData"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Called when a rule throws an error during while validating a CfnResource for compliance and the error is suppressed."
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 261
+          },
+          "name": "onSuppressedError",
+          "overrides": "cdk-nag.INagLogger",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerSuppressedErrorData"
+              }
+            }
+          ]
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 306
+          },
+          "name": "writeToStackComplianceReport",
+          "parameters": [
+            {
+              "name": "data",
+              "type": {
+                "fqn": "cdk-nag.NagLoggerBaseData"
+              }
+            },
+            {
+              "name": "compliance",
+              "type": {
+                "union": {
+                  "types": [
+                    {
+                      "fqn": "cdk-nag.NagRuleCompliance"
+                    },
+                    {
+                      "fqn": "cdk-nag.NagRulePostValidationStates"
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "protected": true
+        }
+      ],
+      "name": "NagReportLogger",
+      "properties": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 231
+          },
+          "name": "formats",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "cdk-nag.NagReportFormat"
+              },
+              "kind": "array"
+            }
+          }
+        }
+      ],
+      "symbolId": "src/nag-logger:NagReportLogger"
+    },
+    "cdk-nag.NagReportLoggerProps": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Props for the NagReportLogger."
+      },
+      "fqn": "cdk-nag.NagReportLoggerProps",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 222
+      },
+      "name": "NagReportLoggerProps",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 223
+          },
+          "name": "formats",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "cdk-nag.NagReportFormat"
+              },
+              "kind": "array"
+            }
+          }
+        }
+      ],
+      "symbolId": "src/nag-logger:NagReportLoggerProps"
+    },
+    "cdk-nag.NagReportSchema": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable"
+      },
+      "fqn": "cdk-nag.NagReportSchema",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/nag-logger.ts",
+        "line": 198
+      },
+      "name": "NagReportSchema",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/nag-logger.ts",
+            "line": 199
+          },
+          "name": "lines",
+          "type": {
+            "collection": {
+              "elementtype": {
+                "fqn": "cdk-nag.NagReportLine"
+              },
+              "kind": "array"
+            }
+          }
+        }
+      ],
+      "symbolId": "src/nag-logger:NagReportSchema"
+    },
+    "cdk-nag.NagRuleCompliance": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "The compliance level of a resource in relation to a rule."
+      },
+      "fqn": "cdk-nag.NagRuleCompliance",
+      "kind": "enum",
+      "locationInModule": {
+        "filename": "src/nag-rules.ts",
+        "line": 20
+      },
+      "members": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "name": "COMPLIANT"
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "name": "NON_COMPLIANT"
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "name": "NOT_APPLICABLE"
+        }
+      ],
+      "name": "NagRuleCompliance",
+      "symbolId": "src/nag-rules:NagRuleCompliance"
+    },
+    "cdk-nag.NagRulePostValidationStates": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Additional states a rule can be in post compliance validation."
+      },
+      "fqn": "cdk-nag.NagRulePostValidationStates",
+      "kind": "enum",
+      "locationInModule": {
+        "filename": "src/nag-rules.ts",
+        "line": 29
+      },
+      "members": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "name": "SUPPRESSED"
+        },
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "name": "UNKNOWN"
+        }
+      ],
+      "name": "NagRulePostValidationStates",
+      "symbolId": "src/nag-rules:NagRulePostValidationStates"
+    },
+    "cdk-nag.NagRules": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Helper class with methods for rule creation."
+      },
+      "fqn": "cdk-nag.NagRules",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        }
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/nag-rules.ts",
+        "line": 52
+      },
+      "methods": [
+        {
+          "docs": {
+            "remarks": "https://developer.mozilla.org/en-US/docs/Glossary/Primitive",
+            "returns": "Return a value if resolves to a primitive data type, otherwise throw an error.",
+            "stability": "stable",
+            "summary": "Use in cases where a primitive value must be known to pass a rule."
+          },
+          "locationInModule": {
+            "filename": "src/nag-rules.ts",
+            "line": 60
+          },
+          "name": "resolveIfPrimitive",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "The CfnResource to check."
+              },
+              "name": "node",
+              "type": {
+                "fqn": "aws-cdk-lib.CfnResource"
+              }
+            },
+            {
+              "docs": {
+                "summary": "The value to attempt to resolve."
+              },
+              "name": "parameter",
+              "type": {
+                "primitive": "any"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "any"
+            }
+          },
+          "static": true
+        },
+        {
+          "docs": {
+            "returns": "Return the Logical resource Id if resolves to a intrinsic function, otherwise the resolved provided value.",
+            "stability": "stable",
+            "summary": "Use in cases where a token resolves to an intrinsic function and the referenced resource must be known to pass a rule."
+          },
+          "locationInModule": {
+            "filename": "src/nag-rules.ts",
+            "line": 79
+          },
+          "name": "resolveResourceFromInstrinsic",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "The CfnResource to check."
+              },
+              "name": "node",
+              "type": {
+                "fqn": "aws-cdk-lib.CfnResource"
+              }
+            },
+            {
+              "docs": {
+                "summary": "The value to attempt to resolve."
+              },
+              "name": "parameter",
+              "type": {
+                "primitive": "any"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "any"
+            }
+          },
+          "static": true
+        }
+      ],
+      "name": "NagRules",
+      "symbolId": "src/nag-rules:NagRules"
+    },
+    "cdk-nag.NagSuppressions": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Helper class with methods to add cdk-nag suppressions to cdk resources."
+      },
+      "fqn": "cdk-nag.NagSuppressions",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        }
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/nag-suppressions.ts",
+        "line": 13
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Add cdk-nag suppressions to a CfnResource and optionally its children."
+          },
+          "locationInModule": {
+            "filename": "src/nag-suppressions.ts",
+            "line": 48
+          },
+          "name": "addResourceSuppressions",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "The IConstruct(s) to apply the suppression to."
+              },
+              "name": "construct",
+              "type": {
+                "union": {
+                  "types": [
+                    {
+                      "fqn": "constructs.IConstruct"
+                    },
+                    {
+                      "collection": {
+                        "elementtype": {
+                          "fqn": "constructs.IConstruct"
+                        },
+                        "kind": "array"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "docs": {
+                "summary": "A list of suppressions to apply to the resource."
+              },
+              "name": "suppressions",
+              "type": {
+                "collection": {
+                  "elementtype": {
+                    "fqn": "cdk-nag.NagPackSuppression"
+                  },
+                  "kind": "array"
+                }
+              }
+            },
+            {
+              "docs": {
+                "summary": "Apply the suppressions to children CfnResources  (default:false)."
+              },
+              "name": "applyToChildren",
+              "optional": true,
+              "type": {
+                "primitive": "boolean"
+              }
+            }
+          ],
+          "static": true
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Add cdk-nag suppressions to a CfnResource and optionally its children via its path."
+          },
+          "locationInModule": {
+            "filename": "src/nag-suppressions.ts",
+            "line": 87
+          },
+          "name": "addResourceSuppressionsByPath",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "The Stack the construct belongs to."
+              },
+              "name": "stack",
+              "type": {
+                "fqn": "aws-cdk-lib.Stack"
+              }
+            },
+            {
+              "docs": {
+                "summary": "The path(s) to the construct in the provided stack."
+              },
+              "name": "path",
+              "type": {
+                "union": {
+                  "types": [
+                    {
+                      "primitive": "string"
+                    },
+                    {
+                      "collection": {
+                        "elementtype": {
+                          "primitive": "string"
+                        },
+                        "kind": "array"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "docs": {
+                "summary": "A list of suppressions to apply to the resource."
+              },
+              "name": "suppressions",
+              "type": {
+                "collection": {
+                  "elementtype": {
+                    "fqn": "cdk-nag.NagPackSuppression"
+                  },
+                  "kind": "array"
+                }
+              }
+            },
+            {
+              "docs": {
+                "summary": "Apply the suppressions to children CfnResources  (default:false)."
+              },
+              "name": "applyToChildren",
+              "optional": true,
+              "type": {
+                "primitive": "boolean"
+              }
+            }
+          ],
+          "static": true
+        },
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "Apply cdk-nag suppressions to a Stack and optionally nested stacks."
+          },
+          "locationInModule": {
+            "filename": "src/nag-suppressions.ts",
+            "line": 20
+          },
+          "name": "addStackSuppressions",
+          "parameters": [
+            {
+              "docs": {
+                "summary": "The Stack to apply the suppression to."
+              },
+              "name": "stack",
+              "type": {
+                "fqn": "aws-cdk-lib.Stack"
+              }
+            },
+            {
+              "docs": {
+                "summary": "A list of suppressions to apply to the stack."
+              },
+              "name": "suppressions",
+              "type": {
+                "collection": {
+                  "elementtype": {
+                    "fqn": "cdk-nag.NagPackSuppression"
+                  },
+                  "kind": "array"
+                }
+              }
+            },
+            {
+              "docs": {
+                "summary": "Apply the suppressions to children stacks (default:false)."
+              },
+              "name": "applyToNestedStacks",
+              "optional": true,
+              "type": {
+                "primitive": "boolean"
+              }
+            }
+          ],
+          "static": true
+        }
+      ],
+      "name": "NagSuppressions",
+      "symbolId": "src/nag-suppressions:NagSuppressions"
+    },
+    "cdk-nag.PCIDSS321Checks": {
+      "assembly": "cdk-nag",
+      "base": "cdk-nag.NagPack",
+      "docs": {
+        "stability": "stable",
+        "summary": "Check for PCI DSS 3.2.1 compliance. Based on the PCI DSS 3.2.1 AWS operational best practices: https://docs.aws.amazon.com/config/latest/developerguide/operational-best-practices-for-pci-dss.html."
+      },
+      "fqn": "cdk-nag.PCIDSS321Checks",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "src/packs/pci-dss-321.ts",
+          "line": 115
+        },
+        "parameters": [
+          {
+            "name": "props",
+            "optional": true,
+            "type": {
+              "fqn": "cdk-nag.NagPackProps"
+            }
+          }
+        ]
+      },
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/packs/pci-dss-321.ts",
+        "line": 114
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable",
+            "summary": "All aspects can visit an IConstruct."
+          },
+          "locationInModule": {
+            "filename": "src/packs/pci-dss-321.ts",
+            "line": 119
+          },
+          "name": "visit",
+          "overrides": "cdk-nag.NagPack",
+          "parameters": [
+            {
+              "name": "node",
+              "type": {
+                "fqn": "constructs.IConstruct"
+              }
+            }
+          ]
+        }
+      ],
+      "name": "PCIDSS321Checks",
+      "symbolId": "src/packs/pci-dss-321:PCIDSS321Checks"
+    },
+    "cdk-nag.RegexAppliesTo": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "A regular expression to apply to matching findings."
+      },
+      "fqn": "cdk-nag.RegexAppliesTo",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/models/nag-suppression.ts",
+        "line": 32
+      },
+      "name": "RegexAppliesTo",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable",
+            "summary": "An ECMA-262 regex string."
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/models/nag-suppression.ts",
+            "line": 36
+          },
+          "name": "regex",
+          "type": {
+            "primitive": "string"
+          }
+        }
+      ],
+      "symbolId": "src/models/nag-suppression:RegexAppliesTo"
+    },
+    "cdk-nag.SuppressionIgnoreAlways": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Always ignore the suppression."
+      },
+      "fqn": "cdk-nag.SuppressionIgnoreAlways",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "src/ignore-suppression-conditions.ts",
+          "line": 91
+        },
+        "parameters": [
+          {
+            "name": "triggerMessage",
+            "type": {
+              "primitive": "string"
+            }
+          }
+        ]
+      },
+      "interfaces": [
+        "cdk-nag.INagSuppressionIgnore"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/ignore-suppression-conditions.ts",
+        "line": 89
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/ignore-suppression-conditions.ts",
+            "line": 99
+          },
+          "name": "createMessage",
+          "overrides": "cdk-nag.INagSuppressionIgnore",
+          "parameters": [
+            {
+              "name": "_input",
+              "type": {
+                "fqn": "cdk-nag.SuppressionIgnoreInput"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "SuppressionIgnoreAlways",
+      "symbolId": "src/ignore-suppression-conditions:SuppressionIgnoreAlways"
+    },
+    "cdk-nag.SuppressionIgnoreAnd": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Ignore the suppression if all of the given INagSuppressionIgnore return a non-empty message."
+      },
+      "fqn": "cdk-nag.SuppressionIgnoreAnd",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "src/ignore-suppression-conditions.ts",
+          "line": 37
+        },
+        "parameters": [
+          {
+            "name": "SuppressionIgnoreAnds",
+            "type": {
+              "fqn": "cdk-nag.INagSuppressionIgnore"
+            },
+            "variadic": true
+          }
+        ],
+        "variadic": true
+      },
+      "interfaces": [
+        "cdk-nag.INagSuppressionIgnore"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/ignore-suppression-conditions.ts",
+        "line": 34
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/ignore-suppression-conditions.ts",
+            "line": 46
+          },
+          "name": "createMessage",
+          "overrides": "cdk-nag.INagSuppressionIgnore",
+          "parameters": [
+            {
+              "name": "input",
+              "type": {
+                "fqn": "cdk-nag.SuppressionIgnoreInput"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "SuppressionIgnoreAnd",
+      "symbolId": "src/ignore-suppression-conditions:SuppressionIgnoreAnd"
+    },
+    "cdk-nag.SuppressionIgnoreErrors": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Ignore Suppressions for Rules with a NagMessageLevel.ERROR."
+      },
+      "fqn": "cdk-nag.SuppressionIgnoreErrors",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        }
+      },
+      "interfaces": [
+        "cdk-nag.INagSuppressionIgnore"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/ignore-suppression-conditions.ts",
+        "line": 116
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/ignore-suppression-conditions.ts",
+            "line": 117
+          },
+          "name": "createMessage",
+          "overrides": "cdk-nag.INagSuppressionIgnore",
+          "parameters": [
+            {
+              "name": "input",
+              "type": {
+                "fqn": "cdk-nag.SuppressionIgnoreInput"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "SuppressionIgnoreErrors",
+      "symbolId": "src/ignore-suppression-conditions:SuppressionIgnoreErrors"
+    },
+    "cdk-nag.SuppressionIgnoreInput": {
+      "assembly": "cdk-nag",
+      "datatype": true,
+      "docs": {
+        "stability": "stable",
+        "summary": "Information about the NagRule and the relevant NagSuppression for the INagSuppressionIgnore."
+      },
+      "fqn": "cdk-nag.SuppressionIgnoreInput",
+      "kind": "interface",
+      "locationInModule": {
+        "filename": "src/ignore-suppression-conditions.ts",
+        "line": 16
+      },
+      "name": "SuppressionIgnoreInput",
+      "properties": [
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/ignore-suppression-conditions.ts",
+            "line": 20
+          },
+          "name": "findingId",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/ignore-suppression-conditions.ts",
+            "line": 18
+          },
+          "name": "reason",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/ignore-suppression-conditions.ts",
+            "line": 17
+          },
+          "name": "resource",
+          "type": {
+            "fqn": "aws-cdk-lib.CfnResource"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/ignore-suppression-conditions.ts",
+            "line": 19
+          },
+          "name": "ruleId",
+          "type": {
+            "primitive": "string"
+          }
+        },
+        {
+          "abstract": true,
+          "docs": {
+            "stability": "stable"
+          },
+          "immutable": true,
+          "locationInModule": {
+            "filename": "src/ignore-suppression-conditions.ts",
+            "line": 21
+          },
+          "name": "ruleLevel",
+          "type": {
+            "fqn": "cdk-nag.NagMessageLevel"
+          }
+        }
+      ],
+      "symbolId": "src/ignore-suppression-conditions:SuppressionIgnoreInput"
+    },
+    "cdk-nag.SuppressionIgnoreNever": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Don't ignore the suppression."
+      },
+      "fqn": "cdk-nag.SuppressionIgnoreNever",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        }
+      },
+      "interfaces": [
+        "cdk-nag.INagSuppressionIgnore"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/ignore-suppression-conditions.ts",
+        "line": 107
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/ignore-suppression-conditions.ts",
+            "line": 108
+          },
+          "name": "createMessage",
+          "overrides": "cdk-nag.INagSuppressionIgnore",
+          "parameters": [
+            {
+              "name": "_input",
+              "type": {
+                "fqn": "cdk-nag.SuppressionIgnoreInput"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "SuppressionIgnoreNever",
+      "symbolId": "src/ignore-suppression-conditions:SuppressionIgnoreNever"
+    },
+    "cdk-nag.SuppressionIgnoreOr": {
+      "assembly": "cdk-nag",
+      "docs": {
+        "stability": "stable",
+        "summary": "Ignore the suppression if any of the given INagSuppressionIgnore return a non-empty message."
+      },
+      "fqn": "cdk-nag.SuppressionIgnoreOr",
+      "initializer": {
+        "docs": {
+          "stability": "stable"
+        },
+        "locationInModule": {
+          "filename": "src/ignore-suppression-conditions.ts",
+          "line": 65
+        },
+        "parameters": [
+          {
+            "name": "orSuppressionIgnores",
+            "type": {
+              "fqn": "cdk-nag.INagSuppressionIgnore"
+            },
+            "variadic": true
+          }
+        ],
+        "variadic": true
+      },
+      "interfaces": [
+        "cdk-nag.INagSuppressionIgnore"
+      ],
+      "kind": "class",
+      "locationInModule": {
+        "filename": "src/ignore-suppression-conditions.ts",
+        "line": 62
+      },
+      "methods": [
+        {
+          "docs": {
+            "stability": "stable"
+          },
+          "locationInModule": {
+            "filename": "src/ignore-suppression-conditions.ts",
+            "line": 74
+          },
+          "name": "createMessage",
+          "overrides": "cdk-nag.INagSuppressionIgnore",
+          "parameters": [
+            {
+              "name": "input",
+              "type": {
+                "fqn": "cdk-nag.SuppressionIgnoreInput"
+              }
+            }
+          ],
+          "returns": {
+            "type": {
+              "primitive": "string"
+            }
+          }
+        }
+      ],
+      "name": "SuppressionIgnoreOr",
+      "symbolId": "src/ignore-suppression-conditions:SuppressionIgnoreOr"
+    }
+  },
+  "version": "2.27.179",
+  "fingerprint": "N0SiBDSkWtP5p6KyEVVrZuZu9Elly/hay6dqabZ2pd0="
+}

--- a/test/docgen/transpile/transpile.test.ts
+++ b/test/docgen/transpile/transpile.test.ts
@@ -58,26 +58,26 @@ describe('submodules without an explicit name', () => {
 
   test('java', async () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-cloudfront', Assemblies.AWSCDK_1_126_0);
-    const markdown = await docs.toMarkdown({ language: Language.JAVA, submodule: 'experimental' });
+    const markdown = await docs.toMarkdown({ language: Language.JAVA, submodule: '@aws-cdk/aws-cloudfront.experimental' });
     expect(markdown.render()).toMatchSnapshot();
   });
 
   test('python', async () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-cloudfront', Assemblies.AWSCDK_1_126_0);
-    const markdown = await docs.toMarkdown({ language: Language.PYTHON, submodule: 'experimental' });
+    const markdown = await docs.toMarkdown({ language: Language.PYTHON, submodule: '@aws-cdk/aws-cloudfront.experimental' });
     expect(markdown.render()).toMatchSnapshot();
   });
 
   test('csharp', async () => {
     const docs = await Documentation.forAssembly('@aws-cdk/aws-cloudfront', Assemblies.AWSCDK_1_126_0);
-    const markdown = await docs.toMarkdown({ language: Language.CSHARP, submodule: 'experimental' });
+    const markdown = await docs.toMarkdown({ language: Language.CSHARP, submodule: '@aws-cdk/aws-cloudfront.experimental' });
     expect(markdown.render()).toMatchSnapshot();
   });
 
   test('go', async () => {
     // NOTE: @aws-cdk/aws-cloudfront 1.126.0 does not support Go, so we use region_info from aws-cdk-lib instead, which does.
     const docs = await Documentation.forAssembly('aws-cdk-lib', Assemblies.AWSCDK_1_106_0);
-    const markdown = await docs.toMarkdown({ language: Language.GO, submodule: 'region_info' });
+    const markdown = await docs.toMarkdown({ language: Language.GO, submodule: 'aws-cdk-lib.region_info' });
     expect(markdown.render()).toMatchSnapshot();
   });
 });

--- a/test/docgen/view/documentation.test.ts
+++ b/test/docgen/view/documentation.test.ts
@@ -140,6 +140,12 @@ describe('typescript', () => {
     const markdown = await docs.toMarkdown({ language: Language.TYPESCRIPT, submodule: 'aws_eks' });
     expect(markdown.render()).toMatchSnapshot();
   });
+
+  test('snapshot - nested submodules', async () => {
+    const docs = await Documentation.forAssembly('cdk-nag', Assemblies.AWSCDK_1_106_0);
+    const markdown = await docs.toMarkdown({ language: Language.TYPESCRIPT, submodule: 'rules.apigw' });
+    expect(markdown.render()).toMatchSnapshot();
+  });
 });
 
 describe('java', () => {


### PR DESCRIPTION
(This is a re-roll of https://github.com/cdklabs/jsii-docgen/pull/1190).

`jsii-docgen` used to assume that submodules only went one level deep,
i.e. that there could not be submodules within submodules. Break that
assumption by doing the following:

- Use `assembly.allSubmodules` everywhere `assembly.submodules` used to
  be used.
- Address submodules by FQN instead of by `name` (which only holds the
  last name component).
- As an exception: `documentation.toJson()` accepts both FQN as well as
  root-relative name for backwards compatibility.