### PR TITLE
chore: update docstring

### DIFF
--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -42,7 +42,7 @@ export interface RenderOptions extends TransliterationOptions {
   /**
    * Include the user defined README.md in the documentation.
    *
-   * @default true
+   * @default false
    */
   readonly readme?: boolean;
 


### PR DESCRIPTION
The `readme` flag actually has `false` as a default, not `true`