### PR TITLE
fix: cannot use splitBySubmodule and multiple languages together

### DIFF
--- a/test/__fixtures__/libraries/construct-library/lib/index.ts
+++ b/test/__fixtures__/libraries/construct-library/lib/index.ts
@@ -5,6 +5,10 @@ export class GreeterBucket extends s3.Bucket {
   public greet() {
     console.log(this.bucketName);
   }
+
+  public greetWithSalutation(salution: string) {
+    console.log(salution + ' ' + this.bucketName);
+  }
 }
 
 export * as submod1 from './submod1';

--- a/test/__fixtures__/libraries/construct-library/lib/submod1/index.ts
+++ b/test/__fixtures__/libraries/construct-library/lib/submod1/index.ts
@@ -5,4 +5,8 @@ export class GoodbyeBucket extends s3.Bucket {
   public goodbye() {
     console.log(this.bucketName);
   }
+
+  public goodbyeWithPhrase(phrase: string) {
+    console.log(phrase + ' ' + this.bucketName);
+  }
 }

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -71,6 +71,7 @@ new submod1.GoodbyeBucket(scope: Construct, id: string, props?: BucketProps)
 | <code><a href="#construct-library.submod1.GoodbyeBucket.addLifecycleRule">addLifecycleRule</a></code> | Add a lifecycle rule to the bucket. |
 | <code><a href="#construct-library.submod1.GoodbyeBucket.addMetric">addMetric</a></code> | Adds a metrics configuration for the CloudWatch request metrics from the bucket. |
 | <code><a href="#construct-library.submod1.GoodbyeBucket.goodbye">goodbye</a></code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase">goodbyeWithPhrase</a></code> | *No description.* |
 
 ---
 
@@ -728,6 +729,18 @@ The metric configuration to add.
 public goodbye(): void
 \`\`\`
 
+##### \`goodbyeWithPhrase\` <a name="goodbyeWithPhrase" id="construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase"></a>
+
+\`\`\`typescript
+public goodbyeWithPhrase(phrase: string): void
+\`\`\`
+
+###### \`phrase\`<sup>Required</sup> <a name="phrase" id="construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase.parameter.phrase"></a>
+
+- *Type:* string
+
+---
+
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
 | **Name** | **Description** |
@@ -1133,6 +1146,7 @@ new GreeterBucket(scope: Construct, id: string, props?: BucketProps)
 | <code><a href="#construct-library.GreeterBucket.addLifecycleRule">addLifecycleRule</a></code> | Add a lifecycle rule to the bucket. |
 | <code><a href="#construct-library.GreeterBucket.addMetric">addMetric</a></code> | Adds a metrics configuration for the CloudWatch request metrics from the bucket. |
 | <code><a href="#construct-library.GreeterBucket.greet">greet</a></code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.greetWithSalutation">greetWithSalutation</a></code> | *No description.* |
 
 ---
 
@@ -1789,6 +1803,18 @@ The metric configuration to add.
 \`\`\`typescript
 public greet(): void
 \`\`\`
+
+##### \`greetWithSalutation\` <a name="greetWithSalutation" id="construct-library.GreeterBucket.greetWithSalutation"></a>
+
+\`\`\`typescript
+public greetWithSalutation(salution: string): void
+\`\`\`
+
+###### \`salution\`<sup>Required</sup> <a name="salution" id="construct-library.GreeterBucket.greetWithSalutation.parameter.salution"></a>
+
+- *Type:* string
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -2526,6 +2552,7 @@ Rules that define when a redirect is applied and the redirect behavior.
 | <code><a href="#construct-library.submod1.GoodbyeBucket.addLifecycleRule">add_lifecycle_rule</a></code> | Add a lifecycle rule to the bucket. |
 | <code><a href="#construct-library.submod1.GoodbyeBucket.addMetric">add_metric</a></code> | Adds a metrics configuration for the CloudWatch request metrics from the bucket. |
 | <code><a href="#construct-library.submod1.GoodbyeBucket.goodbye">goodbye</a></code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase">goodbye_with_phrase</a></code> | *No description.* |
 
 ---
 
@@ -3719,6 +3746,20 @@ The metrics configuration includes only objects that meet the filter's criteria.
 def goodbye() -> None
 \`\`\`
 
+##### \`goodbye_with_phrase\` <a name="goodbye_with_phrase" id="construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase"></a>
+
+\`\`\`python
+def goodbye_with_phrase(
+  phrase: str
+) -> None
+\`\`\`
+
+###### \`phrase\`<sup>Required</sup> <a name="phrase" id="construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase.parameter.phrase"></a>
+
+- *Type:* str
+
+---
+
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
 | **Name** | **Description** |
@@ -4574,6 +4615,7 @@ Rules that define when a redirect is applied and the redirect behavior.
 | <code><a href="#construct-library.GreeterBucket.addLifecycleRule">add_lifecycle_rule</a></code> | Add a lifecycle rule to the bucket. |
 | <code><a href="#construct-library.GreeterBucket.addMetric">add_metric</a></code> | Adds a metrics configuration for the CloudWatch request metrics from the bucket. |
 | <code><a href="#construct-library.GreeterBucket.greet">greet</a></code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.greetWithSalutation">greet_with_salutation</a></code> | *No description.* |
 
 ---
 
@@ -5766,6 +5808,20 @@ The metrics configuration includes only objects that meet the filter's criteria.
 \`\`\`python
 def greet() -> None
 \`\`\`
+
+##### \`greet_with_salutation\` <a name="greet_with_salutation" id="construct-library.GreeterBucket.greetWithSalutation"></a>
+
+\`\`\`python
+def greet_with_salutation(
+  salution: str
+) -> None
+\`\`\`
+
+###### \`salution\`<sup>Required</sup> <a name="salution" id="construct-library.GreeterBucket.greetWithSalutation.parameter.salution"></a>
+
+- *Type:* str
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -12645,6 +12701,7 @@ new GreeterBucket(scope: Construct, id: string, props?: BucketProps)
 | <code><a href="#construct-library.GreeterBucket.addLifecycleRule">addLifecycleRule</a></code> | Add a lifecycle rule to the bucket. |
 | <code><a href="#construct-library.GreeterBucket.addMetric">addMetric</a></code> | Adds a metrics configuration for the CloudWatch request metrics from the bucket. |
 | <code><a href="#construct-library.GreeterBucket.greet">greet</a></code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.greetWithSalutation">greetWithSalutation</a></code> | *No description.* |
 
 ---
 
@@ -13302,6 +13359,18 @@ The metric configuration to add.
 public greet(): void
 \`\`\`
 
+##### \`greetWithSalutation\` <a name="greetWithSalutation" id="construct-library.GreeterBucket.greetWithSalutation"></a>
+
+\`\`\`typescript
+public greetWithSalutation(salution: string): void
+\`\`\`
+
+###### \`salution\`<sup>Required</sup> <a name="salution" id="construct-library.GreeterBucket.greetWithSalutation.parameter.salution"></a>
+
+- *Type:* string
+
+---
+
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
 | **Name** | **Description** |
@@ -13718,6 +13787,7 @@ new submod1.GoodbyeBucket(scope: Construct, id: string, props?: BucketProps)
 | <code><a href="#construct-library.submod1.GoodbyeBucket.addLifecycleRule">addLifecycleRule</a></code> | Add a lifecycle rule to the bucket. |
 | <code><a href="#construct-library.submod1.GoodbyeBucket.addMetric">addMetric</a></code> | Adds a metrics configuration for the CloudWatch request metrics from the bucket. |
 | <code><a href="#construct-library.submod1.GoodbyeBucket.goodbye">goodbye</a></code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase">goodbyeWithPhrase</a></code> | *No description.* |
 
 ---
 
@@ -14374,6 +14444,18 @@ The metric configuration to add.
 \`\`\`typescript
 public goodbye(): void
 \`\`\`
+
+##### \`goodbyeWithPhrase\` <a name="goodbyeWithPhrase" id="construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase"></a>
+
+\`\`\`typescript
+public goodbyeWithPhrase(phrase: string): void
+\`\`\`
+
+###### \`phrase\`<sup>Required</sup> <a name="phrase" id="construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase.parameter.phrase"></a>
+
+- *Type:* string
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -14797,6 +14879,7 @@ new GreeterBucket(scope: Construct, id: string, props?: BucketProps)
 | <code><a href="#construct-library.GreeterBucket.addLifecycleRule">addLifecycleRule</a></code> | Add a lifecycle rule to the bucket. |
 | <code><a href="#construct-library.GreeterBucket.addMetric">addMetric</a></code> | Adds a metrics configuration for the CloudWatch request metrics from the bucket. |
 | <code><a href="#construct-library.GreeterBucket.greet">greet</a></code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.greetWithSalutation">greetWithSalutation</a></code> | *No description.* |
 
 ---
 
@@ -15454,6 +15537,18 @@ The metric configuration to add.
 public greet(): void
 \`\`\`
 
+##### \`greetWithSalutation\` <a name="greetWithSalutation" id="construct-library.GreeterBucket.greetWithSalutation"></a>
+
+\`\`\`typescript
+public greetWithSalutation(salution: string): void
+\`\`\`
+
+###### \`salution\`<sup>Required</sup> <a name="salution" id="construct-library.GreeterBucket.greetWithSalutation.parameter.salution"></a>
+
+- *Type:* string
+
+---
+
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
 | **Name** | **Description** |
@@ -15870,6 +15965,7 @@ new submod1.GoodbyeBucket(scope: Construct, id: string, props?: BucketProps)
 | <code><a href="#construct-library.submod1.GoodbyeBucket.addLifecycleRule">addLifecycleRule</a></code> | Add a lifecycle rule to the bucket. |
 | <code><a href="#construct-library.submod1.GoodbyeBucket.addMetric">addMetric</a></code> | Adds a metrics configuration for the CloudWatch request metrics from the bucket. |
 | <code><a href="#construct-library.submod1.GoodbyeBucket.goodbye">goodbye</a></code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase">goodbyeWithPhrase</a></code> | *No description.* |
 
 ---
 
@@ -16526,6 +16622,18 @@ The metric configuration to add.
 \`\`\`typescript
 public goodbye(): void
 \`\`\`
+
+##### \`goodbyeWithPhrase\` <a name="goodbyeWithPhrase" id="construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase"></a>
+
+\`\`\`typescript
+public goodbyeWithPhrase(phrase: string): void
+\`\`\`
+
+###### \`phrase\`<sup>Required</sup> <a name="phrase" id="construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase.parameter.phrase"></a>
+
+- *Type:* string
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -6242,6 +6242,6338 @@ first call to addToResourcePolicy(s).
 "
 `;
 
+exports[`specify languages and split-by-submodule creates submodule files next to output: API.python.md 1`] = `
+"# API Reference <a name="API Reference" id="api-reference"></a>
+
+## Submodules <a name="Submodules" id="submodules"></a>
+
+The following submodules are available:
+
+- [submod1](./submod1.python.md)
+
+## Constructs <a name="Constructs" id="Constructs"></a>
+
+### GreeterBucket <a name="GreeterBucket" id="construct-library.GreeterBucket"></a>
+
+#### Initializers <a name="Initializers" id="construct-library.GreeterBucket.Initializer"></a>
+
+\`\`\`python
+import construct_library
+
+construct_library.GreeterBucket(
+  scope: Construct,
+  id: str,
+  access_control: BucketAccessControl = None,
+  auto_delete_objects: bool = None,
+  block_public_access: BlockPublicAccess = None,
+  bucket_key_enabled: bool = None,
+  bucket_name: str = None,
+  cors: typing.List[CorsRule] = None,
+  encryption: BucketEncryption = None,
+  encryption_key: IKey = None,
+  enforce_ss_l: bool = None,
+  event_bridge_enabled: bool = None,
+  intelligent_tiering_configurations: typing.List[IntelligentTieringConfiguration] = None,
+  inventories: typing.List[Inventory] = None,
+  lifecycle_rules: typing.List[LifecycleRule] = None,
+  metrics: typing.List[BucketMetrics] = None,
+  notifications_handler_role: IRole = None,
+  object_ownership: ObjectOwnership = None,
+  public_read_access: bool = None,
+  removal_policy: RemovalPolicy = None,
+  server_access_logs_bucket: IBucket = None,
+  server_access_logs_prefix: str = None,
+  transfer_acceleration: bool = None,
+  versioned: bool = None,
+  website_error_document: str = None,
+  website_index_document: str = None,
+  website_redirect: RedirectTarget = None,
+  website_routing_rules: typing.List[RoutingRule] = None
+)
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.id">id</a></code> | <code>str</code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.accessControl">access_control</a></code> | <code>aws_cdk.aws_s3.BucketAccessControl</code> | Specifies a canned ACL that grants predefined permissions to the bucket. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.autoDeleteObjects">auto_delete_objects</a></code> | <code>bool</code> | Whether all objects should be automatically deleted when the bucket is removed from the stack or when the stack is deleted. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.blockPublicAccess">block_public_access</a></code> | <code>aws_cdk.aws_s3.BlockPublicAccess</code> | The block public access configuration of this bucket. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.bucketKeyEnabled">bucket_key_enabled</a></code> | <code>bool</code> | Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.bucketName">bucket_name</a></code> | <code>str</code> | Physical name of this bucket. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.cors">cors</a></code> | <code>typing.List[aws_cdk.aws_s3.CorsRule]</code> | The CORS configuration of this bucket. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.encryption">encryption</a></code> | <code>aws_cdk.aws_s3.BucketEncryption</code> | The kind of server-side encryption to apply to this bucket. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.encryptionKey">encryption_key</a></code> | <code>aws_cdk.aws_kms.IKey</code> | External KMS key to use for bucket encryption. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.enforceSSL">enforce_ss_l</a></code> | <code>bool</code> | Enforces SSL for requests. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.eventBridgeEnabled">event_bridge_enabled</a></code> | <code>bool</code> | Whether this bucket should send notifications to Amazon EventBridge or not. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.intelligentTieringConfigurations">intelligent_tiering_configurations</a></code> | <code>typing.List[aws_cdk.aws_s3.IntelligentTieringConfiguration]</code> | Inteligent Tiering Configurations. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.inventories">inventories</a></code> | <code>typing.List[aws_cdk.aws_s3.Inventory]</code> | The inventory configuration of the bucket. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.lifecycleRules">lifecycle_rules</a></code> | <code>typing.List[aws_cdk.aws_s3.LifecycleRule]</code> | Rules that define how Amazon S3 manages objects during their lifetime. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.metrics">metrics</a></code> | <code>typing.List[aws_cdk.aws_s3.BucketMetrics]</code> | The metrics configuration of this bucket. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.notificationsHandlerRole">notifications_handler_role</a></code> | <code>aws_cdk.aws_iam.IRole</code> | The role to be used by the notifications handler. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.objectOwnership">object_ownership</a></code> | <code>aws_cdk.aws_s3.ObjectOwnership</code> | The objectOwnership of the bucket. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.publicReadAccess">public_read_access</a></code> | <code>bool</code> | Grants public read access to all objects in the bucket. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.removalPolicy">removal_policy</a></code> | <code>aws_cdk.core.RemovalPolicy</code> | Policy to apply when the bucket is removed from this stack. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.serverAccessLogsBucket">server_access_logs_bucket</a></code> | <code>aws_cdk.aws_s3.IBucket</code> | Destination bucket for the server access logs. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.serverAccessLogsPrefix">server_access_logs_prefix</a></code> | <code>str</code> | Optional log file prefix to use for the bucket's access logs. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.transferAcceleration">transfer_acceleration</a></code> | <code>bool</code> | Whether this bucket should have transfer acceleration turned on or not. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.versioned">versioned</a></code> | <code>bool</code> | Whether this bucket should have versioning turned on or not. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.websiteErrorDocument">website_error_document</a></code> | <code>str</code> | The name of the error document (e.g. "404.html") for the website. \`websiteIndexDocument\` must also be set if this is set. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.websiteIndexDocument">website_index_document</a></code> | <code>str</code> | The name of the index document (e.g. "index.html") for the website. Enables static website hosting for this bucket. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.websiteRedirect">website_redirect</a></code> | <code>aws_cdk.aws_s3.RedirectTarget</code> | Specifies the redirect behavior of all requests to a website endpoint of a bucket. |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.websiteRoutingRules">website_routing_rules</a></code> | <code>typing.List[aws_cdk.aws_s3.RoutingRule]</code> | Rules that define when a redirect is applied and the redirect behavior. |
+
+---
+
+##### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.GreeterBucket.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.Initializer.parameter.id"></a>
+
+- *Type:* str
+
+---
+
+##### \`access_control\`<sup>Optional</sup> <a name="access_control" id="construct-library.GreeterBucket.Initializer.parameter.accessControl"></a>
+
+- *Type:* aws_cdk.aws_s3.BucketAccessControl
+- *Default:* BucketAccessControl.PRIVATE
+
+Specifies a canned ACL that grants predefined permissions to the bucket.
+
+---
+
+##### \`auto_delete_objects\`<sup>Optional</sup> <a name="auto_delete_objects" id="construct-library.GreeterBucket.Initializer.parameter.autoDeleteObjects"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Whether all objects should be automatically deleted when the bucket is removed from the stack or when the stack is deleted.
+
+Requires the \`removalPolicy\` to be set to \`RemovalPolicy.DESTROY\`.
+
+**Warning** if you have deployed a bucket with \`autoDeleteObjects: true\`,
+switching this to \`false\` in a CDK version *before* \`1.126.0\` will lead to
+all objects in the bucket being deleted. Be sure to update your bucket resources
+by deploying with CDK version \`1.126.0\` or later **before** switching this value to \`false\`.
+
+---
+
+##### \`block_public_access\`<sup>Optional</sup> <a name="block_public_access" id="construct-library.GreeterBucket.Initializer.parameter.blockPublicAccess"></a>
+
+- *Type:* aws_cdk.aws_s3.BlockPublicAccess
+- *Default:* CloudFormation defaults will apply. New buckets and objects don't allow public access, but users can modify bucket policies or object permissions to allow public access
+
+The block public access configuration of this bucket.
+
+> [https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html)
+
+---
+
+##### \`bucket_key_enabled\`<sup>Optional</sup> <a name="bucket_key_enabled" id="construct-library.GreeterBucket.Initializer.parameter.bucketKeyEnabled"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket.
+
+Only relevant, when Encryption is set to {@link BucketEncryption.KMS}
+
+---
+
+##### \`bucket_name\`<sup>Optional</sup> <a name="bucket_name" id="construct-library.GreeterBucket.Initializer.parameter.bucketName"></a>
+
+- *Type:* str
+- *Default:* Assigned by CloudFormation (recommended).
+
+Physical name of this bucket.
+
+---
+
+##### \`cors\`<sup>Optional</sup> <a name="cors" id="construct-library.GreeterBucket.Initializer.parameter.cors"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.CorsRule]
+- *Default:* No CORS configuration.
+
+The CORS configuration of this bucket.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors.html)
+
+---
+
+##### \`encryption\`<sup>Optional</sup> <a name="encryption" id="construct-library.GreeterBucket.Initializer.parameter.encryption"></a>
+
+- *Type:* aws_cdk.aws_s3.BucketEncryption
+- *Default:* \`Kms\` if \`encryptionKey\` is specified, or \`Unencrypted\` otherwise.
+
+The kind of server-side encryption to apply to this bucket.
+
+If you choose KMS, you can specify a KMS key via \`encryptionKey\`. If
+encryption key is not specified, a key will automatically be created.
+
+---
+
+##### \`encryption_key\`<sup>Optional</sup> <a name="encryption_key" id="construct-library.GreeterBucket.Initializer.parameter.encryptionKey"></a>
+
+- *Type:* aws_cdk.aws_kms.IKey
+- *Default:* If encryption is set to "Kms" and this property is undefined, a new KMS key will be created and associated with this bucket.
+
+External KMS key to use for bucket encryption.
+
+The 'encryption' property must be either not specified or set to "Kms".
+An error will be emitted if encryption is set to "Unencrypted" or
+"Managed".
+
+---
+
+##### \`enforce_ss_l\`<sup>Optional</sup> <a name="enforce_ss_l" id="construct-library.GreeterBucket.Initializer.parameter.enforceSSL"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Enforces SSL for requests.
+
+S3.5 of the AWS Foundational Security Best Practices Regarding S3.
+
+> [https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-ssl-requests-only.html](https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-ssl-requests-only.html)
+
+---
+
+##### \`event_bridge_enabled\`<sup>Optional</sup> <a name="event_bridge_enabled" id="construct-library.GreeterBucket.Initializer.parameter.eventBridgeEnabled"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Whether this bucket should send notifications to Amazon EventBridge or not.
+
+---
+
+##### \`intelligent_tiering_configurations\`<sup>Optional</sup> <a name="intelligent_tiering_configurations" id="construct-library.GreeterBucket.Initializer.parameter.intelligentTieringConfigurations"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.IntelligentTieringConfiguration]
+- *Default:* No Intelligent Tiiering Configurations.
+
+Inteligent Tiering Configurations.
+
+> [https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html)
+
+---
+
+##### \`inventories\`<sup>Optional</sup> <a name="inventories" id="construct-library.GreeterBucket.Initializer.parameter.inventories"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.Inventory]
+- *Default:* No inventory configuration
+
+The inventory configuration of the bucket.
+
+> [https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html)
+
+---
+
+##### \`lifecycle_rules\`<sup>Optional</sup> <a name="lifecycle_rules" id="construct-library.GreeterBucket.Initializer.parameter.lifecycleRules"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.LifecycleRule]
+- *Default:* No lifecycle rules.
+
+Rules that define how Amazon S3 manages objects during their lifetime.
+
+---
+
+##### \`metrics\`<sup>Optional</sup> <a name="metrics" id="construct-library.GreeterBucket.Initializer.parameter.metrics"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.BucketMetrics]
+- *Default:* No metrics configuration.
+
+The metrics configuration of this bucket.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-metricsconfiguration.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-metricsconfiguration.html)
+
+---
+
+##### \`notifications_handler_role\`<sup>Optional</sup> <a name="notifications_handler_role" id="construct-library.GreeterBucket.Initializer.parameter.notificationsHandlerRole"></a>
+
+- *Type:* aws_cdk.aws_iam.IRole
+- *Default:* a new role will be created.
+
+The role to be used by the notifications handler.
+
+---
+
+##### \`object_ownership\`<sup>Optional</sup> <a name="object_ownership" id="construct-library.GreeterBucket.Initializer.parameter.objectOwnership"></a>
+
+- *Type:* aws_cdk.aws_s3.ObjectOwnership
+- *Default:* No ObjectOwnership configuration, uploading account will own the object.
+
+The objectOwnership of the bucket.
+
+> [https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html)
+
+---
+
+##### \`public_read_access\`<sup>Optional</sup> <a name="public_read_access" id="construct-library.GreeterBucket.Initializer.parameter.publicReadAccess"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Grants public read access to all objects in the bucket.
+
+Similar to calling \`bucket.grantPublicAccess()\`
+
+---
+
+##### \`removal_policy\`<sup>Optional</sup> <a name="removal_policy" id="construct-library.GreeterBucket.Initializer.parameter.removalPolicy"></a>
+
+- *Type:* aws_cdk.core.RemovalPolicy
+- *Default:* The bucket will be orphaned.
+
+Policy to apply when the bucket is removed from this stack.
+
+---
+
+##### \`server_access_logs_bucket\`<sup>Optional</sup> <a name="server_access_logs_bucket" id="construct-library.GreeterBucket.Initializer.parameter.serverAccessLogsBucket"></a>
+
+- *Type:* aws_cdk.aws_s3.IBucket
+- *Default:* If "serverAccessLogsPrefix" undefined - access logs disabled, otherwise - log to current bucket.
+
+Destination bucket for the server access logs.
+
+---
+
+##### \`server_access_logs_prefix\`<sup>Optional</sup> <a name="server_access_logs_prefix" id="construct-library.GreeterBucket.Initializer.parameter.serverAccessLogsPrefix"></a>
+
+- *Type:* str
+- *Default:* No log file prefix
+
+Optional log file prefix to use for the bucket's access logs.
+
+If defined without "serverAccessLogsBucket", enables access logs to current bucket with this prefix.
+
+---
+
+##### \`transfer_acceleration\`<sup>Optional</sup> <a name="transfer_acceleration" id="construct-library.GreeterBucket.Initializer.parameter.transferAcceleration"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Whether this bucket should have transfer acceleration turned on or not.
+
+---
+
+##### \`versioned\`<sup>Optional</sup> <a name="versioned" id="construct-library.GreeterBucket.Initializer.parameter.versioned"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Whether this bucket should have versioning turned on or not.
+
+---
+
+##### \`website_error_document\`<sup>Optional</sup> <a name="website_error_document" id="construct-library.GreeterBucket.Initializer.parameter.websiteErrorDocument"></a>
+
+- *Type:* str
+- *Default:* No error document.
+
+The name of the error document (e.g. "404.html") for the website. \`websiteIndexDocument\` must also be set if this is set.
+
+---
+
+##### \`website_index_document\`<sup>Optional</sup> <a name="website_index_document" id="construct-library.GreeterBucket.Initializer.parameter.websiteIndexDocument"></a>
+
+- *Type:* str
+- *Default:* No index document.
+
+The name of the index document (e.g. "index.html") for the website. Enables static website hosting for this bucket.
+
+---
+
+##### \`website_redirect\`<sup>Optional</sup> <a name="website_redirect" id="construct-library.GreeterBucket.Initializer.parameter.websiteRedirect"></a>
+
+- *Type:* aws_cdk.aws_s3.RedirectTarget
+- *Default:* No redirection.
+
+Specifies the redirect behavior of all requests to a website endpoint of a bucket.
+
+If you specify this property, you can't specify "websiteIndexDocument", "websiteErrorDocument" nor , "websiteRoutingRules".
+
+---
+
+##### \`website_routing_rules\`<sup>Optional</sup> <a name="website_routing_rules" id="construct-library.GreeterBucket.Initializer.parameter.websiteRoutingRules"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.RoutingRule]
+- *Default:* No redirection rules.
+
+Rules that define when a redirect is applied and the redirect behavior.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#construct-library.GreeterBucket.toString">to_string</a></code> | Returns a string representation of this construct. |
+| <code><a href="#construct-library.GreeterBucket.applyRemovalPolicy">apply_removal_policy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#construct-library.GreeterBucket.addEventNotification">add_event_notification</a></code> | Adds a bucket notification event destination. |
+| <code><a href="#construct-library.GreeterBucket.addObjectCreatedNotification">add_object_created_notification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
+| <code><a href="#construct-library.GreeterBucket.addObjectRemovedNotification">add_object_removed_notification</a></code> | Subscribes a destination to receive notifications when an object is removed from the bucket. |
+| <code><a href="#construct-library.GreeterBucket.addToResourcePolicy">add_to_resource_policy</a></code> | Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects. |
+| <code><a href="#construct-library.GreeterBucket.arnForObjects">arn_for_objects</a></code> | Returns an ARN that represents all objects within the bucket that match the key pattern specified. |
+| <code><a href="#construct-library.GreeterBucket.grantDelete">grant_delete</a></code> | Grants s3:DeleteObject* permission to an IAM principal for objects in this bucket. |
+| <code><a href="#construct-library.GreeterBucket.grantPublicAccess">grant_public_access</a></code> | Allows unrestricted access to objects from this bucket. |
+| <code><a href="#construct-library.GreeterBucket.grantPut">grant_put</a></code> | Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal. |
+| <code><a href="#construct-library.GreeterBucket.grantPutAcl">grant_put_acl</a></code> | Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket. |
+| <code><a href="#construct-library.GreeterBucket.grantRead">grant_read</a></code> | Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User). |
+| <code><a href="#construct-library.GreeterBucket.grantReadWrite">grant_read_write</a></code> | Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User). |
+| <code><a href="#construct-library.GreeterBucket.grantWrite">grant_write</a></code> | Grant write permissions to this bucket to an IAM principal. |
+| <code><a href="#construct-library.GreeterBucket.onCloudTrailEvent">on_cloud_trail_event</a></code> | Define a CloudWatch event that triggers when something happens to this repository. |
+| <code><a href="#construct-library.GreeterBucket.onCloudTrailPutObject">on_cloud_trail_put_object</a></code> | Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call. |
+| <code><a href="#construct-library.GreeterBucket.onCloudTrailWriteObject">on_cloud_trail_write_object</a></code> | Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to. |
+| <code><a href="#construct-library.GreeterBucket.s3UrlForObject">s3_url_for_object</a></code> | The S3 URL of an S3 object. For example:. |
+| <code><a href="#construct-library.GreeterBucket.transferAccelerationUrlForObject">transfer_acceleration_url_for_object</a></code> | The https Transfer Acceleration URL of an S3 object. |
+| <code><a href="#construct-library.GreeterBucket.urlForObject">url_for_object</a></code> | The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:. |
+| <code><a href="#construct-library.GreeterBucket.virtualHostedUrlForObject">virtual_hosted_url_for_object</a></code> | The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:. |
+| <code><a href="#construct-library.GreeterBucket.addCorsRule">add_cors_rule</a></code> | Adds a cross-origin access configuration for objects in an Amazon S3 bucket. |
+| <code><a href="#construct-library.GreeterBucket.addInventory">add_inventory</a></code> | Add an inventory configuration. |
+| <code><a href="#construct-library.GreeterBucket.addLifecycleRule">add_lifecycle_rule</a></code> | Add a lifecycle rule to the bucket. |
+| <code><a href="#construct-library.GreeterBucket.addMetric">add_metric</a></code> | Adds a metrics configuration for the CloudWatch request metrics from the bucket. |
+| <code><a href="#construct-library.GreeterBucket.greet">greet</a></code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.greetWithSalutation">greet_with_salutation</a></code> | *No description.* |
+
+---
+
+##### \`to_string\` <a name="to_string" id="construct-library.GreeterBucket.toString"></a>
+
+\`\`\`python
+def to_string() -> str
+\`\`\`
+
+Returns a string representation of this construct.
+
+##### \`apply_removal_policy\` <a name="apply_removal_policy" id="construct-library.GreeterBucket.applyRemovalPolicy"></a>
+
+\`\`\`python
+def apply_removal_policy(
+  policy: RemovalPolicy
+) -> None
+\`\`\`
+
+Apply the given removal policy to this resource.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+
+###### \`policy\`<sup>Required</sup> <a name="policy" id="construct-library.GreeterBucket.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws_cdk.core.RemovalPolicy
+
+---
+
+##### \`add_event_notification\` <a name="add_event_notification" id="construct-library.GreeterBucket.addEventNotification"></a>
+
+\`\`\`python
+def add_event_notification(
+  event: EventType,
+  dest: IBucketNotificationDestination,
+  prefix: str = None,
+  suffix: str = None
+) -> None
+\`\`\`
+
+Adds a bucket notification event destination.
+
+> [https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
+
+*Example*
+
+\`\`\`python
+   declare const myLambda: lambda.Function;
+   const bucket = new s3.Bucket(this, 'MyBucket');
+   bucket.addEventNotification(s3.EventType.OBJECT_CREATED, new s3n.LambdaDestination(myLambda), {prefix: 'home/myusername/*'});
+\`\`\`
+
+
+###### \`event\`<sup>Required</sup> <a name="event" id="construct-library.GreeterBucket.addEventNotification.parameter.event"></a>
+
+- *Type:* aws_cdk.aws_s3.EventType
+
+The event to trigger the notification.
+
+---
+
+###### \`dest\`<sup>Required</sup> <a name="dest" id="construct-library.GreeterBucket.addEventNotification.parameter.dest"></a>
+
+- *Type:* aws_cdk.aws_s3.IBucketNotificationDestination
+
+The notification destination (Lambda, SNS Topic or SQS Queue).
+
+---
+
+###### \`prefix\`<sup>Optional</sup> <a name="prefix" id="construct-library.GreeterBucket.addEventNotification.parameter.prefix"></a>
+
+- *Type:* str
+
+S3 keys must have the specified prefix.
+
+---
+
+###### \`suffix\`<sup>Optional</sup> <a name="suffix" id="construct-library.GreeterBucket.addEventNotification.parameter.suffix"></a>
+
+- *Type:* str
+
+S3 keys must have the specified suffix.
+
+---
+
+##### \`add_object_created_notification\` <a name="add_object_created_notification" id="construct-library.GreeterBucket.addObjectCreatedNotification"></a>
+
+\`\`\`python
+def add_object_created_notification(
+  dest: IBucketNotificationDestination,
+  prefix: str = None,
+  suffix: str = None
+) -> None
+\`\`\`
+
+Subscribes a destination to receive notifications when an object is created in the bucket.
+
+This is identical to calling
+\`onEvent(EventType.OBJECT_CREATED)\`.
+
+###### \`dest\`<sup>Required</sup> <a name="dest" id="construct-library.GreeterBucket.addObjectCreatedNotification.parameter.dest"></a>
+
+- *Type:* aws_cdk.aws_s3.IBucketNotificationDestination
+
+The notification destination (see onEvent).
+
+---
+
+###### \`prefix\`<sup>Optional</sup> <a name="prefix" id="construct-library.GreeterBucket.addObjectCreatedNotification.parameter.prefix"></a>
+
+- *Type:* str
+
+S3 keys must have the specified prefix.
+
+---
+
+###### \`suffix\`<sup>Optional</sup> <a name="suffix" id="construct-library.GreeterBucket.addObjectCreatedNotification.parameter.suffix"></a>
+
+- *Type:* str
+
+S3 keys must have the specified suffix.
+
+---
+
+##### \`add_object_removed_notification\` <a name="add_object_removed_notification" id="construct-library.GreeterBucket.addObjectRemovedNotification"></a>
+
+\`\`\`python
+def add_object_removed_notification(
+  dest: IBucketNotificationDestination,
+  prefix: str = None,
+  suffix: str = None
+) -> None
+\`\`\`
+
+Subscribes a destination to receive notifications when an object is removed from the bucket.
+
+This is identical to calling
+\`onEvent(EventType.OBJECT_REMOVED)\`.
+
+###### \`dest\`<sup>Required</sup> <a name="dest" id="construct-library.GreeterBucket.addObjectRemovedNotification.parameter.dest"></a>
+
+- *Type:* aws_cdk.aws_s3.IBucketNotificationDestination
+
+The notification destination (see onEvent).
+
+---
+
+###### \`prefix\`<sup>Optional</sup> <a name="prefix" id="construct-library.GreeterBucket.addObjectRemovedNotification.parameter.prefix"></a>
+
+- *Type:* str
+
+S3 keys must have the specified prefix.
+
+---
+
+###### \`suffix\`<sup>Optional</sup> <a name="suffix" id="construct-library.GreeterBucket.addObjectRemovedNotification.parameter.suffix"></a>
+
+- *Type:* str
+
+S3 keys must have the specified suffix.
+
+---
+
+##### \`add_to_resource_policy\` <a name="add_to_resource_policy" id="construct-library.GreeterBucket.addToResourcePolicy"></a>
+
+\`\`\`python
+def add_to_resource_policy(
+  permission: PolicyStatement
+) -> AddToResourcePolicyResult
+\`\`\`
+
+Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects.
+
+Note that the policy statement may or may not be added to the policy.
+For example, when an \`IBucket\` is created from an existing bucket,
+it's not possible to tell whether the bucket already has a policy
+attached, let alone to re-use that policy to add more statements to it.
+So it's safest to do nothing in these cases.
+
+###### \`permission\`<sup>Required</sup> <a name="permission" id="construct-library.GreeterBucket.addToResourcePolicy.parameter.permission"></a>
+
+- *Type:* aws_cdk.aws_iam.PolicyStatement
+
+the policy statement to be added to the bucket's policy.
+
+---
+
+##### \`arn_for_objects\` <a name="arn_for_objects" id="construct-library.GreeterBucket.arnForObjects"></a>
+
+\`\`\`python
+def arn_for_objects(
+  key_pattern: str
+) -> str
+\`\`\`
+
+Returns an ARN that represents all objects within the bucket that match the key pattern specified.
+
+To represent all keys, specify \`\`"*"\`\`.
+
+If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:
+
+   arnForObjects(\`home/\${team}/\${user}/*\`)
+
+###### \`key_pattern\`<sup>Required</sup> <a name="key_pattern" id="construct-library.GreeterBucket.arnForObjects.parameter.keyPattern"></a>
+
+- *Type:* str
+
+---
+
+##### \`grant_delete\` <a name="grant_delete" id="construct-library.GreeterBucket.grantDelete"></a>
+
+\`\`\`python
+def grant_delete(
+  identity: IGrantable,
+  objects_key_pattern: typing.Any = None
+) -> Grant
+\`\`\`
+
+Grants s3:DeleteObject* permission to an IAM principal for objects in this bucket.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantDelete.parameter.identity"></a>
+
+- *Type:* aws_cdk.aws_iam.IGrantable
+
+The principal.
+
+---
+
+###### \`objects_key_pattern\`<sup>Optional</sup> <a name="objects_key_pattern" id="construct-library.GreeterBucket.grantDelete.parameter.objectsKeyPattern"></a>
+
+- *Type:* typing.Any
+
+Restrict the permission to a certain key pattern (default '*').
+
+---
+
+##### \`grant_public_access\` <a name="grant_public_access" id="construct-library.GreeterBucket.grantPublicAccess"></a>
+
+\`\`\`python
+def grant_public_access(
+  allowed_actions: str,
+  key_prefix: str = None
+) -> Grant
+\`\`\`
+
+Allows unrestricted access to objects from this bucket.
+
+IMPORTANT: This permission allows anyone to perform actions on S3 objects
+in this bucket, which is useful for when you configure your bucket as a
+website and want everyone to be able to read objects in the bucket without
+needing to authenticate.
+
+Without arguments, this method will grant read ("s3:GetObject") access to
+all objects ("*") in the bucket.
+
+The method returns the \`iam.Grant\` object, which can then be modified
+as needed. For example, you can add a condition that will restrict access only
+to an IPv4 range like this:
+
+     const grant = bucket.grantPublicAccess();
+     grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });
+
+Note that if this \`IBucket\` refers to an existing bucket, possibly not
+managed by CloudFormation, this method will have no effect, since it's
+impossible to modify the policy of an existing bucket.
+
+###### \`allowed_actions\`<sup>Required</sup> <a name="allowed_actions" id="construct-library.GreeterBucket.grantPublicAccess.parameter.allowedActions"></a>
+
+- *Type:* str
+
+the set of S3 actions to allow.
+
+Default is "s3:GetObject".
+
+---
+
+###### \`key_prefix\`<sup>Optional</sup> <a name="key_prefix" id="construct-library.GreeterBucket.grantPublicAccess.parameter.keyPrefix"></a>
+
+- *Type:* str
+
+the prefix of S3 object keys (e.g. \`home/*\`). Default is "*".
+
+---
+
+##### \`grant_put\` <a name="grant_put" id="construct-library.GreeterBucket.grantPut"></a>
+
+\`\`\`python
+def grant_put(
+  identity: IGrantable,
+  objects_key_pattern: typing.Any = None
+) -> Grant
+\`\`\`
+
+Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal.
+
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantPut.parameter.identity"></a>
+
+- *Type:* aws_cdk.aws_iam.IGrantable
+
+The principal.
+
+---
+
+###### \`objects_key_pattern\`<sup>Optional</sup> <a name="objects_key_pattern" id="construct-library.GreeterBucket.grantPut.parameter.objectsKeyPattern"></a>
+
+- *Type:* typing.Any
+
+Restrict the permission to a certain key pattern (default '*').
+
+---
+
+##### \`grant_put_acl\` <a name="grant_put_acl" id="construct-library.GreeterBucket.grantPutAcl"></a>
+
+\`\`\`python
+def grant_put_acl(
+  identity: IGrantable,
+  objects_key_pattern: str = None
+) -> Grant
+\`\`\`
+
+Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
+
+If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
+calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+in this case, if you need to modify object ACLs, call this method explicitly.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantPutAcl.parameter.identity"></a>
+
+- *Type:* aws_cdk.aws_iam.IGrantable
+
+---
+
+###### \`objects_key_pattern\`<sup>Optional</sup> <a name="objects_key_pattern" id="construct-library.GreeterBucket.grantPutAcl.parameter.objectsKeyPattern"></a>
+
+- *Type:* str
+
+---
+
+##### \`grant_read\` <a name="grant_read" id="construct-library.GreeterBucket.grantRead"></a>
+
+\`\`\`python
+def grant_read(
+  identity: IGrantable,
+  objects_key_pattern: typing.Any = None
+) -> Grant
+\`\`\`
+
+Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
+
+If encryption is used, permission to use the key to decrypt the contents
+of the bucket will also be granted to the same principal.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantRead.parameter.identity"></a>
+
+- *Type:* aws_cdk.aws_iam.IGrantable
+
+The principal.
+
+---
+
+###### \`objects_key_pattern\`<sup>Optional</sup> <a name="objects_key_pattern" id="construct-library.GreeterBucket.grantRead.parameter.objectsKeyPattern"></a>
+
+- *Type:* typing.Any
+
+Restrict the permission to a certain key pattern (default '*').
+
+---
+
+##### \`grant_read_write\` <a name="grant_read_write" id="construct-library.GreeterBucket.grantReadWrite"></a>
+
+\`\`\`python
+def grant_read_write(
+  identity: IGrantable,
+  objects_key_pattern: typing.Any = None
+) -> Grant
+\`\`\`
+
+Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
+
+If an encryption key is used, permission to use the key for
+encrypt/decrypt will also be granted.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantReadWrite.parameter.identity"></a>
+
+- *Type:* aws_cdk.aws_iam.IGrantable
+
+---
+
+###### \`objects_key_pattern\`<sup>Optional</sup> <a name="objects_key_pattern" id="construct-library.GreeterBucket.grantReadWrite.parameter.objectsKeyPattern"></a>
+
+- *Type:* typing.Any
+
+---
+
+##### \`grant_write\` <a name="grant_write" id="construct-library.GreeterBucket.grantWrite"></a>
+
+\`\`\`python
+def grant_write(
+  identity: IGrantable,
+  objects_key_pattern: typing.Any = None
+) -> Grant
+\`\`\`
+
+Grant write permissions to this bucket to an IAM principal.
+
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantWrite.parameter.identity"></a>
+
+- *Type:* aws_cdk.aws_iam.IGrantable
+
+---
+
+###### \`objects_key_pattern\`<sup>Optional</sup> <a name="objects_key_pattern" id="construct-library.GreeterBucket.grantWrite.parameter.objectsKeyPattern"></a>
+
+- *Type:* typing.Any
+
+---
+
+##### \`on_cloud_trail_event\` <a name="on_cloud_trail_event" id="construct-library.GreeterBucket.onCloudTrailEvent"></a>
+
+\`\`\`python
+def on_cloud_trail_event(
+  id: str,
+  description: str = None,
+  event_pattern: EventPattern = None,
+  rule_name: str = None,
+  target: IRuleTarget = None,
+  paths: typing.List[str] = None
+) -> Rule
+\`\`\`
+
+Define a CloudWatch event that triggers when something happens to this repository.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.onCloudTrailEvent.parameter.id"></a>
+
+- *Type:* str
+
+The id of the rule.
+
+---
+
+###### \`description\`<sup>Optional</sup> <a name="description" id="construct-library.GreeterBucket.onCloudTrailEvent.parameter.description"></a>
+
+- *Type:* str
+- *Default:* No description
+
+A description of the rule's purpose.
+
+---
+
+###### \`event_pattern\`<sup>Optional</sup> <a name="event_pattern" id="construct-library.GreeterBucket.onCloudTrailEvent.parameter.eventPattern"></a>
+
+- *Type:* aws_cdk.aws_events.EventPattern
+- *Default:* No additional filtering based on an event pattern.
+
+Additional restrictions for the event to route to the specified target.
+
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
+
+> [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
+
+---
+
+###### \`rule_name\`<sup>Optional</sup> <a name="rule_name" id="construct-library.GreeterBucket.onCloudTrailEvent.parameter.ruleName"></a>
+
+- *Type:* str
+- *Default:* AWS CloudFormation generates a unique physical ID.
+
+A name for the rule.
+
+---
+
+###### \`target\`<sup>Optional</sup> <a name="target" id="construct-library.GreeterBucket.onCloudTrailEvent.parameter.target"></a>
+
+- *Type:* aws_cdk.aws_events.IRuleTarget
+- *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
+
+The target to register for the event.
+
+---
+
+###### \`paths\`<sup>Optional</sup> <a name="paths" id="construct-library.GreeterBucket.onCloudTrailEvent.parameter.paths"></a>
+
+- *Type:* typing.List[str]
+- *Default:* Watch changes to all objects
+
+Only watch changes to these object paths.
+
+---
+
+##### \`on_cloud_trail_put_object\` <a name="on_cloud_trail_put_object" id="construct-library.GreeterBucket.onCloudTrailPutObject"></a>
+
+\`\`\`python
+def on_cloud_trail_put_object(
+  id: str,
+  description: str = None,
+  event_pattern: EventPattern = None,
+  rule_name: str = None,
+  target: IRuleTarget = None,
+  paths: typing.List[str] = None
+) -> Rule
+\`\`\`
+
+Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using \`onCloudTrailWriteObject\` may be preferable.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.onCloudTrailPutObject.parameter.id"></a>
+
+- *Type:* str
+
+The id of the rule.
+
+---
+
+###### \`description\`<sup>Optional</sup> <a name="description" id="construct-library.GreeterBucket.onCloudTrailPutObject.parameter.description"></a>
+
+- *Type:* str
+- *Default:* No description
+
+A description of the rule's purpose.
+
+---
+
+###### \`event_pattern\`<sup>Optional</sup> <a name="event_pattern" id="construct-library.GreeterBucket.onCloudTrailPutObject.parameter.eventPattern"></a>
+
+- *Type:* aws_cdk.aws_events.EventPattern
+- *Default:* No additional filtering based on an event pattern.
+
+Additional restrictions for the event to route to the specified target.
+
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
+
+> [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
+
+---
+
+###### \`rule_name\`<sup>Optional</sup> <a name="rule_name" id="construct-library.GreeterBucket.onCloudTrailPutObject.parameter.ruleName"></a>
+
+- *Type:* str
+- *Default:* AWS CloudFormation generates a unique physical ID.
+
+A name for the rule.
+
+---
+
+###### \`target\`<sup>Optional</sup> <a name="target" id="construct-library.GreeterBucket.onCloudTrailPutObject.parameter.target"></a>
+
+- *Type:* aws_cdk.aws_events.IRuleTarget
+- *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
+
+The target to register for the event.
+
+---
+
+###### \`paths\`<sup>Optional</sup> <a name="paths" id="construct-library.GreeterBucket.onCloudTrailPutObject.parameter.paths"></a>
+
+- *Type:* typing.List[str]
+- *Default:* Watch changes to all objects
+
+Only watch changes to these object paths.
+
+---
+
+##### \`on_cloud_trail_write_object\` <a name="on_cloud_trail_write_object" id="construct-library.GreeterBucket.onCloudTrailWriteObject"></a>
+
+\`\`\`python
+def on_cloud_trail_write_object(
+  id: str,
+  description: str = None,
+  event_pattern: EventPattern = None,
+  rule_name: str = None,
+  target: IRuleTarget = None,
+  paths: typing.List[str] = None
+) -> Rule
+\`\`\`
+
+Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to.
+
+This includes
+the events PutObject, CopyObject, and CompleteMultipartUpload.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using this method may be preferable to \`onCloudTrailPutObject\`.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.onCloudTrailWriteObject.parameter.id"></a>
+
+- *Type:* str
+
+The id of the rule.
+
+---
+
+###### \`description\`<sup>Optional</sup> <a name="description" id="construct-library.GreeterBucket.onCloudTrailWriteObject.parameter.description"></a>
+
+- *Type:* str
+- *Default:* No description
+
+A description of the rule's purpose.
+
+---
+
+###### \`event_pattern\`<sup>Optional</sup> <a name="event_pattern" id="construct-library.GreeterBucket.onCloudTrailWriteObject.parameter.eventPattern"></a>
+
+- *Type:* aws_cdk.aws_events.EventPattern
+- *Default:* No additional filtering based on an event pattern.
+
+Additional restrictions for the event to route to the specified target.
+
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
+
+> [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
+
+---
+
+###### \`rule_name\`<sup>Optional</sup> <a name="rule_name" id="construct-library.GreeterBucket.onCloudTrailWriteObject.parameter.ruleName"></a>
+
+- *Type:* str
+- *Default:* AWS CloudFormation generates a unique physical ID.
+
+A name for the rule.
+
+---
+
+###### \`target\`<sup>Optional</sup> <a name="target" id="construct-library.GreeterBucket.onCloudTrailWriteObject.parameter.target"></a>
+
+- *Type:* aws_cdk.aws_events.IRuleTarget
+- *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
+
+The target to register for the event.
+
+---
+
+###### \`paths\`<sup>Optional</sup> <a name="paths" id="construct-library.GreeterBucket.onCloudTrailWriteObject.parameter.paths"></a>
+
+- *Type:* typing.List[str]
+- *Default:* Watch changes to all objects
+
+Only watch changes to these object paths.
+
+---
+
+##### \`s3_url_for_object\` <a name="s3_url_for_object" id="construct-library.GreeterBucket.s3UrlForObject"></a>
+
+\`\`\`python
+def s3_url_for_object(
+  key: str = None
+) -> str
+\`\`\`
+
+The S3 URL of an S3 object. For example:.
+
+\`s3://onlybucket\`
+- \`s3://bucket/key\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.GreeterBucket.s3UrlForObject.parameter.key"></a>
+
+- *Type:* str
+
+The S3 key of the object.
+
+If not specified, the S3 URL of the
+bucket is returned.
+
+---
+
+##### \`transfer_acceleration_url_for_object\` <a name="transfer_acceleration_url_for_object" id="construct-library.GreeterBucket.transferAccelerationUrlForObject"></a>
+
+\`\`\`python
+def transfer_acceleration_url_for_object(
+  key: str = None,
+  dual_stack: bool = None
+) -> str
+\`\`\`
+
+The https Transfer Acceleration URL of an S3 object.
+
+Specify \`dualStack: true\` at the options
+for dual-stack endpoint (connect to the bucket over IPv6). For example:
+
+- \`https://bucket.s3-accelerate.amazonaws.com\`
+- \`https://bucket.s3-accelerate.amazonaws.com/key\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.GreeterBucket.transferAccelerationUrlForObject.parameter.key"></a>
+
+- *Type:* str
+
+The S3 key of the object.
+
+If not specified, the URL of the
+bucket is returned.
+
+---
+
+###### \`dual_stack\`<sup>Optional</sup> <a name="dual_stack" id="construct-library.GreeterBucket.transferAccelerationUrlForObject.parameter.dualStack"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Dual-stack support to connect to the bucket over IPv6.
+
+---
+
+##### \`url_for_object\` <a name="url_for_object" id="construct-library.GreeterBucket.urlForObject"></a>
+
+\`\`\`python
+def url_for_object(
+  key: str = None
+) -> str
+\`\`\`
+
+The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:.
+
+\`https://s3.us-west-1.amazonaws.com/onlybucket\`
+- \`https://s3.us-west-1.amazonaws.com/bucket/key\`
+- \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.GreeterBucket.urlForObject.parameter.key"></a>
+
+- *Type:* str
+
+The S3 key of the object.
+
+If not specified, the URL of the
+bucket is returned.
+
+---
+
+##### \`virtual_hosted_url_for_object\` <a name="virtual_hosted_url_for_object" id="construct-library.GreeterBucket.virtualHostedUrlForObject"></a>
+
+\`\`\`python
+def virtual_hosted_url_for_object(
+  key: str = None,
+  regional: bool = None
+) -> str
+\`\`\`
+
+The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:.
+
+\`https://only-bucket.s3.us-west-1.amazonaws.com\`
+- \`https://bucket.s3.us-west-1.amazonaws.com/key\`
+- \`https://bucket.s3.amazonaws.com/key\`
+- \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.GreeterBucket.virtualHostedUrlForObject.parameter.key"></a>
+
+- *Type:* str
+
+The S3 key of the object.
+
+If not specified, the URL of the
+bucket is returned.
+
+---
+
+###### \`regional\`<sup>Optional</sup> <a name="regional" id="construct-library.GreeterBucket.virtualHostedUrlForObject.parameter.regional"></a>
+
+- *Type:* bool
+- *Default:* true
+
+Specifies the URL includes the region.
+
+---
+
+##### \`add_cors_rule\` <a name="add_cors_rule" id="construct-library.GreeterBucket.addCorsRule"></a>
+
+\`\`\`python
+def add_cors_rule(
+  allowed_methods: typing.List[HttpMethods],
+  allowed_origins: typing.List[str],
+  allowed_headers: typing.List[str] = None,
+  exposed_headers: typing.List[str] = None,
+  id: str = None,
+  max_age: typing.Union[int, float] = None
+) -> None
+\`\`\`
+
+Adds a cross-origin access configuration for objects in an Amazon S3 bucket.
+
+###### \`allowed_methods\`<sup>Required</sup> <a name="allowed_methods" id="construct-library.GreeterBucket.addCorsRule.parameter.allowedMethods"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.HttpMethods]
+
+An HTTP method that you allow the origin to execute.
+
+---
+
+###### \`allowed_origins\`<sup>Required</sup> <a name="allowed_origins" id="construct-library.GreeterBucket.addCorsRule.parameter.allowedOrigins"></a>
+
+- *Type:* typing.List[str]
+
+One or more origins you want customers to be able to access the bucket from.
+
+---
+
+###### \`allowed_headers\`<sup>Optional</sup> <a name="allowed_headers" id="construct-library.GreeterBucket.addCorsRule.parameter.allowedHeaders"></a>
+
+- *Type:* typing.List[str]
+- *Default:* No headers allowed.
+
+Headers that are specified in the Access-Control-Request-Headers header.
+
+---
+
+###### \`exposed_headers\`<sup>Optional</sup> <a name="exposed_headers" id="construct-library.GreeterBucket.addCorsRule.parameter.exposedHeaders"></a>
+
+- *Type:* typing.List[str]
+- *Default:* No headers exposed.
+
+One or more headers in the response that you want customers to be able to access from their applications.
+
+---
+
+###### \`id\`<sup>Optional</sup> <a name="id" id="construct-library.GreeterBucket.addCorsRule.parameter.id"></a>
+
+- *Type:* str
+- *Default:* No id specified.
+
+A unique identifier for this rule.
+
+---
+
+###### \`max_age\`<sup>Optional</sup> <a name="max_age" id="construct-library.GreeterBucket.addCorsRule.parameter.maxAge"></a>
+
+- *Type:* typing.Union[int, float]
+- *Default:* No caching.
+
+The time in seconds that your browser is to cache the preflight response for the specified resource.
+
+---
+
+##### \`add_inventory\` <a name="add_inventory" id="construct-library.GreeterBucket.addInventory"></a>
+
+\`\`\`python
+def add_inventory(
+  destination: InventoryDestination,
+  enabled: bool = None,
+  format: InventoryFormat = None,
+  frequency: InventoryFrequency = None,
+  include_object_versions: InventoryObjectVersion = None,
+  inventory_id: str = None,
+  objects_prefix: str = None,
+  optional_fields: typing.List[str] = None
+) -> None
+\`\`\`
+
+Add an inventory configuration.
+
+###### \`destination\`<sup>Required</sup> <a name="destination" id="construct-library.GreeterBucket.addInventory.parameter.destination"></a>
+
+- *Type:* aws_cdk.aws_s3.InventoryDestination
+
+The destination of the inventory.
+
+---
+
+###### \`enabled\`<sup>Optional</sup> <a name="enabled" id="construct-library.GreeterBucket.addInventory.parameter.enabled"></a>
+
+- *Type:* bool
+- *Default:* true
+
+Whether the inventory is enabled or disabled.
+
+---
+
+###### \`format\`<sup>Optional</sup> <a name="format" id="construct-library.GreeterBucket.addInventory.parameter.format"></a>
+
+- *Type:* aws_cdk.aws_s3.InventoryFormat
+- *Default:* InventoryFormat.CSV
+
+The format of the inventory.
+
+---
+
+###### \`frequency\`<sup>Optional</sup> <a name="frequency" id="construct-library.GreeterBucket.addInventory.parameter.frequency"></a>
+
+- *Type:* aws_cdk.aws_s3.InventoryFrequency
+- *Default:* InventoryFrequency.WEEKLY
+
+Frequency at which the inventory should be generated.
+
+---
+
+###### \`include_object_versions\`<sup>Optional</sup> <a name="include_object_versions" id="construct-library.GreeterBucket.addInventory.parameter.includeObjectVersions"></a>
+
+- *Type:* aws_cdk.aws_s3.InventoryObjectVersion
+- *Default:* InventoryObjectVersion.ALL
+
+If the inventory should contain all the object versions or only the current one.
+
+---
+
+###### \`inventory_id\`<sup>Optional</sup> <a name="inventory_id" id="construct-library.GreeterBucket.addInventory.parameter.inventoryId"></a>
+
+- *Type:* str
+- *Default:* generated ID.
+
+The inventory configuration ID.
+
+---
+
+###### \`objects_prefix\`<sup>Optional</sup> <a name="objects_prefix" id="construct-library.GreeterBucket.addInventory.parameter.objectsPrefix"></a>
+
+- *Type:* str
+- *Default:* No objects prefix
+
+The inventory will only include objects that meet the prefix filter criteria.
+
+---
+
+###### \`optional_fields\`<sup>Optional</sup> <a name="optional_fields" id="construct-library.GreeterBucket.addInventory.parameter.optionalFields"></a>
+
+- *Type:* typing.List[str]
+- *Default:* No optional fields.
+
+A list of optional fields to be included in the inventory result.
+
+---
+
+##### \`add_lifecycle_rule\` <a name="add_lifecycle_rule" id="construct-library.GreeterBucket.addLifecycleRule"></a>
+
+\`\`\`python
+def add_lifecycle_rule(
+  abort_incomplete_multipart_upload_after: Duration = None,
+  enabled: bool = None,
+  expiration: Duration = None,
+  expiration_date: datetime.datetime = None,
+  expired_object_delete_marker: bool = None,
+  id: str = None,
+  noncurrent_version_expiration: Duration = None,
+  noncurrent_versions_to_retain: typing.Union[int, float] = None,
+  noncurrent_version_transitions: typing.List[NoncurrentVersionTransition] = None,
+  object_size_greater_than: typing.Union[int, float] = None,
+  object_size_less_than: typing.Union[int, float] = None,
+  prefix: str = None,
+  tag_filters: typing.Mapping[typing.Any] = None,
+  transitions: typing.List[Transition] = None
+) -> None
+\`\`\`
+
+Add a lifecycle rule to the bucket.
+
+###### \`abort_incomplete_multipart_upload_after\`<sup>Optional</sup> <a name="abort_incomplete_multipart_upload_after" id="construct-library.GreeterBucket.addLifecycleRule.parameter.abortIncompleteMultipartUploadAfter"></a>
+
+- *Type:* aws_cdk.core.Duration
+- *Default:* Incomplete uploads are never aborted
+
+Specifies a lifecycle rule that aborts incomplete multipart uploads to an Amazon S3 bucket.
+
+The AbortIncompleteMultipartUpload property type creates a lifecycle
+rule that aborts incomplete multipart uploads to an Amazon S3 bucket.
+When Amazon S3 aborts a multipart upload, it deletes all parts
+associated with the multipart upload.
+
+---
+
+###### \`enabled\`<sup>Optional</sup> <a name="enabled" id="construct-library.GreeterBucket.addLifecycleRule.parameter.enabled"></a>
+
+- *Type:* bool
+- *Default:* true
+
+Whether this rule is enabled.
+
+---
+
+###### \`expiration\`<sup>Optional</sup> <a name="expiration" id="construct-library.GreeterBucket.addLifecycleRule.parameter.expiration"></a>
+
+- *Type:* aws_cdk.core.Duration
+- *Default:* No expiration timeout
+
+Indicates the number of days after creation when objects are deleted from Amazon S3 and Amazon Glacier.
+
+If you specify an expiration and transition time, you must use the same
+time unit for both properties (either in days or by date). The
+expiration time must also be later than the transition time.
+
+---
+
+###### \`expiration_date\`<sup>Optional</sup> <a name="expiration_date" id="construct-library.GreeterBucket.addLifecycleRule.parameter.expirationDate"></a>
+
+- *Type:* datetime.datetime
+- *Default:* No expiration date
+
+Indicates when objects are deleted from Amazon S3 and Amazon Glacier.
+
+The date value must be in ISO 8601 format. The time is always midnight UTC.
+
+If you specify an expiration and transition time, you must use the same
+time unit for both properties (either in days or by date). The
+expiration time must also be later than the transition time.
+
+---
+
+###### \`expired_object_delete_marker\`<sup>Optional</sup> <a name="expired_object_delete_marker" id="construct-library.GreeterBucket.addLifecycleRule.parameter.expiredObjectDeleteMarker"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions.
+
+If set to true, the delete marker will be expired.
+
+---
+
+###### \`id\`<sup>Optional</sup> <a name="id" id="construct-library.GreeterBucket.addLifecycleRule.parameter.id"></a>
+
+- *Type:* str
+
+A unique identifier for this rule.
+
+The value cannot be more than 255 characters.
+
+---
+
+###### \`noncurrent_version_expiration\`<sup>Optional</sup> <a name="noncurrent_version_expiration" id="construct-library.GreeterBucket.addLifecycleRule.parameter.noncurrentVersionExpiration"></a>
+
+- *Type:* aws_cdk.core.Duration
+- *Default:* No noncurrent version expiration
+
+Time between when a new version of the object is uploaded to the bucket and when old versions of the object expire.
+
+For buckets with versioning enabled (or suspended), specifies the time,
+in days, between when a new version of the object is uploaded to the
+bucket and when old versions of the object expire. When object versions
+expire, Amazon S3 permanently deletes them. If you specify a transition
+and expiration time, the expiration time must be later than the
+transition time.
+
+---
+
+###### \`noncurrent_versions_to_retain\`<sup>Optional</sup> <a name="noncurrent_versions_to_retain" id="construct-library.GreeterBucket.addLifecycleRule.parameter.noncurrentVersionsToRetain"></a>
+
+- *Type:* typing.Union[int, float]
+- *Default:* No noncurrent versions to retain
+
+Indicates a maximum number of noncurrent versions to retain.
+
+If there are this many more noncurrent versions,
+Amazon S3 permanently deletes them.
+
+---
+
+###### \`noncurrent_version_transitions\`<sup>Optional</sup> <a name="noncurrent_version_transitions" id="construct-library.GreeterBucket.addLifecycleRule.parameter.noncurrentVersionTransitions"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.NoncurrentVersionTransition]
+
+One or more transition rules that specify when non-current objects transition to a specified storage class.
+
+Only for for buckets with versioning enabled (or suspended).
+
+If you specify a transition and expiration time, the expiration time
+must be later than the transition time.
+
+---
+
+###### \`object_size_greater_than\`<sup>Optional</sup> <a name="object_size_greater_than" id="construct-library.GreeterBucket.addLifecycleRule.parameter.objectSizeGreaterThan"></a>
+
+- *Type:* typing.Union[int, float]
+- *Default:* No rule
+
+Specifies the minimum object size in bytes for this rule to apply to.
+
+---
+
+###### \`object_size_less_than\`<sup>Optional</sup> <a name="object_size_less_than" id="construct-library.GreeterBucket.addLifecycleRule.parameter.objectSizeLessThan"></a>
+
+- *Type:* typing.Union[int, float]
+- *Default:* No rule
+
+Specifies the maximum object size in bytes for this rule to apply to.
+
+---
+
+###### \`prefix\`<sup>Optional</sup> <a name="prefix" id="construct-library.GreeterBucket.addLifecycleRule.parameter.prefix"></a>
+
+- *Type:* str
+- *Default:* Rule applies to all objects
+
+Object key prefix that identifies one or more objects to which this rule applies.
+
+---
+
+###### \`tag_filters\`<sup>Optional</sup> <a name="tag_filters" id="construct-library.GreeterBucket.addLifecycleRule.parameter.tagFilters"></a>
+
+- *Type:* typing.Mapping[typing.Any]
+- *Default:* Rule applies to all objects
+
+The TagFilter property type specifies tags to use to identify a subset of objects for an Amazon S3 bucket.
+
+---
+
+###### \`transitions\`<sup>Optional</sup> <a name="transitions" id="construct-library.GreeterBucket.addLifecycleRule.parameter.transitions"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.Transition]
+- *Default:* No transition rules
+
+One or more transition rules that specify when an object transitions to a specified storage class.
+
+If you specify an expiration and transition time, you must use the same
+time unit for both properties (either in days or by date). The
+expiration time must also be later than the transition time.
+
+---
+
+##### \`add_metric\` <a name="add_metric" id="construct-library.GreeterBucket.addMetric"></a>
+
+\`\`\`python
+def add_metric(
+  id: str,
+  prefix: str = None,
+  tag_filters: typing.Mapping[typing.Any] = None
+) -> None
+\`\`\`
+
+Adds a metrics configuration for the CloudWatch request metrics from the bucket.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.addMetric.parameter.id"></a>
+
+- *Type:* str
+
+The ID used to identify the metrics configuration.
+
+---
+
+###### \`prefix\`<sup>Optional</sup> <a name="prefix" id="construct-library.GreeterBucket.addMetric.parameter.prefix"></a>
+
+- *Type:* str
+
+The prefix that an object must have to be included in the metrics results.
+
+---
+
+###### \`tag_filters\`<sup>Optional</sup> <a name="tag_filters" id="construct-library.GreeterBucket.addMetric.parameter.tagFilters"></a>
+
+- *Type:* typing.Mapping[typing.Any]
+
+Specifies a list of tag filters to use as a metrics configuration filter.
+
+The metrics configuration includes only objects that meet the filter's criteria.
+
+---
+
+##### \`greet\` <a name="greet" id="construct-library.GreeterBucket.greet"></a>
+
+\`\`\`python
+def greet() -> None
+\`\`\`
+
+##### \`greet_with_salutation\` <a name="greet_with_salutation" id="construct-library.GreeterBucket.greetWithSalutation"></a>
+
+\`\`\`python
+def greet_with_salutation(
+  salution: str
+) -> None
+\`\`\`
+
+###### \`salution\`<sup>Required</sup> <a name="salution" id="construct-library.GreeterBucket.greetWithSalutation.parameter.salution"></a>
+
+- *Type:* str
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#construct-library.GreeterBucket.isConstruct">is_construct</a></code> | Return whether the given object is a Construct. |
+| <code><a href="#construct-library.GreeterBucket.isResource">is_resource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#construct-library.GreeterBucket.fromBucketArn">from_bucket_arn</a></code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.fromBucketAttributes">from_bucket_attributes</a></code> | Creates a Bucket construct that represents an external bucket. |
+| <code><a href="#construct-library.GreeterBucket.fromBucketName">from_bucket_name</a></code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.validateBucketName">validate_bucket_name</a></code> | Thrown an exception if the given bucket name is not valid. |
+
+---
+
+##### \`is_construct\` <a name="is_construct" id="construct-library.GreeterBucket.isConstruct"></a>
+
+\`\`\`python
+import construct_library
+
+construct_library.GreeterBucket.is_construct(
+  x: typing.Any
+)
+\`\`\`
+
+Return whether the given object is a Construct.
+
+###### \`x\`<sup>Required</sup> <a name="x" id="construct-library.GreeterBucket.isConstruct.parameter.x"></a>
+
+- *Type:* typing.Any
+
+---
+
+##### \`is_resource\` <a name="is_resource" id="construct-library.GreeterBucket.isResource"></a>
+
+\`\`\`python
+import construct_library
+
+construct_library.GreeterBucket.is_resource(
+  construct: IConstruct
+)
+\`\`\`
+
+Check whether the given construct is a Resource.
+
+###### \`construct\`<sup>Required</sup> <a name="construct" id="construct-library.GreeterBucket.isResource.parameter.construct"></a>
+
+- *Type:* aws_cdk.core.IConstruct
+
+---
+
+##### \`from_bucket_arn\` <a name="from_bucket_arn" id="construct-library.GreeterBucket.fromBucketArn"></a>
+
+\`\`\`python
+import construct_library
+
+construct_library.GreeterBucket.from_bucket_arn(
+  scope: Construct,
+  id: str,
+  bucket_arn: str
+)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.GreeterBucket.fromBucketArn.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.fromBucketArn.parameter.id"></a>
+
+- *Type:* str
+
+---
+
+###### \`bucket_arn\`<sup>Required</sup> <a name="bucket_arn" id="construct-library.GreeterBucket.fromBucketArn.parameter.bucketArn"></a>
+
+- *Type:* str
+
+---
+
+##### \`from_bucket_attributes\` <a name="from_bucket_attributes" id="construct-library.GreeterBucket.fromBucketAttributes"></a>
+
+\`\`\`python
+import construct_library
+
+construct_library.GreeterBucket.from_bucket_attributes(
+  scope: Construct,
+  id: str,
+  account: str = None,
+  bucket_arn: str = None,
+  bucket_domain_name: str = None,
+  bucket_dual_stack_domain_name: str = None,
+  bucket_name: str = None,
+  bucket_regional_domain_name: str = None,
+  bucket_website_new_url_format: bool = None,
+  bucket_website_url: str = None,
+  encryption_key: IKey = None,
+  is_website: bool = None,
+  notifications_handler_role: IRole = None,
+  region: str = None
+)
+\`\`\`
+
+Creates a Bucket construct that represents an external bucket.
+
+###### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually \`this\`).
+
+---
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.id"></a>
+
+- *Type:* str
+
+The construct's name.
+
+---
+
+###### \`account\`<sup>Optional</sup> <a name="account" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.account"></a>
+
+- *Type:* str
+- *Default:* it's assumed the bucket belongs to the same account as the scope it's being imported into
+
+The account this existing bucket belongs to.
+
+---
+
+###### \`bucket_arn\`<sup>Optional</sup> <a name="bucket_arn" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.bucketArn"></a>
+
+- *Type:* str
+
+The ARN of the bucket.
+
+At least one of bucketArn or bucketName must be
+defined in order to initialize a bucket ref.
+
+---
+
+###### \`bucket_domain_name\`<sup>Optional</sup> <a name="bucket_domain_name" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.bucketDomainName"></a>
+
+- *Type:* str
+- *Default:* Inferred from bucket name
+
+The domain name of the bucket.
+
+---
+
+###### \`bucket_dual_stack_domain_name\`<sup>Optional</sup> <a name="bucket_dual_stack_domain_name" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.bucketDualStackDomainName"></a>
+
+- *Type:* str
+
+The IPv6 DNS name of the specified bucket.
+
+---
+
+###### \`bucket_name\`<sup>Optional</sup> <a name="bucket_name" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.bucketName"></a>
+
+- *Type:* str
+
+The name of the bucket.
+
+If the underlying value of ARN is a string, the
+name will be parsed from the ARN. Otherwise, the name is optional, but
+some features that require the bucket name such as auto-creating a bucket
+policy, won't work.
+
+---
+
+###### \`bucket_regional_domain_name\`<sup>Optional</sup> <a name="bucket_regional_domain_name" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.bucketRegionalDomainName"></a>
+
+- *Type:* str
+
+The regional domain name of the specified bucket.
+
+---
+
+###### \`bucket_website_new_url_format\`<sup>Optional</sup> <a name="bucket_website_new_url_format" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.bucketWebsiteNewUrlFormat"></a>
+
+- *Type:* bool
+- *Default:* false
+
+The format of the website URL of the bucket.
+
+This should be true for
+regions launched since 2014.
+
+---
+
+###### \`bucket_website_url\`<sup>Optional</sup> <a name="bucket_website_url" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.bucketWebsiteUrl"></a>
+
+- *Type:* str
+- *Default:* Inferred from bucket name
+
+The website URL of the bucket (if static web hosting is enabled).
+
+---
+
+###### \`encryption_key\`<sup>Optional</sup> <a name="encryption_key" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.encryptionKey"></a>
+
+- *Type:* aws_cdk.aws_kms.IKey
+
+---
+
+###### \`is_website\`<sup>Optional</sup> <a name="is_website" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.isWebsite"></a>
+
+- *Type:* bool
+- *Default:* false
+
+If this bucket has been configured for static website hosting.
+
+---
+
+###### \`notifications_handler_role\`<sup>Optional</sup> <a name="notifications_handler_role" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.notificationsHandlerRole"></a>
+
+- *Type:* aws_cdk.aws_iam.IRole
+- *Default:* a new role will be created.
+
+The role to be used by the notifications handler.
+
+---
+
+###### \`region\`<sup>Optional</sup> <a name="region" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.region"></a>
+
+- *Type:* str
+- *Default:* it's assumed the bucket is in the same region as the scope it's being imported into
+
+The region this existing bucket is in.
+
+---
+
+##### \`from_bucket_name\` <a name="from_bucket_name" id="construct-library.GreeterBucket.fromBucketName"></a>
+
+\`\`\`python
+import construct_library
+
+construct_library.GreeterBucket.from_bucket_name(
+  scope: Construct,
+  id: str,
+  bucket_name: str
+)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.GreeterBucket.fromBucketName.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.fromBucketName.parameter.id"></a>
+
+- *Type:* str
+
+---
+
+###### \`bucket_name\`<sup>Required</sup> <a name="bucket_name" id="construct-library.GreeterBucket.fromBucketName.parameter.bucketName"></a>
+
+- *Type:* str
+
+---
+
+##### \`validate_bucket_name\` <a name="validate_bucket_name" id="construct-library.GreeterBucket.validateBucketName"></a>
+
+\`\`\`python
+import construct_library
+
+construct_library.GreeterBucket.validate_bucket_name(
+  physical_name: str
+)
+\`\`\`
+
+Thrown an exception if the given bucket name is not valid.
+
+###### \`physical_name\`<sup>Required</sup> <a name="physical_name" id="construct-library.GreeterBucket.validateBucketName.parameter.physicalName"></a>
+
+- *Type:* str
+
+name of the bucket.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#construct-library.GreeterBucket.property.node">node</a></code> | <code>aws_cdk.core.ConstructNode</code> | The construct tree node associated with this construct. |
+| <code><a href="#construct-library.GreeterBucket.property.env">env</a></code> | <code>aws_cdk.core.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#construct-library.GreeterBucket.property.stack">stack</a></code> | <code>aws_cdk.core.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketArn">bucket_arn</a></code> | <code>str</code> | The ARN of the bucket. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketDomainName">bucket_domain_name</a></code> | <code>str</code> | The IPv4 DNS name of the specified bucket. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketDualStackDomainName">bucket_dual_stack_domain_name</a></code> | <code>str</code> | The IPv6 DNS name of the specified bucket. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketName">bucket_name</a></code> | <code>str</code> | The name of the bucket. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketRegionalDomainName">bucket_regional_domain_name</a></code> | <code>str</code> | The regional domain name of the specified bucket. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketWebsiteDomainName">bucket_website_domain_name</a></code> | <code>str</code> | The Domain name of the static website. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketWebsiteUrl">bucket_website_url</a></code> | <code>str</code> | The URL of the static website. |
+| <code><a href="#construct-library.GreeterBucket.property.encryptionKey">encryption_key</a></code> | <code>aws_cdk.aws_kms.IKey</code> | Optional KMS encryption key associated with this bucket. |
+| <code><a href="#construct-library.GreeterBucket.property.isWebsite">is_website</a></code> | <code>bool</code> | If this bucket has been configured for static website hosting. |
+| <code><a href="#construct-library.GreeterBucket.property.policy">policy</a></code> | <code>aws_cdk.aws_s3.BucketPolicy</code> | The resource policy associated with this bucket. |
+
+---
+
+##### \`node\`<sup>Required</sup> <a name="node" id="construct-library.GreeterBucket.property.node"></a>
+
+\`\`\`python
+node: ConstructNode
+\`\`\`
+
+- *Type:* aws_cdk.core.ConstructNode
+
+The construct tree node associated with this construct.
+
+---
+
+##### \`env\`<sup>Required</sup> <a name="env" id="construct-library.GreeterBucket.property.env"></a>
+
+\`\`\`python
+env: ResourceEnvironment
+\`\`\`
+
+- *Type:* aws_cdk.core.ResourceEnvironment
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### \`stack\`<sup>Required</sup> <a name="stack" id="construct-library.GreeterBucket.property.stack"></a>
+
+\`\`\`python
+stack: Stack
+\`\`\`
+
+- *Type:* aws_cdk.core.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### \`bucket_arn\`<sup>Required</sup> <a name="bucket_arn" id="construct-library.GreeterBucket.property.bucketArn"></a>
+
+\`\`\`python
+bucket_arn: str
+\`\`\`
+
+- *Type:* str
+
+The ARN of the bucket.
+
+---
+
+##### \`bucket_domain_name\`<sup>Required</sup> <a name="bucket_domain_name" id="construct-library.GreeterBucket.property.bucketDomainName"></a>
+
+\`\`\`python
+bucket_domain_name: str
+\`\`\`
+
+- *Type:* str
+
+The IPv4 DNS name of the specified bucket.
+
+---
+
+##### \`bucket_dual_stack_domain_name\`<sup>Required</sup> <a name="bucket_dual_stack_domain_name" id="construct-library.GreeterBucket.property.bucketDualStackDomainName"></a>
+
+\`\`\`python
+bucket_dual_stack_domain_name: str
+\`\`\`
+
+- *Type:* str
+
+The IPv6 DNS name of the specified bucket.
+
+---
+
+##### \`bucket_name\`<sup>Required</sup> <a name="bucket_name" id="construct-library.GreeterBucket.property.bucketName"></a>
+
+\`\`\`python
+bucket_name: str
+\`\`\`
+
+- *Type:* str
+
+The name of the bucket.
+
+---
+
+##### \`bucket_regional_domain_name\`<sup>Required</sup> <a name="bucket_regional_domain_name" id="construct-library.GreeterBucket.property.bucketRegionalDomainName"></a>
+
+\`\`\`python
+bucket_regional_domain_name: str
+\`\`\`
+
+- *Type:* str
+
+The regional domain name of the specified bucket.
+
+---
+
+##### \`bucket_website_domain_name\`<sup>Required</sup> <a name="bucket_website_domain_name" id="construct-library.GreeterBucket.property.bucketWebsiteDomainName"></a>
+
+\`\`\`python
+bucket_website_domain_name: str
+\`\`\`
+
+- *Type:* str
+
+The Domain name of the static website.
+
+---
+
+##### \`bucket_website_url\`<sup>Required</sup> <a name="bucket_website_url" id="construct-library.GreeterBucket.property.bucketWebsiteUrl"></a>
+
+\`\`\`python
+bucket_website_url: str
+\`\`\`
+
+- *Type:* str
+
+The URL of the static website.
+
+---
+
+##### \`encryption_key\`<sup>Optional</sup> <a name="encryption_key" id="construct-library.GreeterBucket.property.encryptionKey"></a>
+
+\`\`\`python
+encryption_key: IKey
+\`\`\`
+
+- *Type:* aws_cdk.aws_kms.IKey
+
+Optional KMS encryption key associated with this bucket.
+
+---
+
+##### \`is_website\`<sup>Optional</sup> <a name="is_website" id="construct-library.GreeterBucket.property.isWebsite"></a>
+
+\`\`\`python
+is_website: bool
+\`\`\`
+
+- *Type:* bool
+
+If this bucket has been configured for static website hosting.
+
+---
+
+##### \`policy\`<sup>Optional</sup> <a name="policy" id="construct-library.GreeterBucket.property.policy"></a>
+
+\`\`\`python
+policy: BucketPolicy
+\`\`\`
+
+- *Type:* aws_cdk.aws_s3.BucketPolicy
+
+The resource policy associated with this bucket.
+
+If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the
+first call to addToResourcePolicy(s).
+
+---
+
+
+
+
+
+"
+`;
+
+exports[`specify languages and split-by-submodule creates submodule files next to output: API.typescript.md 1`] = `
+"# API Reference <a name="API Reference" id="api-reference"></a>
+
+## Submodules <a name="Submodules" id="submodules"></a>
+
+The following submodules are available:
+
+- [submod1](./submod1.typescript.md)
+
+## Constructs <a name="Constructs" id="Constructs"></a>
+
+### GreeterBucket <a name="GreeterBucket" id="construct-library.GreeterBucket"></a>
+
+#### Initializers <a name="Initializers" id="construct-library.GreeterBucket.Initializer"></a>
+
+\`\`\`typescript
+import { GreeterBucket } from 'construct-library'
+
+new GreeterBucket(scope: Construct, id: string, props?: BucketProps)
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.Initializer.parameter.props">props</a></code> | <code>@aws-cdk/aws-s3.BucketProps</code> | *No description.* |
+
+---
+
+##### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.GreeterBucket.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### \`props\`<sup>Optional</sup> <a name="props" id="construct-library.GreeterBucket.Initializer.parameter.props"></a>
+
+- *Type:* @aws-cdk/aws-s3.BucketProps
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#construct-library.GreeterBucket.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#construct-library.GreeterBucket.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#construct-library.GreeterBucket.addEventNotification">addEventNotification</a></code> | Adds a bucket notification event destination. |
+| <code><a href="#construct-library.GreeterBucket.addObjectCreatedNotification">addObjectCreatedNotification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
+| <code><a href="#construct-library.GreeterBucket.addObjectRemovedNotification">addObjectRemovedNotification</a></code> | Subscribes a destination to receive notifications when an object is removed from the bucket. |
+| <code><a href="#construct-library.GreeterBucket.addToResourcePolicy">addToResourcePolicy</a></code> | Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects. |
+| <code><a href="#construct-library.GreeterBucket.arnForObjects">arnForObjects</a></code> | Returns an ARN that represents all objects within the bucket that match the key pattern specified. |
+| <code><a href="#construct-library.GreeterBucket.grantDelete">grantDelete</a></code> | Grants s3:DeleteObject* permission to an IAM principal for objects in this bucket. |
+| <code><a href="#construct-library.GreeterBucket.grantPublicAccess">grantPublicAccess</a></code> | Allows unrestricted access to objects from this bucket. |
+| <code><a href="#construct-library.GreeterBucket.grantPut">grantPut</a></code> | Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal. |
+| <code><a href="#construct-library.GreeterBucket.grantPutAcl">grantPutAcl</a></code> | Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket. |
+| <code><a href="#construct-library.GreeterBucket.grantRead">grantRead</a></code> | Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User). |
+| <code><a href="#construct-library.GreeterBucket.grantReadWrite">grantReadWrite</a></code> | Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User). |
+| <code><a href="#construct-library.GreeterBucket.grantWrite">grantWrite</a></code> | Grant write permissions to this bucket to an IAM principal. |
+| <code><a href="#construct-library.GreeterBucket.onCloudTrailEvent">onCloudTrailEvent</a></code> | Define a CloudWatch event that triggers when something happens to this repository. |
+| <code><a href="#construct-library.GreeterBucket.onCloudTrailPutObject">onCloudTrailPutObject</a></code> | Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call. |
+| <code><a href="#construct-library.GreeterBucket.onCloudTrailWriteObject">onCloudTrailWriteObject</a></code> | Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to. |
+| <code><a href="#construct-library.GreeterBucket.s3UrlForObject">s3UrlForObject</a></code> | The S3 URL of an S3 object. For example:. |
+| <code><a href="#construct-library.GreeterBucket.transferAccelerationUrlForObject">transferAccelerationUrlForObject</a></code> | The https Transfer Acceleration URL of an S3 object. |
+| <code><a href="#construct-library.GreeterBucket.urlForObject">urlForObject</a></code> | The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:. |
+| <code><a href="#construct-library.GreeterBucket.virtualHostedUrlForObject">virtualHostedUrlForObject</a></code> | The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:. |
+| <code><a href="#construct-library.GreeterBucket.addCorsRule">addCorsRule</a></code> | Adds a cross-origin access configuration for objects in an Amazon S3 bucket. |
+| <code><a href="#construct-library.GreeterBucket.addInventory">addInventory</a></code> | Add an inventory configuration. |
+| <code><a href="#construct-library.GreeterBucket.addLifecycleRule">addLifecycleRule</a></code> | Add a lifecycle rule to the bucket. |
+| <code><a href="#construct-library.GreeterBucket.addMetric">addMetric</a></code> | Adds a metrics configuration for the CloudWatch request metrics from the bucket. |
+| <code><a href="#construct-library.GreeterBucket.greet">greet</a></code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.greetWithSalutation">greetWithSalutation</a></code> | *No description.* |
+
+---
+
+##### \`toString\` <a name="toString" id="construct-library.GreeterBucket.toString"></a>
+
+\`\`\`typescript
+public toString(): string
+\`\`\`
+
+Returns a string representation of this construct.
+
+##### \`applyRemovalPolicy\` <a name="applyRemovalPolicy" id="construct-library.GreeterBucket.applyRemovalPolicy"></a>
+
+\`\`\`typescript
+public applyRemovalPolicy(policy: RemovalPolicy): void
+\`\`\`
+
+Apply the given removal policy to this resource.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+
+###### \`policy\`<sup>Required</sup> <a name="policy" id="construct-library.GreeterBucket.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* @aws-cdk/core.RemovalPolicy
+
+---
+
+##### \`addEventNotification\` <a name="addEventNotification" id="construct-library.GreeterBucket.addEventNotification"></a>
+
+\`\`\`typescript
+public addEventNotification(event: EventType, dest: IBucketNotificationDestination, filters: NotificationKeyFilter): void
+\`\`\`
+
+Adds a bucket notification event destination.
+
+> [https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
+
+*Example*
+
+\`\`\`typescript
+   declare const myLambda: lambda.Function;
+   const bucket = new s3.Bucket(this, 'MyBucket');
+   bucket.addEventNotification(s3.EventType.OBJECT_CREATED, new s3n.LambdaDestination(myLambda), {prefix: 'home/myusername/*'});
+\`\`\`
+
+
+###### \`event\`<sup>Required</sup> <a name="event" id="construct-library.GreeterBucket.addEventNotification.parameter.event"></a>
+
+- *Type:* @aws-cdk/aws-s3.EventType
+
+The event to trigger the notification.
+
+---
+
+###### \`dest\`<sup>Required</sup> <a name="dest" id="construct-library.GreeterBucket.addEventNotification.parameter.dest"></a>
+
+- *Type:* @aws-cdk/aws-s3.IBucketNotificationDestination
+
+The notification destination (Lambda, SNS Topic or SQS Queue).
+
+---
+
+###### \`filters\`<sup>Required</sup> <a name="filters" id="construct-library.GreeterBucket.addEventNotification.parameter.filters"></a>
+
+- *Type:* @aws-cdk/aws-s3.NotificationKeyFilter
+
+S3 object key filter rules to determine which objects trigger this event.
+
+Each filter must include a \`prefix\` and/or \`suffix\`
+that will be matched against the s3 object key. Refer to the S3 Developer Guide
+for details about allowed filter rules.
+
+---
+
+##### \`addObjectCreatedNotification\` <a name="addObjectCreatedNotification" id="construct-library.GreeterBucket.addObjectCreatedNotification"></a>
+
+\`\`\`typescript
+public addObjectCreatedNotification(dest: IBucketNotificationDestination, filters: NotificationKeyFilter): void
+\`\`\`
+
+Subscribes a destination to receive notifications when an object is created in the bucket.
+
+This is identical to calling
+\`onEvent(EventType.OBJECT_CREATED)\`.
+
+###### \`dest\`<sup>Required</sup> <a name="dest" id="construct-library.GreeterBucket.addObjectCreatedNotification.parameter.dest"></a>
+
+- *Type:* @aws-cdk/aws-s3.IBucketNotificationDestination
+
+The notification destination (see onEvent).
+
+---
+
+###### \`filters\`<sup>Required</sup> <a name="filters" id="construct-library.GreeterBucket.addObjectCreatedNotification.parameter.filters"></a>
+
+- *Type:* @aws-cdk/aws-s3.NotificationKeyFilter
+
+Filters (see onEvent).
+
+---
+
+##### \`addObjectRemovedNotification\` <a name="addObjectRemovedNotification" id="construct-library.GreeterBucket.addObjectRemovedNotification"></a>
+
+\`\`\`typescript
+public addObjectRemovedNotification(dest: IBucketNotificationDestination, filters: NotificationKeyFilter): void
+\`\`\`
+
+Subscribes a destination to receive notifications when an object is removed from the bucket.
+
+This is identical to calling
+\`onEvent(EventType.OBJECT_REMOVED)\`.
+
+###### \`dest\`<sup>Required</sup> <a name="dest" id="construct-library.GreeterBucket.addObjectRemovedNotification.parameter.dest"></a>
+
+- *Type:* @aws-cdk/aws-s3.IBucketNotificationDestination
+
+The notification destination (see onEvent).
+
+---
+
+###### \`filters\`<sup>Required</sup> <a name="filters" id="construct-library.GreeterBucket.addObjectRemovedNotification.parameter.filters"></a>
+
+- *Type:* @aws-cdk/aws-s3.NotificationKeyFilter
+
+Filters (see onEvent).
+
+---
+
+##### \`addToResourcePolicy\` <a name="addToResourcePolicy" id="construct-library.GreeterBucket.addToResourcePolicy"></a>
+
+\`\`\`typescript
+public addToResourcePolicy(permission: PolicyStatement): AddToResourcePolicyResult
+\`\`\`
+
+Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects.
+
+Note that the policy statement may or may not be added to the policy.
+For example, when an \`IBucket\` is created from an existing bucket,
+it's not possible to tell whether the bucket already has a policy
+attached, let alone to re-use that policy to add more statements to it.
+So it's safest to do nothing in these cases.
+
+###### \`permission\`<sup>Required</sup> <a name="permission" id="construct-library.GreeterBucket.addToResourcePolicy.parameter.permission"></a>
+
+- *Type:* @aws-cdk/aws-iam.PolicyStatement
+
+the policy statement to be added to the bucket's policy.
+
+---
+
+##### \`arnForObjects\` <a name="arnForObjects" id="construct-library.GreeterBucket.arnForObjects"></a>
+
+\`\`\`typescript
+public arnForObjects(keyPattern: string): string
+\`\`\`
+
+Returns an ARN that represents all objects within the bucket that match the key pattern specified.
+
+To represent all keys, specify \`\`"*"\`\`.
+
+If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:
+
+   arnForObjects(\`home/\${team}/\${user}/*\`)
+
+###### \`keyPattern\`<sup>Required</sup> <a name="keyPattern" id="construct-library.GreeterBucket.arnForObjects.parameter.keyPattern"></a>
+
+- *Type:* string
+
+---
+
+##### \`grantDelete\` <a name="grantDelete" id="construct-library.GreeterBucket.grantDelete"></a>
+
+\`\`\`typescript
+public grantDelete(identity: IGrantable, objectsKeyPattern?: any): Grant
+\`\`\`
+
+Grants s3:DeleteObject* permission to an IAM principal for objects in this bucket.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantDelete.parameter.identity"></a>
+
+- *Type:* @aws-cdk/aws-iam.IGrantable
+
+The principal.
+
+---
+
+###### \`objectsKeyPattern\`<sup>Optional</sup> <a name="objectsKeyPattern" id="construct-library.GreeterBucket.grantDelete.parameter.objectsKeyPattern"></a>
+
+- *Type:* any
+
+Restrict the permission to a certain key pattern (default '*').
+
+---
+
+##### \`grantPublicAccess\` <a name="grantPublicAccess" id="construct-library.GreeterBucket.grantPublicAccess"></a>
+
+\`\`\`typescript
+public grantPublicAccess(allowedActions: string, keyPrefix?: string): Grant
+\`\`\`
+
+Allows unrestricted access to objects from this bucket.
+
+IMPORTANT: This permission allows anyone to perform actions on S3 objects
+in this bucket, which is useful for when you configure your bucket as a
+website and want everyone to be able to read objects in the bucket without
+needing to authenticate.
+
+Without arguments, this method will grant read ("s3:GetObject") access to
+all objects ("*") in the bucket.
+
+The method returns the \`iam.Grant\` object, which can then be modified
+as needed. For example, you can add a condition that will restrict access only
+to an IPv4 range like this:
+
+     const grant = bucket.grantPublicAccess();
+     grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });
+
+Note that if this \`IBucket\` refers to an existing bucket, possibly not
+managed by CloudFormation, this method will have no effect, since it's
+impossible to modify the policy of an existing bucket.
+
+###### \`allowedActions\`<sup>Required</sup> <a name="allowedActions" id="construct-library.GreeterBucket.grantPublicAccess.parameter.allowedActions"></a>
+
+- *Type:* string
+
+the set of S3 actions to allow.
+
+Default is "s3:GetObject".
+
+---
+
+###### \`keyPrefix\`<sup>Optional</sup> <a name="keyPrefix" id="construct-library.GreeterBucket.grantPublicAccess.parameter.keyPrefix"></a>
+
+- *Type:* string
+
+the prefix of S3 object keys (e.g. \`home/*\`). Default is "*".
+
+---
+
+##### \`grantPut\` <a name="grantPut" id="construct-library.GreeterBucket.grantPut"></a>
+
+\`\`\`typescript
+public grantPut(identity: IGrantable, objectsKeyPattern?: any): Grant
+\`\`\`
+
+Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal.
+
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantPut.parameter.identity"></a>
+
+- *Type:* @aws-cdk/aws-iam.IGrantable
+
+The principal.
+
+---
+
+###### \`objectsKeyPattern\`<sup>Optional</sup> <a name="objectsKeyPattern" id="construct-library.GreeterBucket.grantPut.parameter.objectsKeyPattern"></a>
+
+- *Type:* any
+
+Restrict the permission to a certain key pattern (default '*').
+
+---
+
+##### \`grantPutAcl\` <a name="grantPutAcl" id="construct-library.GreeterBucket.grantPutAcl"></a>
+
+\`\`\`typescript
+public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
+\`\`\`
+
+Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
+
+If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
+calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+in this case, if you need to modify object ACLs, call this method explicitly.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantPutAcl.parameter.identity"></a>
+
+- *Type:* @aws-cdk/aws-iam.IGrantable
+
+---
+
+###### \`objectsKeyPattern\`<sup>Optional</sup> <a name="objectsKeyPattern" id="construct-library.GreeterBucket.grantPutAcl.parameter.objectsKeyPattern"></a>
+
+- *Type:* string
+
+---
+
+##### \`grantRead\` <a name="grantRead" id="construct-library.GreeterBucket.grantRead"></a>
+
+\`\`\`typescript
+public grantRead(identity: IGrantable, objectsKeyPattern?: any): Grant
+\`\`\`
+
+Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
+
+If encryption is used, permission to use the key to decrypt the contents
+of the bucket will also be granted to the same principal.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantRead.parameter.identity"></a>
+
+- *Type:* @aws-cdk/aws-iam.IGrantable
+
+The principal.
+
+---
+
+###### \`objectsKeyPattern\`<sup>Optional</sup> <a name="objectsKeyPattern" id="construct-library.GreeterBucket.grantRead.parameter.objectsKeyPattern"></a>
+
+- *Type:* any
+
+Restrict the permission to a certain key pattern (default '*').
+
+---
+
+##### \`grantReadWrite\` <a name="grantReadWrite" id="construct-library.GreeterBucket.grantReadWrite"></a>
+
+\`\`\`typescript
+public grantReadWrite(identity: IGrantable, objectsKeyPattern?: any): Grant
+\`\`\`
+
+Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
+
+If an encryption key is used, permission to use the key for
+encrypt/decrypt will also be granted.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantReadWrite.parameter.identity"></a>
+
+- *Type:* @aws-cdk/aws-iam.IGrantable
+
+---
+
+###### \`objectsKeyPattern\`<sup>Optional</sup> <a name="objectsKeyPattern" id="construct-library.GreeterBucket.grantReadWrite.parameter.objectsKeyPattern"></a>
+
+- *Type:* any
+
+---
+
+##### \`grantWrite\` <a name="grantWrite" id="construct-library.GreeterBucket.grantWrite"></a>
+
+\`\`\`typescript
+public grantWrite(identity: IGrantable, objectsKeyPattern?: any): Grant
+\`\`\`
+
+Grant write permissions to this bucket to an IAM principal.
+
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantWrite.parameter.identity"></a>
+
+- *Type:* @aws-cdk/aws-iam.IGrantable
+
+---
+
+###### \`objectsKeyPattern\`<sup>Optional</sup> <a name="objectsKeyPattern" id="construct-library.GreeterBucket.grantWrite.parameter.objectsKeyPattern"></a>
+
+- *Type:* any
+
+---
+
+##### \`onCloudTrailEvent\` <a name="onCloudTrailEvent" id="construct-library.GreeterBucket.onCloudTrailEvent"></a>
+
+\`\`\`typescript
+public onCloudTrailEvent(id: string, options?: OnCloudTrailBucketEventOptions): Rule
+\`\`\`
+
+Define a CloudWatch event that triggers when something happens to this repository.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.onCloudTrailEvent.parameter.id"></a>
+
+- *Type:* string
+
+The id of the rule.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name="options" id="construct-library.GreeterBucket.onCloudTrailEvent.parameter.options"></a>
+
+- *Type:* @aws-cdk/aws-s3.OnCloudTrailBucketEventOptions
+
+Options for adding the rule.
+
+---
+
+##### \`onCloudTrailPutObject\` <a name="onCloudTrailPutObject" id="construct-library.GreeterBucket.onCloudTrailPutObject"></a>
+
+\`\`\`typescript
+public onCloudTrailPutObject(id: string, options?: OnCloudTrailBucketEventOptions): Rule
+\`\`\`
+
+Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using \`onCloudTrailWriteObject\` may be preferable.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.onCloudTrailPutObject.parameter.id"></a>
+
+- *Type:* string
+
+The id of the rule.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name="options" id="construct-library.GreeterBucket.onCloudTrailPutObject.parameter.options"></a>
+
+- *Type:* @aws-cdk/aws-s3.OnCloudTrailBucketEventOptions
+
+Options for adding the rule.
+
+---
+
+##### \`onCloudTrailWriteObject\` <a name="onCloudTrailWriteObject" id="construct-library.GreeterBucket.onCloudTrailWriteObject"></a>
+
+\`\`\`typescript
+public onCloudTrailWriteObject(id: string, options?: OnCloudTrailBucketEventOptions): Rule
+\`\`\`
+
+Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to.
+
+This includes
+the events PutObject, CopyObject, and CompleteMultipartUpload.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using this method may be preferable to \`onCloudTrailPutObject\`.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.onCloudTrailWriteObject.parameter.id"></a>
+
+- *Type:* string
+
+The id of the rule.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name="options" id="construct-library.GreeterBucket.onCloudTrailWriteObject.parameter.options"></a>
+
+- *Type:* @aws-cdk/aws-s3.OnCloudTrailBucketEventOptions
+
+Options for adding the rule.
+
+---
+
+##### \`s3UrlForObject\` <a name="s3UrlForObject" id="construct-library.GreeterBucket.s3UrlForObject"></a>
+
+\`\`\`typescript
+public s3UrlForObject(key?: string): string
+\`\`\`
+
+The S3 URL of an S3 object. For example:.
+
+\`s3://onlybucket\`
+- \`s3://bucket/key\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.GreeterBucket.s3UrlForObject.parameter.key"></a>
+
+- *Type:* string
+
+The S3 key of the object.
+
+If not specified, the S3 URL of the
+bucket is returned.
+
+---
+
+##### \`transferAccelerationUrlForObject\` <a name="transferAccelerationUrlForObject" id="construct-library.GreeterBucket.transferAccelerationUrlForObject"></a>
+
+\`\`\`typescript
+public transferAccelerationUrlForObject(key?: string, options?: TransferAccelerationUrlOptions): string
+\`\`\`
+
+The https Transfer Acceleration URL of an S3 object.
+
+Specify \`dualStack: true\` at the options
+for dual-stack endpoint (connect to the bucket over IPv6). For example:
+
+- \`https://bucket.s3-accelerate.amazonaws.com\`
+- \`https://bucket.s3-accelerate.amazonaws.com/key\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.GreeterBucket.transferAccelerationUrlForObject.parameter.key"></a>
+
+- *Type:* string
+
+The S3 key of the object.
+
+If not specified, the URL of the
+bucket is returned.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name="options" id="construct-library.GreeterBucket.transferAccelerationUrlForObject.parameter.options"></a>
+
+- *Type:* @aws-cdk/aws-s3.TransferAccelerationUrlOptions
+
+Options for generating URL.
+
+---
+
+##### \`urlForObject\` <a name="urlForObject" id="construct-library.GreeterBucket.urlForObject"></a>
+
+\`\`\`typescript
+public urlForObject(key?: string): string
+\`\`\`
+
+The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:.
+
+\`https://s3.us-west-1.amazonaws.com/onlybucket\`
+- \`https://s3.us-west-1.amazonaws.com/bucket/key\`
+- \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.GreeterBucket.urlForObject.parameter.key"></a>
+
+- *Type:* string
+
+The S3 key of the object.
+
+If not specified, the URL of the
+bucket is returned.
+
+---
+
+##### \`virtualHostedUrlForObject\` <a name="virtualHostedUrlForObject" id="construct-library.GreeterBucket.virtualHostedUrlForObject"></a>
+
+\`\`\`typescript
+public virtualHostedUrlForObject(key?: string, options?: VirtualHostedStyleUrlOptions): string
+\`\`\`
+
+The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:.
+
+\`https://only-bucket.s3.us-west-1.amazonaws.com\`
+- \`https://bucket.s3.us-west-1.amazonaws.com/key\`
+- \`https://bucket.s3.amazonaws.com/key\`
+- \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.GreeterBucket.virtualHostedUrlForObject.parameter.key"></a>
+
+- *Type:* string
+
+The S3 key of the object.
+
+If not specified, the URL of the
+bucket is returned.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name="options" id="construct-library.GreeterBucket.virtualHostedUrlForObject.parameter.options"></a>
+
+- *Type:* @aws-cdk/aws-s3.VirtualHostedStyleUrlOptions
+
+Options for generating URL.
+
+---
+
+##### \`addCorsRule\` <a name="addCorsRule" id="construct-library.GreeterBucket.addCorsRule"></a>
+
+\`\`\`typescript
+public addCorsRule(rule: CorsRule): void
+\`\`\`
+
+Adds a cross-origin access configuration for objects in an Amazon S3 bucket.
+
+###### \`rule\`<sup>Required</sup> <a name="rule" id="construct-library.GreeterBucket.addCorsRule.parameter.rule"></a>
+
+- *Type:* @aws-cdk/aws-s3.CorsRule
+
+The CORS configuration rule to add.
+
+---
+
+##### \`addInventory\` <a name="addInventory" id="construct-library.GreeterBucket.addInventory"></a>
+
+\`\`\`typescript
+public addInventory(inventory: Inventory): void
+\`\`\`
+
+Add an inventory configuration.
+
+###### \`inventory\`<sup>Required</sup> <a name="inventory" id="construct-library.GreeterBucket.addInventory.parameter.inventory"></a>
+
+- *Type:* @aws-cdk/aws-s3.Inventory
+
+configuration to add.
+
+---
+
+##### \`addLifecycleRule\` <a name="addLifecycleRule" id="construct-library.GreeterBucket.addLifecycleRule"></a>
+
+\`\`\`typescript
+public addLifecycleRule(rule: LifecycleRule): void
+\`\`\`
+
+Add a lifecycle rule to the bucket.
+
+###### \`rule\`<sup>Required</sup> <a name="rule" id="construct-library.GreeterBucket.addLifecycleRule.parameter.rule"></a>
+
+- *Type:* @aws-cdk/aws-s3.LifecycleRule
+
+The rule to add.
+
+---
+
+##### \`addMetric\` <a name="addMetric" id="construct-library.GreeterBucket.addMetric"></a>
+
+\`\`\`typescript
+public addMetric(metric: BucketMetrics): void
+\`\`\`
+
+Adds a metrics configuration for the CloudWatch request metrics from the bucket.
+
+###### \`metric\`<sup>Required</sup> <a name="metric" id="construct-library.GreeterBucket.addMetric.parameter.metric"></a>
+
+- *Type:* @aws-cdk/aws-s3.BucketMetrics
+
+The metric configuration to add.
+
+---
+
+##### \`greet\` <a name="greet" id="construct-library.GreeterBucket.greet"></a>
+
+\`\`\`typescript
+public greet(): void
+\`\`\`
+
+##### \`greetWithSalutation\` <a name="greetWithSalutation" id="construct-library.GreeterBucket.greetWithSalutation"></a>
+
+\`\`\`typescript
+public greetWithSalutation(salution: string): void
+\`\`\`
+
+###### \`salution\`<sup>Required</sup> <a name="salution" id="construct-library.GreeterBucket.greetWithSalutation.parameter.salution"></a>
+
+- *Type:* string
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#construct-library.GreeterBucket.isConstruct">isConstruct</a></code> | Return whether the given object is a Construct. |
+| <code><a href="#construct-library.GreeterBucket.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#construct-library.GreeterBucket.fromBucketArn">fromBucketArn</a></code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.fromBucketAttributes">fromBucketAttributes</a></code> | Creates a Bucket construct that represents an external bucket. |
+| <code><a href="#construct-library.GreeterBucket.fromBucketName">fromBucketName</a></code> | *No description.* |
+| <code><a href="#construct-library.GreeterBucket.validateBucketName">validateBucketName</a></code> | Thrown an exception if the given bucket name is not valid. |
+
+---
+
+##### \`isConstruct\` <a name="isConstruct" id="construct-library.GreeterBucket.isConstruct"></a>
+
+\`\`\`typescript
+import { GreeterBucket } from 'construct-library'
+
+GreeterBucket.isConstruct(x: any)
+\`\`\`
+
+Return whether the given object is a Construct.
+
+###### \`x\`<sup>Required</sup> <a name="x" id="construct-library.GreeterBucket.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+---
+
+##### \`isResource\` <a name="isResource" id="construct-library.GreeterBucket.isResource"></a>
+
+\`\`\`typescript
+import { GreeterBucket } from 'construct-library'
+
+GreeterBucket.isResource(construct: IConstruct)
+\`\`\`
+
+Check whether the given construct is a Resource.
+
+###### \`construct\`<sup>Required</sup> <a name="construct" id="construct-library.GreeterBucket.isResource.parameter.construct"></a>
+
+- *Type:* @aws-cdk/core.IConstruct
+
+---
+
+##### \`fromBucketArn\` <a name="fromBucketArn" id="construct-library.GreeterBucket.fromBucketArn"></a>
+
+\`\`\`typescript
+import { GreeterBucket } from 'construct-library'
+
+GreeterBucket.fromBucketArn(scope: Construct, id: string, bucketArn: string)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.GreeterBucket.fromBucketArn.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.fromBucketArn.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### \`bucketArn\`<sup>Required</sup> <a name="bucketArn" id="construct-library.GreeterBucket.fromBucketArn.parameter.bucketArn"></a>
+
+- *Type:* string
+
+---
+
+##### \`fromBucketAttributes\` <a name="fromBucketAttributes" id="construct-library.GreeterBucket.fromBucketAttributes"></a>
+
+\`\`\`typescript
+import { GreeterBucket } from 'construct-library'
+
+GreeterBucket.fromBucketAttributes(scope: Construct, id: string, attrs: BucketAttributes)
+\`\`\`
+
+Creates a Bucket construct that represents an external bucket.
+
+###### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually \`this\`).
+
+---
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### \`attrs\`<sup>Required</sup> <a name="attrs" id="construct-library.GreeterBucket.fromBucketAttributes.parameter.attrs"></a>
+
+- *Type:* @aws-cdk/aws-s3.BucketAttributes
+
+A \`BucketAttributes\` object.
+
+Can be obtained from a call to
+\`bucket.export()\` or manually created.
+
+---
+
+##### \`fromBucketName\` <a name="fromBucketName" id="construct-library.GreeterBucket.fromBucketName"></a>
+
+\`\`\`typescript
+import { GreeterBucket } from 'construct-library'
+
+GreeterBucket.fromBucketName(scope: Construct, id: string, bucketName: string)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.GreeterBucket.fromBucketName.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.GreeterBucket.fromBucketName.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### \`bucketName\`<sup>Required</sup> <a name="bucketName" id="construct-library.GreeterBucket.fromBucketName.parameter.bucketName"></a>
+
+- *Type:* string
+
+---
+
+##### \`validateBucketName\` <a name="validateBucketName" id="construct-library.GreeterBucket.validateBucketName"></a>
+
+\`\`\`typescript
+import { GreeterBucket } from 'construct-library'
+
+GreeterBucket.validateBucketName(physicalName: string)
+\`\`\`
+
+Thrown an exception if the given bucket name is not valid.
+
+###### \`physicalName\`<sup>Required</sup> <a name="physicalName" id="construct-library.GreeterBucket.validateBucketName.parameter.physicalName"></a>
+
+- *Type:* string
+
+name of the bucket.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#construct-library.GreeterBucket.property.node">node</a></code> | <code>@aws-cdk/core.ConstructNode</code> | The construct tree node associated with this construct. |
+| <code><a href="#construct-library.GreeterBucket.property.env">env</a></code> | <code>@aws-cdk/core.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#construct-library.GreeterBucket.property.stack">stack</a></code> | <code>@aws-cdk/core.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketArn">bucketArn</a></code> | <code>string</code> | The ARN of the bucket. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketDomainName">bucketDomainName</a></code> | <code>string</code> | The IPv4 DNS name of the specified bucket. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketDualStackDomainName">bucketDualStackDomainName</a></code> | <code>string</code> | The IPv6 DNS name of the specified bucket. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketName">bucketName</a></code> | <code>string</code> | The name of the bucket. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketRegionalDomainName">bucketRegionalDomainName</a></code> | <code>string</code> | The regional domain name of the specified bucket. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketWebsiteDomainName">bucketWebsiteDomainName</a></code> | <code>string</code> | The Domain name of the static website. |
+| <code><a href="#construct-library.GreeterBucket.property.bucketWebsiteUrl">bucketWebsiteUrl</a></code> | <code>string</code> | The URL of the static website. |
+| <code><a href="#construct-library.GreeterBucket.property.encryptionKey">encryptionKey</a></code> | <code>@aws-cdk/aws-kms.IKey</code> | Optional KMS encryption key associated with this bucket. |
+| <code><a href="#construct-library.GreeterBucket.property.isWebsite">isWebsite</a></code> | <code>boolean</code> | If this bucket has been configured for static website hosting. |
+| <code><a href="#construct-library.GreeterBucket.property.policy">policy</a></code> | <code>@aws-cdk/aws-s3.BucketPolicy</code> | The resource policy associated with this bucket. |
+
+---
+
+##### \`node\`<sup>Required</sup> <a name="node" id="construct-library.GreeterBucket.property.node"></a>
+
+\`\`\`typescript
+public readonly node: ConstructNode;
+\`\`\`
+
+- *Type:* @aws-cdk/core.ConstructNode
+
+The construct tree node associated with this construct.
+
+---
+
+##### \`env\`<sup>Required</sup> <a name="env" id="construct-library.GreeterBucket.property.env"></a>
+
+\`\`\`typescript
+public readonly env: ResourceEnvironment;
+\`\`\`
+
+- *Type:* @aws-cdk/core.ResourceEnvironment
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### \`stack\`<sup>Required</sup> <a name="stack" id="construct-library.GreeterBucket.property.stack"></a>
+
+\`\`\`typescript
+public readonly stack: Stack;
+\`\`\`
+
+- *Type:* @aws-cdk/core.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### \`bucketArn\`<sup>Required</sup> <a name="bucketArn" id="construct-library.GreeterBucket.property.bucketArn"></a>
+
+\`\`\`typescript
+public readonly bucketArn: string;
+\`\`\`
+
+- *Type:* string
+
+The ARN of the bucket.
+
+---
+
+##### \`bucketDomainName\`<sup>Required</sup> <a name="bucketDomainName" id="construct-library.GreeterBucket.property.bucketDomainName"></a>
+
+\`\`\`typescript
+public readonly bucketDomainName: string;
+\`\`\`
+
+- *Type:* string
+
+The IPv4 DNS name of the specified bucket.
+
+---
+
+##### \`bucketDualStackDomainName\`<sup>Required</sup> <a name="bucketDualStackDomainName" id="construct-library.GreeterBucket.property.bucketDualStackDomainName"></a>
+
+\`\`\`typescript
+public readonly bucketDualStackDomainName: string;
+\`\`\`
+
+- *Type:* string
+
+The IPv6 DNS name of the specified bucket.
+
+---
+
+##### \`bucketName\`<sup>Required</sup> <a name="bucketName" id="construct-library.GreeterBucket.property.bucketName"></a>
+
+\`\`\`typescript
+public readonly bucketName: string;
+\`\`\`
+
+- *Type:* string
+
+The name of the bucket.
+
+---
+
+##### \`bucketRegionalDomainName\`<sup>Required</sup> <a name="bucketRegionalDomainName" id="construct-library.GreeterBucket.property.bucketRegionalDomainName"></a>
+
+\`\`\`typescript
+public readonly bucketRegionalDomainName: string;
+\`\`\`
+
+- *Type:* string
+
+The regional domain name of the specified bucket.
+
+---
+
+##### \`bucketWebsiteDomainName\`<sup>Required</sup> <a name="bucketWebsiteDomainName" id="construct-library.GreeterBucket.property.bucketWebsiteDomainName"></a>
+
+\`\`\`typescript
+public readonly bucketWebsiteDomainName: string;
+\`\`\`
+
+- *Type:* string
+
+The Domain name of the static website.
+
+---
+
+##### \`bucketWebsiteUrl\`<sup>Required</sup> <a name="bucketWebsiteUrl" id="construct-library.GreeterBucket.property.bucketWebsiteUrl"></a>
+
+\`\`\`typescript
+public readonly bucketWebsiteUrl: string;
+\`\`\`
+
+- *Type:* string
+
+The URL of the static website.
+
+---
+
+##### \`encryptionKey\`<sup>Optional</sup> <a name="encryptionKey" id="construct-library.GreeterBucket.property.encryptionKey"></a>
+
+\`\`\`typescript
+public readonly encryptionKey: IKey;
+\`\`\`
+
+- *Type:* @aws-cdk/aws-kms.IKey
+
+Optional KMS encryption key associated with this bucket.
+
+---
+
+##### \`isWebsite\`<sup>Optional</sup> <a name="isWebsite" id="construct-library.GreeterBucket.property.isWebsite"></a>
+
+\`\`\`typescript
+public readonly isWebsite: boolean;
+\`\`\`
+
+- *Type:* boolean
+
+If this bucket has been configured for static website hosting.
+
+---
+
+##### \`policy\`<sup>Optional</sup> <a name="policy" id="construct-library.GreeterBucket.property.policy"></a>
+
+\`\`\`typescript
+public readonly policy: BucketPolicy;
+\`\`\`
+
+- *Type:* @aws-cdk/aws-s3.BucketPolicy
+
+The resource policy associated with this bucket.
+
+If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the
+first call to addToResourcePolicy(s).
+
+---
+
+
+
+
+
+"
+`;
+
+exports[`specify languages and split-by-submodule creates submodule files next to output: submod1.python.md 1`] = `
+"# \`submod1\` Submodule <a name="\`submod1\` Submodule" id="construct-library.submod1"></a>
+
+## Constructs <a name="Constructs" id="Constructs"></a>
+
+### GoodbyeBucket <a name="GoodbyeBucket" id="construct-library.submod1.GoodbyeBucket"></a>
+
+#### Initializers <a name="Initializers" id="construct-library.submod1.GoodbyeBucket.Initializer"></a>
+
+\`\`\`python
+from construct_library import submod1
+
+submod1.GoodbyeBucket(
+  scope: Construct,
+  id: str,
+  access_control: BucketAccessControl = None,
+  auto_delete_objects: bool = None,
+  block_public_access: BlockPublicAccess = None,
+  bucket_key_enabled: bool = None,
+  bucket_name: str = None,
+  cors: typing.List[CorsRule] = None,
+  encryption: BucketEncryption = None,
+  encryption_key: IKey = None,
+  enforce_ss_l: bool = None,
+  event_bridge_enabled: bool = None,
+  intelligent_tiering_configurations: typing.List[IntelligentTieringConfiguration] = None,
+  inventories: typing.List[Inventory] = None,
+  lifecycle_rules: typing.List[LifecycleRule] = None,
+  metrics: typing.List[BucketMetrics] = None,
+  notifications_handler_role: IRole = None,
+  object_ownership: ObjectOwnership = None,
+  public_read_access: bool = None,
+  removal_policy: RemovalPolicy = None,
+  server_access_logs_bucket: IBucket = None,
+  server_access_logs_prefix: str = None,
+  transfer_acceleration: bool = None,
+  versioned: bool = None,
+  website_error_document: str = None,
+  website_index_document: str = None,
+  website_redirect: RedirectTarget = None,
+  website_routing_rules: typing.List[RoutingRule] = None
+)
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.id">id</a></code> | <code>str</code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.accessControl">access_control</a></code> | <code>aws_cdk.aws_s3.BucketAccessControl</code> | Specifies a canned ACL that grants predefined permissions to the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.autoDeleteObjects">auto_delete_objects</a></code> | <code>bool</code> | Whether all objects should be automatically deleted when the bucket is removed from the stack or when the stack is deleted. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.blockPublicAccess">block_public_access</a></code> | <code>aws_cdk.aws_s3.BlockPublicAccess</code> | The block public access configuration of this bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.bucketKeyEnabled">bucket_key_enabled</a></code> | <code>bool</code> | Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.bucketName">bucket_name</a></code> | <code>str</code> | Physical name of this bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.cors">cors</a></code> | <code>typing.List[aws_cdk.aws_s3.CorsRule]</code> | The CORS configuration of this bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.encryption">encryption</a></code> | <code>aws_cdk.aws_s3.BucketEncryption</code> | The kind of server-side encryption to apply to this bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.encryptionKey">encryption_key</a></code> | <code>aws_cdk.aws_kms.IKey</code> | External KMS key to use for bucket encryption. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.enforceSSL">enforce_ss_l</a></code> | <code>bool</code> | Enforces SSL for requests. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.eventBridgeEnabled">event_bridge_enabled</a></code> | <code>bool</code> | Whether this bucket should send notifications to Amazon EventBridge or not. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.intelligentTieringConfigurations">intelligent_tiering_configurations</a></code> | <code>typing.List[aws_cdk.aws_s3.IntelligentTieringConfiguration]</code> | Inteligent Tiering Configurations. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.inventories">inventories</a></code> | <code>typing.List[aws_cdk.aws_s3.Inventory]</code> | The inventory configuration of the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.lifecycleRules">lifecycle_rules</a></code> | <code>typing.List[aws_cdk.aws_s3.LifecycleRule]</code> | Rules that define how Amazon S3 manages objects during their lifetime. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.metrics">metrics</a></code> | <code>typing.List[aws_cdk.aws_s3.BucketMetrics]</code> | The metrics configuration of this bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.notificationsHandlerRole">notifications_handler_role</a></code> | <code>aws_cdk.aws_iam.IRole</code> | The role to be used by the notifications handler. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.objectOwnership">object_ownership</a></code> | <code>aws_cdk.aws_s3.ObjectOwnership</code> | The objectOwnership of the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.publicReadAccess">public_read_access</a></code> | <code>bool</code> | Grants public read access to all objects in the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.removalPolicy">removal_policy</a></code> | <code>aws_cdk.core.RemovalPolicy</code> | Policy to apply when the bucket is removed from this stack. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.serverAccessLogsBucket">server_access_logs_bucket</a></code> | <code>aws_cdk.aws_s3.IBucket</code> | Destination bucket for the server access logs. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.serverAccessLogsPrefix">server_access_logs_prefix</a></code> | <code>str</code> | Optional log file prefix to use for the bucket's access logs. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.transferAcceleration">transfer_acceleration</a></code> | <code>bool</code> | Whether this bucket should have transfer acceleration turned on or not. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.versioned">versioned</a></code> | <code>bool</code> | Whether this bucket should have versioning turned on or not. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.websiteErrorDocument">website_error_document</a></code> | <code>str</code> | The name of the error document (e.g. "404.html") for the website. \`websiteIndexDocument\` must also be set if this is set. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.websiteIndexDocument">website_index_document</a></code> | <code>str</code> | The name of the index document (e.g. "index.html") for the website. Enables static website hosting for this bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.websiteRedirect">website_redirect</a></code> | <code>aws_cdk.aws_s3.RedirectTarget</code> | Specifies the redirect behavior of all requests to a website endpoint of a bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.websiteRoutingRules">website_routing_rules</a></code> | <code>typing.List[aws_cdk.aws_s3.RoutingRule]</code> | Rules that define when a redirect is applied and the redirect behavior. |
+
+---
+
+##### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.id"></a>
+
+- *Type:* str
+
+---
+
+##### \`access_control\`<sup>Optional</sup> <a name="access_control" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.accessControl"></a>
+
+- *Type:* aws_cdk.aws_s3.BucketAccessControl
+- *Default:* BucketAccessControl.PRIVATE
+
+Specifies a canned ACL that grants predefined permissions to the bucket.
+
+---
+
+##### \`auto_delete_objects\`<sup>Optional</sup> <a name="auto_delete_objects" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.autoDeleteObjects"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Whether all objects should be automatically deleted when the bucket is removed from the stack or when the stack is deleted.
+
+Requires the \`removalPolicy\` to be set to \`RemovalPolicy.DESTROY\`.
+
+**Warning** if you have deployed a bucket with \`autoDeleteObjects: true\`,
+switching this to \`false\` in a CDK version *before* \`1.126.0\` will lead to
+all objects in the bucket being deleted. Be sure to update your bucket resources
+by deploying with CDK version \`1.126.0\` or later **before** switching this value to \`false\`.
+
+---
+
+##### \`block_public_access\`<sup>Optional</sup> <a name="block_public_access" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.blockPublicAccess"></a>
+
+- *Type:* aws_cdk.aws_s3.BlockPublicAccess
+- *Default:* CloudFormation defaults will apply. New buckets and objects don't allow public access, but users can modify bucket policies or object permissions to allow public access
+
+The block public access configuration of this bucket.
+
+> [https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html)
+
+---
+
+##### \`bucket_key_enabled\`<sup>Optional</sup> <a name="bucket_key_enabled" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.bucketKeyEnabled"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket.
+
+Only relevant, when Encryption is set to {@link BucketEncryption.KMS}
+
+---
+
+##### \`bucket_name\`<sup>Optional</sup> <a name="bucket_name" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.bucketName"></a>
+
+- *Type:* str
+- *Default:* Assigned by CloudFormation (recommended).
+
+Physical name of this bucket.
+
+---
+
+##### \`cors\`<sup>Optional</sup> <a name="cors" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.cors"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.CorsRule]
+- *Default:* No CORS configuration.
+
+The CORS configuration of this bucket.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors.html)
+
+---
+
+##### \`encryption\`<sup>Optional</sup> <a name="encryption" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.encryption"></a>
+
+- *Type:* aws_cdk.aws_s3.BucketEncryption
+- *Default:* \`Kms\` if \`encryptionKey\` is specified, or \`Unencrypted\` otherwise.
+
+The kind of server-side encryption to apply to this bucket.
+
+If you choose KMS, you can specify a KMS key via \`encryptionKey\`. If
+encryption key is not specified, a key will automatically be created.
+
+---
+
+##### \`encryption_key\`<sup>Optional</sup> <a name="encryption_key" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.encryptionKey"></a>
+
+- *Type:* aws_cdk.aws_kms.IKey
+- *Default:* If encryption is set to "Kms" and this property is undefined, a new KMS key will be created and associated with this bucket.
+
+External KMS key to use for bucket encryption.
+
+The 'encryption' property must be either not specified or set to "Kms".
+An error will be emitted if encryption is set to "Unencrypted" or
+"Managed".
+
+---
+
+##### \`enforce_ss_l\`<sup>Optional</sup> <a name="enforce_ss_l" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.enforceSSL"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Enforces SSL for requests.
+
+S3.5 of the AWS Foundational Security Best Practices Regarding S3.
+
+> [https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-ssl-requests-only.html](https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-ssl-requests-only.html)
+
+---
+
+##### \`event_bridge_enabled\`<sup>Optional</sup> <a name="event_bridge_enabled" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.eventBridgeEnabled"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Whether this bucket should send notifications to Amazon EventBridge or not.
+
+---
+
+##### \`intelligent_tiering_configurations\`<sup>Optional</sup> <a name="intelligent_tiering_configurations" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.intelligentTieringConfigurations"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.IntelligentTieringConfiguration]
+- *Default:* No Intelligent Tiiering Configurations.
+
+Inteligent Tiering Configurations.
+
+> [https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html)
+
+---
+
+##### \`inventories\`<sup>Optional</sup> <a name="inventories" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.inventories"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.Inventory]
+- *Default:* No inventory configuration
+
+The inventory configuration of the bucket.
+
+> [https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html)
+
+---
+
+##### \`lifecycle_rules\`<sup>Optional</sup> <a name="lifecycle_rules" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.lifecycleRules"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.LifecycleRule]
+- *Default:* No lifecycle rules.
+
+Rules that define how Amazon S3 manages objects during their lifetime.
+
+---
+
+##### \`metrics\`<sup>Optional</sup> <a name="metrics" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.metrics"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.BucketMetrics]
+- *Default:* No metrics configuration.
+
+The metrics configuration of this bucket.
+
+> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-metricsconfiguration.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-metricsconfiguration.html)
+
+---
+
+##### \`notifications_handler_role\`<sup>Optional</sup> <a name="notifications_handler_role" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.notificationsHandlerRole"></a>
+
+- *Type:* aws_cdk.aws_iam.IRole
+- *Default:* a new role will be created.
+
+The role to be used by the notifications handler.
+
+---
+
+##### \`object_ownership\`<sup>Optional</sup> <a name="object_ownership" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.objectOwnership"></a>
+
+- *Type:* aws_cdk.aws_s3.ObjectOwnership
+- *Default:* No ObjectOwnership configuration, uploading account will own the object.
+
+The objectOwnership of the bucket.
+
+> [https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html)
+
+---
+
+##### \`public_read_access\`<sup>Optional</sup> <a name="public_read_access" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.publicReadAccess"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Grants public read access to all objects in the bucket.
+
+Similar to calling \`bucket.grantPublicAccess()\`
+
+---
+
+##### \`removal_policy\`<sup>Optional</sup> <a name="removal_policy" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.removalPolicy"></a>
+
+- *Type:* aws_cdk.core.RemovalPolicy
+- *Default:* The bucket will be orphaned.
+
+Policy to apply when the bucket is removed from this stack.
+
+---
+
+##### \`server_access_logs_bucket\`<sup>Optional</sup> <a name="server_access_logs_bucket" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.serverAccessLogsBucket"></a>
+
+- *Type:* aws_cdk.aws_s3.IBucket
+- *Default:* If "serverAccessLogsPrefix" undefined - access logs disabled, otherwise - log to current bucket.
+
+Destination bucket for the server access logs.
+
+---
+
+##### \`server_access_logs_prefix\`<sup>Optional</sup> <a name="server_access_logs_prefix" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.serverAccessLogsPrefix"></a>
+
+- *Type:* str
+- *Default:* No log file prefix
+
+Optional log file prefix to use for the bucket's access logs.
+
+If defined without "serverAccessLogsBucket", enables access logs to current bucket with this prefix.
+
+---
+
+##### \`transfer_acceleration\`<sup>Optional</sup> <a name="transfer_acceleration" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.transferAcceleration"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Whether this bucket should have transfer acceleration turned on or not.
+
+---
+
+##### \`versioned\`<sup>Optional</sup> <a name="versioned" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.versioned"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Whether this bucket should have versioning turned on or not.
+
+---
+
+##### \`website_error_document\`<sup>Optional</sup> <a name="website_error_document" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.websiteErrorDocument"></a>
+
+- *Type:* str
+- *Default:* No error document.
+
+The name of the error document (e.g. "404.html") for the website. \`websiteIndexDocument\` must also be set if this is set.
+
+---
+
+##### \`website_index_document\`<sup>Optional</sup> <a name="website_index_document" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.websiteIndexDocument"></a>
+
+- *Type:* str
+- *Default:* No index document.
+
+The name of the index document (e.g. "index.html") for the website. Enables static website hosting for this bucket.
+
+---
+
+##### \`website_redirect\`<sup>Optional</sup> <a name="website_redirect" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.websiteRedirect"></a>
+
+- *Type:* aws_cdk.aws_s3.RedirectTarget
+- *Default:* No redirection.
+
+Specifies the redirect behavior of all requests to a website endpoint of a bucket.
+
+If you specify this property, you can't specify "websiteIndexDocument", "websiteErrorDocument" nor , "websiteRoutingRules".
+
+---
+
+##### \`website_routing_rules\`<sup>Optional</sup> <a name="website_routing_rules" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.websiteRoutingRules"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.RoutingRule]
+- *Default:* No redirection rules.
+
+Rules that define when a redirect is applied and the redirect behavior.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.toString">to_string</a></code> | Returns a string representation of this construct. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.applyRemovalPolicy">apply_removal_policy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addEventNotification">add_event_notification</a></code> | Adds a bucket notification event destination. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification">add_object_created_notification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addObjectRemovedNotification">add_object_removed_notification</a></code> | Subscribes a destination to receive notifications when an object is removed from the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addToResourcePolicy">add_to_resource_policy</a></code> | Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.arnForObjects">arn_for_objects</a></code> | Returns an ARN that represents all objects within the bucket that match the key pattern specified. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantDelete">grant_delete</a></code> | Grants s3:DeleteObject* permission to an IAM principal for objects in this bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantPublicAccess">grant_public_access</a></code> | Allows unrestricted access to objects from this bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantPut">grant_put</a></code> | Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantPutAcl">grant_put_acl</a></code> | Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantRead">grant_read</a></code> | Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User). |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantReadWrite">grant_read_write</a></code> | Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User). |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantWrite">grant_write</a></code> | Grant write permissions to this bucket to an IAM principal. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.onCloudTrailEvent">on_cloud_trail_event</a></code> | Define a CloudWatch event that triggers when something happens to this repository. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject">on_cloud_trail_put_object</a></code> | Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject">on_cloud_trail_write_object</a></code> | Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.s3UrlForObject">s3_url_for_object</a></code> | The S3 URL of an S3 object. For example:. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.transferAccelerationUrlForObject">transfer_acceleration_url_for_object</a></code> | The https Transfer Acceleration URL of an S3 object. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.urlForObject">url_for_object</a></code> | The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.virtualHostedUrlForObject">virtual_hosted_url_for_object</a></code> | The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addCorsRule">add_cors_rule</a></code> | Adds a cross-origin access configuration for objects in an Amazon S3 bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addInventory">add_inventory</a></code> | Add an inventory configuration. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addLifecycleRule">add_lifecycle_rule</a></code> | Add a lifecycle rule to the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addMetric">add_metric</a></code> | Adds a metrics configuration for the CloudWatch request metrics from the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.goodbye">goodbye</a></code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase">goodbye_with_phrase</a></code> | *No description.* |
+
+---
+
+##### \`to_string\` <a name="to_string" id="construct-library.submod1.GoodbyeBucket.toString"></a>
+
+\`\`\`python
+def to_string() -> str
+\`\`\`
+
+Returns a string representation of this construct.
+
+##### \`apply_removal_policy\` <a name="apply_removal_policy" id="construct-library.submod1.GoodbyeBucket.applyRemovalPolicy"></a>
+
+\`\`\`python
+def apply_removal_policy(
+  policy: RemovalPolicy
+) -> None
+\`\`\`
+
+Apply the given removal policy to this resource.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+
+###### \`policy\`<sup>Required</sup> <a name="policy" id="construct-library.submod1.GoodbyeBucket.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws_cdk.core.RemovalPolicy
+
+---
+
+##### \`add_event_notification\` <a name="add_event_notification" id="construct-library.submod1.GoodbyeBucket.addEventNotification"></a>
+
+\`\`\`python
+def add_event_notification(
+  event: EventType,
+  dest: IBucketNotificationDestination,
+  prefix: str = None,
+  suffix: str = None
+) -> None
+\`\`\`
+
+Adds a bucket notification event destination.
+
+> [https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
+
+*Example*
+
+\`\`\`python
+   declare const myLambda: lambda.Function;
+   const bucket = new s3.Bucket(this, 'MyBucket');
+   bucket.addEventNotification(s3.EventType.OBJECT_CREATED, new s3n.LambdaDestination(myLambda), {prefix: 'home/myusername/*'});
+\`\`\`
+
+
+###### \`event\`<sup>Required</sup> <a name="event" id="construct-library.submod1.GoodbyeBucket.addEventNotification.parameter.event"></a>
+
+- *Type:* aws_cdk.aws_s3.EventType
+
+The event to trigger the notification.
+
+---
+
+###### \`dest\`<sup>Required</sup> <a name="dest" id="construct-library.submod1.GoodbyeBucket.addEventNotification.parameter.dest"></a>
+
+- *Type:* aws_cdk.aws_s3.IBucketNotificationDestination
+
+The notification destination (Lambda, SNS Topic or SQS Queue).
+
+---
+
+###### \`prefix\`<sup>Optional</sup> <a name="prefix" id="construct-library.submod1.GoodbyeBucket.addEventNotification.parameter.prefix"></a>
+
+- *Type:* str
+
+S3 keys must have the specified prefix.
+
+---
+
+###### \`suffix\`<sup>Optional</sup> <a name="suffix" id="construct-library.submod1.GoodbyeBucket.addEventNotification.parameter.suffix"></a>
+
+- *Type:* str
+
+S3 keys must have the specified suffix.
+
+---
+
+##### \`add_object_created_notification\` <a name="add_object_created_notification" id="construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification"></a>
+
+\`\`\`python
+def add_object_created_notification(
+  dest: IBucketNotificationDestination,
+  prefix: str = None,
+  suffix: str = None
+) -> None
+\`\`\`
+
+Subscribes a destination to receive notifications when an object is created in the bucket.
+
+This is identical to calling
+\`onEvent(EventType.OBJECT_CREATED)\`.
+
+###### \`dest\`<sup>Required</sup> <a name="dest" id="construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification.parameter.dest"></a>
+
+- *Type:* aws_cdk.aws_s3.IBucketNotificationDestination
+
+The notification destination (see onEvent).
+
+---
+
+###### \`prefix\`<sup>Optional</sup> <a name="prefix" id="construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification.parameter.prefix"></a>
+
+- *Type:* str
+
+S3 keys must have the specified prefix.
+
+---
+
+###### \`suffix\`<sup>Optional</sup> <a name="suffix" id="construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification.parameter.suffix"></a>
+
+- *Type:* str
+
+S3 keys must have the specified suffix.
+
+---
+
+##### \`add_object_removed_notification\` <a name="add_object_removed_notification" id="construct-library.submod1.GoodbyeBucket.addObjectRemovedNotification"></a>
+
+\`\`\`python
+def add_object_removed_notification(
+  dest: IBucketNotificationDestination,
+  prefix: str = None,
+  suffix: str = None
+) -> None
+\`\`\`
+
+Subscribes a destination to receive notifications when an object is removed from the bucket.
+
+This is identical to calling
+\`onEvent(EventType.OBJECT_REMOVED)\`.
+
+###### \`dest\`<sup>Required</sup> <a name="dest" id="construct-library.submod1.GoodbyeBucket.addObjectRemovedNotification.parameter.dest"></a>
+
+- *Type:* aws_cdk.aws_s3.IBucketNotificationDestination
+
+The notification destination (see onEvent).
+
+---
+
+###### \`prefix\`<sup>Optional</sup> <a name="prefix" id="construct-library.submod1.GoodbyeBucket.addObjectRemovedNotification.parameter.prefix"></a>
+
+- *Type:* str
+
+S3 keys must have the specified prefix.
+
+---
+
+###### \`suffix\`<sup>Optional</sup> <a name="suffix" id="construct-library.submod1.GoodbyeBucket.addObjectRemovedNotification.parameter.suffix"></a>
+
+- *Type:* str
+
+S3 keys must have the specified suffix.
+
+---
+
+##### \`add_to_resource_policy\` <a name="add_to_resource_policy" id="construct-library.submod1.GoodbyeBucket.addToResourcePolicy"></a>
+
+\`\`\`python
+def add_to_resource_policy(
+  permission: PolicyStatement
+) -> AddToResourcePolicyResult
+\`\`\`
+
+Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects.
+
+Note that the policy statement may or may not be added to the policy.
+For example, when an \`IBucket\` is created from an existing bucket,
+it's not possible to tell whether the bucket already has a policy
+attached, let alone to re-use that policy to add more statements to it.
+So it's safest to do nothing in these cases.
+
+###### \`permission\`<sup>Required</sup> <a name="permission" id="construct-library.submod1.GoodbyeBucket.addToResourcePolicy.parameter.permission"></a>
+
+- *Type:* aws_cdk.aws_iam.PolicyStatement
+
+the policy statement to be added to the bucket's policy.
+
+---
+
+##### \`arn_for_objects\` <a name="arn_for_objects" id="construct-library.submod1.GoodbyeBucket.arnForObjects"></a>
+
+\`\`\`python
+def arn_for_objects(
+  key_pattern: str
+) -> str
+\`\`\`
+
+Returns an ARN that represents all objects within the bucket that match the key pattern specified.
+
+To represent all keys, specify \`\`"*"\`\`.
+
+If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:
+
+   arnForObjects(\`home/\${team}/\${user}/*\`)
+
+###### \`key_pattern\`<sup>Required</sup> <a name="key_pattern" id="construct-library.submod1.GoodbyeBucket.arnForObjects.parameter.keyPattern"></a>
+
+- *Type:* str
+
+---
+
+##### \`grant_delete\` <a name="grant_delete" id="construct-library.submod1.GoodbyeBucket.grantDelete"></a>
+
+\`\`\`python
+def grant_delete(
+  identity: IGrantable,
+  objects_key_pattern: typing.Any = None
+) -> Grant
+\`\`\`
+
+Grants s3:DeleteObject* permission to an IAM principal for objects in this bucket.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantDelete.parameter.identity"></a>
+
+- *Type:* aws_cdk.aws_iam.IGrantable
+
+The principal.
+
+---
+
+###### \`objects_key_pattern\`<sup>Optional</sup> <a name="objects_key_pattern" id="construct-library.submod1.GoodbyeBucket.grantDelete.parameter.objectsKeyPattern"></a>
+
+- *Type:* typing.Any
+
+Restrict the permission to a certain key pattern (default '*').
+
+---
+
+##### \`grant_public_access\` <a name="grant_public_access" id="construct-library.submod1.GoodbyeBucket.grantPublicAccess"></a>
+
+\`\`\`python
+def grant_public_access(
+  allowed_actions: str,
+  key_prefix: str = None
+) -> Grant
+\`\`\`
+
+Allows unrestricted access to objects from this bucket.
+
+IMPORTANT: This permission allows anyone to perform actions on S3 objects
+in this bucket, which is useful for when you configure your bucket as a
+website and want everyone to be able to read objects in the bucket without
+needing to authenticate.
+
+Without arguments, this method will grant read ("s3:GetObject") access to
+all objects ("*") in the bucket.
+
+The method returns the \`iam.Grant\` object, which can then be modified
+as needed. For example, you can add a condition that will restrict access only
+to an IPv4 range like this:
+
+     const grant = bucket.grantPublicAccess();
+     grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });
+
+Note that if this \`IBucket\` refers to an existing bucket, possibly not
+managed by CloudFormation, this method will have no effect, since it's
+impossible to modify the policy of an existing bucket.
+
+###### \`allowed_actions\`<sup>Required</sup> <a name="allowed_actions" id="construct-library.submod1.GoodbyeBucket.grantPublicAccess.parameter.allowedActions"></a>
+
+- *Type:* str
+
+the set of S3 actions to allow.
+
+Default is "s3:GetObject".
+
+---
+
+###### \`key_prefix\`<sup>Optional</sup> <a name="key_prefix" id="construct-library.submod1.GoodbyeBucket.grantPublicAccess.parameter.keyPrefix"></a>
+
+- *Type:* str
+
+the prefix of S3 object keys (e.g. \`home/*\`). Default is "*".
+
+---
+
+##### \`grant_put\` <a name="grant_put" id="construct-library.submod1.GoodbyeBucket.grantPut"></a>
+
+\`\`\`python
+def grant_put(
+  identity: IGrantable,
+  objects_key_pattern: typing.Any = None
+) -> Grant
+\`\`\`
+
+Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal.
+
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantPut.parameter.identity"></a>
+
+- *Type:* aws_cdk.aws_iam.IGrantable
+
+The principal.
+
+---
+
+###### \`objects_key_pattern\`<sup>Optional</sup> <a name="objects_key_pattern" id="construct-library.submod1.GoodbyeBucket.grantPut.parameter.objectsKeyPattern"></a>
+
+- *Type:* typing.Any
+
+Restrict the permission to a certain key pattern (default '*').
+
+---
+
+##### \`grant_put_acl\` <a name="grant_put_acl" id="construct-library.submod1.GoodbyeBucket.grantPutAcl"></a>
+
+\`\`\`python
+def grant_put_acl(
+  identity: IGrantable,
+  objects_key_pattern: str = None
+) -> Grant
+\`\`\`
+
+Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
+
+If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
+calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+in this case, if you need to modify object ACLs, call this method explicitly.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.identity"></a>
+
+- *Type:* aws_cdk.aws_iam.IGrantable
+
+---
+
+###### \`objects_key_pattern\`<sup>Optional</sup> <a name="objects_key_pattern" id="construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.objectsKeyPattern"></a>
+
+- *Type:* str
+
+---
+
+##### \`grant_read\` <a name="grant_read" id="construct-library.submod1.GoodbyeBucket.grantRead"></a>
+
+\`\`\`python
+def grant_read(
+  identity: IGrantable,
+  objects_key_pattern: typing.Any = None
+) -> Grant
+\`\`\`
+
+Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
+
+If encryption is used, permission to use the key to decrypt the contents
+of the bucket will also be granted to the same principal.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantRead.parameter.identity"></a>
+
+- *Type:* aws_cdk.aws_iam.IGrantable
+
+The principal.
+
+---
+
+###### \`objects_key_pattern\`<sup>Optional</sup> <a name="objects_key_pattern" id="construct-library.submod1.GoodbyeBucket.grantRead.parameter.objectsKeyPattern"></a>
+
+- *Type:* typing.Any
+
+Restrict the permission to a certain key pattern (default '*').
+
+---
+
+##### \`grant_read_write\` <a name="grant_read_write" id="construct-library.submod1.GoodbyeBucket.grantReadWrite"></a>
+
+\`\`\`python
+def grant_read_write(
+  identity: IGrantable,
+  objects_key_pattern: typing.Any = None
+) -> Grant
+\`\`\`
+
+Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
+
+If an encryption key is used, permission to use the key for
+encrypt/decrypt will also be granted.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.identity"></a>
+
+- *Type:* aws_cdk.aws_iam.IGrantable
+
+---
+
+###### \`objects_key_pattern\`<sup>Optional</sup> <a name="objects_key_pattern" id="construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.objectsKeyPattern"></a>
+
+- *Type:* typing.Any
+
+---
+
+##### \`grant_write\` <a name="grant_write" id="construct-library.submod1.GoodbyeBucket.grantWrite"></a>
+
+\`\`\`python
+def grant_write(
+  identity: IGrantable,
+  objects_key_pattern: typing.Any = None
+) -> Grant
+\`\`\`
+
+Grant write permissions to this bucket to an IAM principal.
+
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantWrite.parameter.identity"></a>
+
+- *Type:* aws_cdk.aws_iam.IGrantable
+
+---
+
+###### \`objects_key_pattern\`<sup>Optional</sup> <a name="objects_key_pattern" id="construct-library.submod1.GoodbyeBucket.grantWrite.parameter.objectsKeyPattern"></a>
+
+- *Type:* typing.Any
+
+---
+
+##### \`on_cloud_trail_event\` <a name="on_cloud_trail_event" id="construct-library.submod1.GoodbyeBucket.onCloudTrailEvent"></a>
+
+\`\`\`python
+def on_cloud_trail_event(
+  id: str,
+  description: str = None,
+  event_pattern: EventPattern = None,
+  rule_name: str = None,
+  target: IRuleTarget = None,
+  paths: typing.List[str] = None
+) -> Rule
+\`\`\`
+
+Define a CloudWatch event that triggers when something happens to this repository.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.onCloudTrailEvent.parameter.id"></a>
+
+- *Type:* str
+
+The id of the rule.
+
+---
+
+###### \`description\`<sup>Optional</sup> <a name="description" id="construct-library.submod1.GoodbyeBucket.onCloudTrailEvent.parameter.description"></a>
+
+- *Type:* str
+- *Default:* No description
+
+A description of the rule's purpose.
+
+---
+
+###### \`event_pattern\`<sup>Optional</sup> <a name="event_pattern" id="construct-library.submod1.GoodbyeBucket.onCloudTrailEvent.parameter.eventPattern"></a>
+
+- *Type:* aws_cdk.aws_events.EventPattern
+- *Default:* No additional filtering based on an event pattern.
+
+Additional restrictions for the event to route to the specified target.
+
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
+
+> [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
+
+---
+
+###### \`rule_name\`<sup>Optional</sup> <a name="rule_name" id="construct-library.submod1.GoodbyeBucket.onCloudTrailEvent.parameter.ruleName"></a>
+
+- *Type:* str
+- *Default:* AWS CloudFormation generates a unique physical ID.
+
+A name for the rule.
+
+---
+
+###### \`target\`<sup>Optional</sup> <a name="target" id="construct-library.submod1.GoodbyeBucket.onCloudTrailEvent.parameter.target"></a>
+
+- *Type:* aws_cdk.aws_events.IRuleTarget
+- *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
+
+The target to register for the event.
+
+---
+
+###### \`paths\`<sup>Optional</sup> <a name="paths" id="construct-library.submod1.GoodbyeBucket.onCloudTrailEvent.parameter.paths"></a>
+
+- *Type:* typing.List[str]
+- *Default:* Watch changes to all objects
+
+Only watch changes to these object paths.
+
+---
+
+##### \`on_cloud_trail_put_object\` <a name="on_cloud_trail_put_object" id="construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject"></a>
+
+\`\`\`python
+def on_cloud_trail_put_object(
+  id: str,
+  description: str = None,
+  event_pattern: EventPattern = None,
+  rule_name: str = None,
+  target: IRuleTarget = None,
+  paths: typing.List[str] = None
+) -> Rule
+\`\`\`
+
+Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using \`onCloudTrailWriteObject\` may be preferable.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject.parameter.id"></a>
+
+- *Type:* str
+
+The id of the rule.
+
+---
+
+###### \`description\`<sup>Optional</sup> <a name="description" id="construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject.parameter.description"></a>
+
+- *Type:* str
+- *Default:* No description
+
+A description of the rule's purpose.
+
+---
+
+###### \`event_pattern\`<sup>Optional</sup> <a name="event_pattern" id="construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject.parameter.eventPattern"></a>
+
+- *Type:* aws_cdk.aws_events.EventPattern
+- *Default:* No additional filtering based on an event pattern.
+
+Additional restrictions for the event to route to the specified target.
+
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
+
+> [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
+
+---
+
+###### \`rule_name\`<sup>Optional</sup> <a name="rule_name" id="construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject.parameter.ruleName"></a>
+
+- *Type:* str
+- *Default:* AWS CloudFormation generates a unique physical ID.
+
+A name for the rule.
+
+---
+
+###### \`target\`<sup>Optional</sup> <a name="target" id="construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject.parameter.target"></a>
+
+- *Type:* aws_cdk.aws_events.IRuleTarget
+- *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
+
+The target to register for the event.
+
+---
+
+###### \`paths\`<sup>Optional</sup> <a name="paths" id="construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject.parameter.paths"></a>
+
+- *Type:* typing.List[str]
+- *Default:* Watch changes to all objects
+
+Only watch changes to these object paths.
+
+---
+
+##### \`on_cloud_trail_write_object\` <a name="on_cloud_trail_write_object" id="construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject"></a>
+
+\`\`\`python
+def on_cloud_trail_write_object(
+  id: str,
+  description: str = None,
+  event_pattern: EventPattern = None,
+  rule_name: str = None,
+  target: IRuleTarget = None,
+  paths: typing.List[str] = None
+) -> Rule
+\`\`\`
+
+Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to.
+
+This includes
+the events PutObject, CopyObject, and CompleteMultipartUpload.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using this method may be preferable to \`onCloudTrailPutObject\`.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject.parameter.id"></a>
+
+- *Type:* str
+
+The id of the rule.
+
+---
+
+###### \`description\`<sup>Optional</sup> <a name="description" id="construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject.parameter.description"></a>
+
+- *Type:* str
+- *Default:* No description
+
+A description of the rule's purpose.
+
+---
+
+###### \`event_pattern\`<sup>Optional</sup> <a name="event_pattern" id="construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject.parameter.eventPattern"></a>
+
+- *Type:* aws_cdk.aws_events.EventPattern
+- *Default:* No additional filtering based on an event pattern.
+
+Additional restrictions for the event to route to the specified target.
+
+The method that generates the rule probably imposes some type of event
+filtering. The filtering implied by what you pass here is added
+on top of that filtering.
+
+> [https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html)
+
+---
+
+###### \`rule_name\`<sup>Optional</sup> <a name="rule_name" id="construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject.parameter.ruleName"></a>
+
+- *Type:* str
+- *Default:* AWS CloudFormation generates a unique physical ID.
+
+A name for the rule.
+
+---
+
+###### \`target\`<sup>Optional</sup> <a name="target" id="construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject.parameter.target"></a>
+
+- *Type:* aws_cdk.aws_events.IRuleTarget
+- *Default:* No target is added to the rule. Use \`addTarget()\` to add a target.
+
+The target to register for the event.
+
+---
+
+###### \`paths\`<sup>Optional</sup> <a name="paths" id="construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject.parameter.paths"></a>
+
+- *Type:* typing.List[str]
+- *Default:* Watch changes to all objects
+
+Only watch changes to these object paths.
+
+---
+
+##### \`s3_url_for_object\` <a name="s3_url_for_object" id="construct-library.submod1.GoodbyeBucket.s3UrlForObject"></a>
+
+\`\`\`python
+def s3_url_for_object(
+  key: str = None
+) -> str
+\`\`\`
+
+The S3 URL of an S3 object. For example:.
+
+\`s3://onlybucket\`
+- \`s3://bucket/key\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.submod1.GoodbyeBucket.s3UrlForObject.parameter.key"></a>
+
+- *Type:* str
+
+The S3 key of the object.
+
+If not specified, the S3 URL of the
+bucket is returned.
+
+---
+
+##### \`transfer_acceleration_url_for_object\` <a name="transfer_acceleration_url_for_object" id="construct-library.submod1.GoodbyeBucket.transferAccelerationUrlForObject"></a>
+
+\`\`\`python
+def transfer_acceleration_url_for_object(
+  key: str = None,
+  dual_stack: bool = None
+) -> str
+\`\`\`
+
+The https Transfer Acceleration URL of an S3 object.
+
+Specify \`dualStack: true\` at the options
+for dual-stack endpoint (connect to the bucket over IPv6). For example:
+
+- \`https://bucket.s3-accelerate.amazonaws.com\`
+- \`https://bucket.s3-accelerate.amazonaws.com/key\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.submod1.GoodbyeBucket.transferAccelerationUrlForObject.parameter.key"></a>
+
+- *Type:* str
+
+The S3 key of the object.
+
+If not specified, the URL of the
+bucket is returned.
+
+---
+
+###### \`dual_stack\`<sup>Optional</sup> <a name="dual_stack" id="construct-library.submod1.GoodbyeBucket.transferAccelerationUrlForObject.parameter.dualStack"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Dual-stack support to connect to the bucket over IPv6.
+
+---
+
+##### \`url_for_object\` <a name="url_for_object" id="construct-library.submod1.GoodbyeBucket.urlForObject"></a>
+
+\`\`\`python
+def url_for_object(
+  key: str = None
+) -> str
+\`\`\`
+
+The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:.
+
+\`https://s3.us-west-1.amazonaws.com/onlybucket\`
+- \`https://s3.us-west-1.amazonaws.com/bucket/key\`
+- \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.submod1.GoodbyeBucket.urlForObject.parameter.key"></a>
+
+- *Type:* str
+
+The S3 key of the object.
+
+If not specified, the URL of the
+bucket is returned.
+
+---
+
+##### \`virtual_hosted_url_for_object\` <a name="virtual_hosted_url_for_object" id="construct-library.submod1.GoodbyeBucket.virtualHostedUrlForObject"></a>
+
+\`\`\`python
+def virtual_hosted_url_for_object(
+  key: str = None,
+  regional: bool = None
+) -> str
+\`\`\`
+
+The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:.
+
+\`https://only-bucket.s3.us-west-1.amazonaws.com\`
+- \`https://bucket.s3.us-west-1.amazonaws.com/key\`
+- \`https://bucket.s3.amazonaws.com/key\`
+- \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.submod1.GoodbyeBucket.virtualHostedUrlForObject.parameter.key"></a>
+
+- *Type:* str
+
+The S3 key of the object.
+
+If not specified, the URL of the
+bucket is returned.
+
+---
+
+###### \`regional\`<sup>Optional</sup> <a name="regional" id="construct-library.submod1.GoodbyeBucket.virtualHostedUrlForObject.parameter.regional"></a>
+
+- *Type:* bool
+- *Default:* true
+
+Specifies the URL includes the region.
+
+---
+
+##### \`add_cors_rule\` <a name="add_cors_rule" id="construct-library.submod1.GoodbyeBucket.addCorsRule"></a>
+
+\`\`\`python
+def add_cors_rule(
+  allowed_methods: typing.List[HttpMethods],
+  allowed_origins: typing.List[str],
+  allowed_headers: typing.List[str] = None,
+  exposed_headers: typing.List[str] = None,
+  id: str = None,
+  max_age: typing.Union[int, float] = None
+) -> None
+\`\`\`
+
+Adds a cross-origin access configuration for objects in an Amazon S3 bucket.
+
+###### \`allowed_methods\`<sup>Required</sup> <a name="allowed_methods" id="construct-library.submod1.GoodbyeBucket.addCorsRule.parameter.allowedMethods"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.HttpMethods]
+
+An HTTP method that you allow the origin to execute.
+
+---
+
+###### \`allowed_origins\`<sup>Required</sup> <a name="allowed_origins" id="construct-library.submod1.GoodbyeBucket.addCorsRule.parameter.allowedOrigins"></a>
+
+- *Type:* typing.List[str]
+
+One or more origins you want customers to be able to access the bucket from.
+
+---
+
+###### \`allowed_headers\`<sup>Optional</sup> <a name="allowed_headers" id="construct-library.submod1.GoodbyeBucket.addCorsRule.parameter.allowedHeaders"></a>
+
+- *Type:* typing.List[str]
+- *Default:* No headers allowed.
+
+Headers that are specified in the Access-Control-Request-Headers header.
+
+---
+
+###### \`exposed_headers\`<sup>Optional</sup> <a name="exposed_headers" id="construct-library.submod1.GoodbyeBucket.addCorsRule.parameter.exposedHeaders"></a>
+
+- *Type:* typing.List[str]
+- *Default:* No headers exposed.
+
+One or more headers in the response that you want customers to be able to access from their applications.
+
+---
+
+###### \`id\`<sup>Optional</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.addCorsRule.parameter.id"></a>
+
+- *Type:* str
+- *Default:* No id specified.
+
+A unique identifier for this rule.
+
+---
+
+###### \`max_age\`<sup>Optional</sup> <a name="max_age" id="construct-library.submod1.GoodbyeBucket.addCorsRule.parameter.maxAge"></a>
+
+- *Type:* typing.Union[int, float]
+- *Default:* No caching.
+
+The time in seconds that your browser is to cache the preflight response for the specified resource.
+
+---
+
+##### \`add_inventory\` <a name="add_inventory" id="construct-library.submod1.GoodbyeBucket.addInventory"></a>
+
+\`\`\`python
+def add_inventory(
+  destination: InventoryDestination,
+  enabled: bool = None,
+  format: InventoryFormat = None,
+  frequency: InventoryFrequency = None,
+  include_object_versions: InventoryObjectVersion = None,
+  inventory_id: str = None,
+  objects_prefix: str = None,
+  optional_fields: typing.List[str] = None
+) -> None
+\`\`\`
+
+Add an inventory configuration.
+
+###### \`destination\`<sup>Required</sup> <a name="destination" id="construct-library.submod1.GoodbyeBucket.addInventory.parameter.destination"></a>
+
+- *Type:* aws_cdk.aws_s3.InventoryDestination
+
+The destination of the inventory.
+
+---
+
+###### \`enabled\`<sup>Optional</sup> <a name="enabled" id="construct-library.submod1.GoodbyeBucket.addInventory.parameter.enabled"></a>
+
+- *Type:* bool
+- *Default:* true
+
+Whether the inventory is enabled or disabled.
+
+---
+
+###### \`format\`<sup>Optional</sup> <a name="format" id="construct-library.submod1.GoodbyeBucket.addInventory.parameter.format"></a>
+
+- *Type:* aws_cdk.aws_s3.InventoryFormat
+- *Default:* InventoryFormat.CSV
+
+The format of the inventory.
+
+---
+
+###### \`frequency\`<sup>Optional</sup> <a name="frequency" id="construct-library.submod1.GoodbyeBucket.addInventory.parameter.frequency"></a>
+
+- *Type:* aws_cdk.aws_s3.InventoryFrequency
+- *Default:* InventoryFrequency.WEEKLY
+
+Frequency at which the inventory should be generated.
+
+---
+
+###### \`include_object_versions\`<sup>Optional</sup> <a name="include_object_versions" id="construct-library.submod1.GoodbyeBucket.addInventory.parameter.includeObjectVersions"></a>
+
+- *Type:* aws_cdk.aws_s3.InventoryObjectVersion
+- *Default:* InventoryObjectVersion.ALL
+
+If the inventory should contain all the object versions or only the current one.
+
+---
+
+###### \`inventory_id\`<sup>Optional</sup> <a name="inventory_id" id="construct-library.submod1.GoodbyeBucket.addInventory.parameter.inventoryId"></a>
+
+- *Type:* str
+- *Default:* generated ID.
+
+The inventory configuration ID.
+
+---
+
+###### \`objects_prefix\`<sup>Optional</sup> <a name="objects_prefix" id="construct-library.submod1.GoodbyeBucket.addInventory.parameter.objectsPrefix"></a>
+
+- *Type:* str
+- *Default:* No objects prefix
+
+The inventory will only include objects that meet the prefix filter criteria.
+
+---
+
+###### \`optional_fields\`<sup>Optional</sup> <a name="optional_fields" id="construct-library.submod1.GoodbyeBucket.addInventory.parameter.optionalFields"></a>
+
+- *Type:* typing.List[str]
+- *Default:* No optional fields.
+
+A list of optional fields to be included in the inventory result.
+
+---
+
+##### \`add_lifecycle_rule\` <a name="add_lifecycle_rule" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule"></a>
+
+\`\`\`python
+def add_lifecycle_rule(
+  abort_incomplete_multipart_upload_after: Duration = None,
+  enabled: bool = None,
+  expiration: Duration = None,
+  expiration_date: datetime.datetime = None,
+  expired_object_delete_marker: bool = None,
+  id: str = None,
+  noncurrent_version_expiration: Duration = None,
+  noncurrent_versions_to_retain: typing.Union[int, float] = None,
+  noncurrent_version_transitions: typing.List[NoncurrentVersionTransition] = None,
+  object_size_greater_than: typing.Union[int, float] = None,
+  object_size_less_than: typing.Union[int, float] = None,
+  prefix: str = None,
+  tag_filters: typing.Mapping[typing.Any] = None,
+  transitions: typing.List[Transition] = None
+) -> None
+\`\`\`
+
+Add a lifecycle rule to the bucket.
+
+###### \`abort_incomplete_multipart_upload_after\`<sup>Optional</sup> <a name="abort_incomplete_multipart_upload_after" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.abortIncompleteMultipartUploadAfter"></a>
+
+- *Type:* aws_cdk.core.Duration
+- *Default:* Incomplete uploads are never aborted
+
+Specifies a lifecycle rule that aborts incomplete multipart uploads to an Amazon S3 bucket.
+
+The AbortIncompleteMultipartUpload property type creates a lifecycle
+rule that aborts incomplete multipart uploads to an Amazon S3 bucket.
+When Amazon S3 aborts a multipart upload, it deletes all parts
+associated with the multipart upload.
+
+---
+
+###### \`enabled\`<sup>Optional</sup> <a name="enabled" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.enabled"></a>
+
+- *Type:* bool
+- *Default:* true
+
+Whether this rule is enabled.
+
+---
+
+###### \`expiration\`<sup>Optional</sup> <a name="expiration" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.expiration"></a>
+
+- *Type:* aws_cdk.core.Duration
+- *Default:* No expiration timeout
+
+Indicates the number of days after creation when objects are deleted from Amazon S3 and Amazon Glacier.
+
+If you specify an expiration and transition time, you must use the same
+time unit for both properties (either in days or by date). The
+expiration time must also be later than the transition time.
+
+---
+
+###### \`expiration_date\`<sup>Optional</sup> <a name="expiration_date" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.expirationDate"></a>
+
+- *Type:* datetime.datetime
+- *Default:* No expiration date
+
+Indicates when objects are deleted from Amazon S3 and Amazon Glacier.
+
+The date value must be in ISO 8601 format. The time is always midnight UTC.
+
+If you specify an expiration and transition time, you must use the same
+time unit for both properties (either in days or by date). The
+expiration time must also be later than the transition time.
+
+---
+
+###### \`expired_object_delete_marker\`<sup>Optional</sup> <a name="expired_object_delete_marker" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.expiredObjectDeleteMarker"></a>
+
+- *Type:* bool
+- *Default:* false
+
+Indicates whether Amazon S3 will remove a delete marker with no noncurrent versions.
+
+If set to true, the delete marker will be expired.
+
+---
+
+###### \`id\`<sup>Optional</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.id"></a>
+
+- *Type:* str
+
+A unique identifier for this rule.
+
+The value cannot be more than 255 characters.
+
+---
+
+###### \`noncurrent_version_expiration\`<sup>Optional</sup> <a name="noncurrent_version_expiration" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.noncurrentVersionExpiration"></a>
+
+- *Type:* aws_cdk.core.Duration
+- *Default:* No noncurrent version expiration
+
+Time between when a new version of the object is uploaded to the bucket and when old versions of the object expire.
+
+For buckets with versioning enabled (or suspended), specifies the time,
+in days, between when a new version of the object is uploaded to the
+bucket and when old versions of the object expire. When object versions
+expire, Amazon S3 permanently deletes them. If you specify a transition
+and expiration time, the expiration time must be later than the
+transition time.
+
+---
+
+###### \`noncurrent_versions_to_retain\`<sup>Optional</sup> <a name="noncurrent_versions_to_retain" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.noncurrentVersionsToRetain"></a>
+
+- *Type:* typing.Union[int, float]
+- *Default:* No noncurrent versions to retain
+
+Indicates a maximum number of noncurrent versions to retain.
+
+If there are this many more noncurrent versions,
+Amazon S3 permanently deletes them.
+
+---
+
+###### \`noncurrent_version_transitions\`<sup>Optional</sup> <a name="noncurrent_version_transitions" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.noncurrentVersionTransitions"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.NoncurrentVersionTransition]
+
+One or more transition rules that specify when non-current objects transition to a specified storage class.
+
+Only for for buckets with versioning enabled (or suspended).
+
+If you specify a transition and expiration time, the expiration time
+must be later than the transition time.
+
+---
+
+###### \`object_size_greater_than\`<sup>Optional</sup> <a name="object_size_greater_than" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.objectSizeGreaterThan"></a>
+
+- *Type:* typing.Union[int, float]
+- *Default:* No rule
+
+Specifies the minimum object size in bytes for this rule to apply to.
+
+---
+
+###### \`object_size_less_than\`<sup>Optional</sup> <a name="object_size_less_than" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.objectSizeLessThan"></a>
+
+- *Type:* typing.Union[int, float]
+- *Default:* No rule
+
+Specifies the maximum object size in bytes for this rule to apply to.
+
+---
+
+###### \`prefix\`<sup>Optional</sup> <a name="prefix" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.prefix"></a>
+
+- *Type:* str
+- *Default:* Rule applies to all objects
+
+Object key prefix that identifies one or more objects to which this rule applies.
+
+---
+
+###### \`tag_filters\`<sup>Optional</sup> <a name="tag_filters" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.tagFilters"></a>
+
+- *Type:* typing.Mapping[typing.Any]
+- *Default:* Rule applies to all objects
+
+The TagFilter property type specifies tags to use to identify a subset of objects for an Amazon S3 bucket.
+
+---
+
+###### \`transitions\`<sup>Optional</sup> <a name="transitions" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.transitions"></a>
+
+- *Type:* typing.List[aws_cdk.aws_s3.Transition]
+- *Default:* No transition rules
+
+One or more transition rules that specify when an object transitions to a specified storage class.
+
+If you specify an expiration and transition time, you must use the same
+time unit for both properties (either in days or by date). The
+expiration time must also be later than the transition time.
+
+---
+
+##### \`add_metric\` <a name="add_metric" id="construct-library.submod1.GoodbyeBucket.addMetric"></a>
+
+\`\`\`python
+def add_metric(
+  id: str,
+  prefix: str = None,
+  tag_filters: typing.Mapping[typing.Any] = None
+) -> None
+\`\`\`
+
+Adds a metrics configuration for the CloudWatch request metrics from the bucket.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.addMetric.parameter.id"></a>
+
+- *Type:* str
+
+The ID used to identify the metrics configuration.
+
+---
+
+###### \`prefix\`<sup>Optional</sup> <a name="prefix" id="construct-library.submod1.GoodbyeBucket.addMetric.parameter.prefix"></a>
+
+- *Type:* str
+
+The prefix that an object must have to be included in the metrics results.
+
+---
+
+###### \`tag_filters\`<sup>Optional</sup> <a name="tag_filters" id="construct-library.submod1.GoodbyeBucket.addMetric.parameter.tagFilters"></a>
+
+- *Type:* typing.Mapping[typing.Any]
+
+Specifies a list of tag filters to use as a metrics configuration filter.
+
+The metrics configuration includes only objects that meet the filter's criteria.
+
+---
+
+##### \`goodbye\` <a name="goodbye" id="construct-library.submod1.GoodbyeBucket.goodbye"></a>
+
+\`\`\`python
+def goodbye() -> None
+\`\`\`
+
+##### \`goodbye_with_phrase\` <a name="goodbye_with_phrase" id="construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase"></a>
+
+\`\`\`python
+def goodbye_with_phrase(
+  phrase: str
+) -> None
+\`\`\`
+
+###### \`phrase\`<sup>Required</sup> <a name="phrase" id="construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase.parameter.phrase"></a>
+
+- *Type:* str
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.isConstruct">is_construct</a></code> | Return whether the given object is a Construct. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.isResource">is_resource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.fromBucketArn">from_bucket_arn</a></code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.fromBucketAttributes">from_bucket_attributes</a></code> | Creates a Bucket construct that represents an external bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.fromBucketName">from_bucket_name</a></code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.validateBucketName">validate_bucket_name</a></code> | Thrown an exception if the given bucket name is not valid. |
+
+---
+
+##### \`is_construct\` <a name="is_construct" id="construct-library.submod1.GoodbyeBucket.isConstruct"></a>
+
+\`\`\`python
+from construct_library import submod1
+
+submod1.GoodbyeBucket.is_construct(
+  x: typing.Any
+)
+\`\`\`
+
+Return whether the given object is a Construct.
+
+###### \`x\`<sup>Required</sup> <a name="x" id="construct-library.submod1.GoodbyeBucket.isConstruct.parameter.x"></a>
+
+- *Type:* typing.Any
+
+---
+
+##### \`is_resource\` <a name="is_resource" id="construct-library.submod1.GoodbyeBucket.isResource"></a>
+
+\`\`\`python
+from construct_library import submod1
+
+submod1.GoodbyeBucket.is_resource(
+  construct: IConstruct
+)
+\`\`\`
+
+Check whether the given construct is a Resource.
+
+###### \`construct\`<sup>Required</sup> <a name="construct" id="construct-library.submod1.GoodbyeBucket.isResource.parameter.construct"></a>
+
+- *Type:* aws_cdk.core.IConstruct
+
+---
+
+##### \`from_bucket_arn\` <a name="from_bucket_arn" id="construct-library.submod1.GoodbyeBucket.fromBucketArn"></a>
+
+\`\`\`python
+from construct_library import submod1
+
+submod1.GoodbyeBucket.from_bucket_arn(
+  scope: Construct,
+  id: str,
+  bucket_arn: str
+)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.submod1.GoodbyeBucket.fromBucketArn.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.fromBucketArn.parameter.id"></a>
+
+- *Type:* str
+
+---
+
+###### \`bucket_arn\`<sup>Required</sup> <a name="bucket_arn" id="construct-library.submod1.GoodbyeBucket.fromBucketArn.parameter.bucketArn"></a>
+
+- *Type:* str
+
+---
+
+##### \`from_bucket_attributes\` <a name="from_bucket_attributes" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes"></a>
+
+\`\`\`python
+from construct_library import submod1
+
+submod1.GoodbyeBucket.from_bucket_attributes(
+  scope: Construct,
+  id: str,
+  account: str = None,
+  bucket_arn: str = None,
+  bucket_domain_name: str = None,
+  bucket_dual_stack_domain_name: str = None,
+  bucket_name: str = None,
+  bucket_regional_domain_name: str = None,
+  bucket_website_new_url_format: bool = None,
+  bucket_website_url: str = None,
+  encryption_key: IKey = None,
+  is_website: bool = None,
+  notifications_handler_role: IRole = None,
+  region: str = None
+)
+\`\`\`
+
+Creates a Bucket construct that represents an external bucket.
+
+###### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually \`this\`).
+
+---
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.id"></a>
+
+- *Type:* str
+
+The construct's name.
+
+---
+
+###### \`account\`<sup>Optional</sup> <a name="account" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.account"></a>
+
+- *Type:* str
+- *Default:* it's assumed the bucket belongs to the same account as the scope it's being imported into
+
+The account this existing bucket belongs to.
+
+---
+
+###### \`bucket_arn\`<sup>Optional</sup> <a name="bucket_arn" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.bucketArn"></a>
+
+- *Type:* str
+
+The ARN of the bucket.
+
+At least one of bucketArn or bucketName must be
+defined in order to initialize a bucket ref.
+
+---
+
+###### \`bucket_domain_name\`<sup>Optional</sup> <a name="bucket_domain_name" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.bucketDomainName"></a>
+
+- *Type:* str
+- *Default:* Inferred from bucket name
+
+The domain name of the bucket.
+
+---
+
+###### \`bucket_dual_stack_domain_name\`<sup>Optional</sup> <a name="bucket_dual_stack_domain_name" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.bucketDualStackDomainName"></a>
+
+- *Type:* str
+
+The IPv6 DNS name of the specified bucket.
+
+---
+
+###### \`bucket_name\`<sup>Optional</sup> <a name="bucket_name" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.bucketName"></a>
+
+- *Type:* str
+
+The name of the bucket.
+
+If the underlying value of ARN is a string, the
+name will be parsed from the ARN. Otherwise, the name is optional, but
+some features that require the bucket name such as auto-creating a bucket
+policy, won't work.
+
+---
+
+###### \`bucket_regional_domain_name\`<sup>Optional</sup> <a name="bucket_regional_domain_name" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.bucketRegionalDomainName"></a>
+
+- *Type:* str
+
+The regional domain name of the specified bucket.
+
+---
+
+###### \`bucket_website_new_url_format\`<sup>Optional</sup> <a name="bucket_website_new_url_format" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.bucketWebsiteNewUrlFormat"></a>
+
+- *Type:* bool
+- *Default:* false
+
+The format of the website URL of the bucket.
+
+This should be true for
+regions launched since 2014.
+
+---
+
+###### \`bucket_website_url\`<sup>Optional</sup> <a name="bucket_website_url" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.bucketWebsiteUrl"></a>
+
+- *Type:* str
+- *Default:* Inferred from bucket name
+
+The website URL of the bucket (if static web hosting is enabled).
+
+---
+
+###### \`encryption_key\`<sup>Optional</sup> <a name="encryption_key" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.encryptionKey"></a>
+
+- *Type:* aws_cdk.aws_kms.IKey
+
+---
+
+###### \`is_website\`<sup>Optional</sup> <a name="is_website" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.isWebsite"></a>
+
+- *Type:* bool
+- *Default:* false
+
+If this bucket has been configured for static website hosting.
+
+---
+
+###### \`notifications_handler_role\`<sup>Optional</sup> <a name="notifications_handler_role" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.notificationsHandlerRole"></a>
+
+- *Type:* aws_cdk.aws_iam.IRole
+- *Default:* a new role will be created.
+
+The role to be used by the notifications handler.
+
+---
+
+###### \`region\`<sup>Optional</sup> <a name="region" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.region"></a>
+
+- *Type:* str
+- *Default:* it's assumed the bucket is in the same region as the scope it's being imported into
+
+The region this existing bucket is in.
+
+---
+
+##### \`from_bucket_name\` <a name="from_bucket_name" id="construct-library.submod1.GoodbyeBucket.fromBucketName"></a>
+
+\`\`\`python
+from construct_library import submod1
+
+submod1.GoodbyeBucket.from_bucket_name(
+  scope: Construct,
+  id: str,
+  bucket_name: str
+)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.submod1.GoodbyeBucket.fromBucketName.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.fromBucketName.parameter.id"></a>
+
+- *Type:* str
+
+---
+
+###### \`bucket_name\`<sup>Required</sup> <a name="bucket_name" id="construct-library.submod1.GoodbyeBucket.fromBucketName.parameter.bucketName"></a>
+
+- *Type:* str
+
+---
+
+##### \`validate_bucket_name\` <a name="validate_bucket_name" id="construct-library.submod1.GoodbyeBucket.validateBucketName"></a>
+
+\`\`\`python
+from construct_library import submod1
+
+submod1.GoodbyeBucket.validate_bucket_name(
+  physical_name: str
+)
+\`\`\`
+
+Thrown an exception if the given bucket name is not valid.
+
+###### \`physical_name\`<sup>Required</sup> <a name="physical_name" id="construct-library.submod1.GoodbyeBucket.validateBucketName.parameter.physicalName"></a>
+
+- *Type:* str
+
+name of the bucket.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.node">node</a></code> | <code>aws_cdk.core.ConstructNode</code> | The construct tree node associated with this construct. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.env">env</a></code> | <code>aws_cdk.core.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.stack">stack</a></code> | <code>aws_cdk.core.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketArn">bucket_arn</a></code> | <code>str</code> | The ARN of the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketDomainName">bucket_domain_name</a></code> | <code>str</code> | The IPv4 DNS name of the specified bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketDualStackDomainName">bucket_dual_stack_domain_name</a></code> | <code>str</code> | The IPv6 DNS name of the specified bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketName">bucket_name</a></code> | <code>str</code> | The name of the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketRegionalDomainName">bucket_regional_domain_name</a></code> | <code>str</code> | The regional domain name of the specified bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketWebsiteDomainName">bucket_website_domain_name</a></code> | <code>str</code> | The Domain name of the static website. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketWebsiteUrl">bucket_website_url</a></code> | <code>str</code> | The URL of the static website. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.encryptionKey">encryption_key</a></code> | <code>aws_cdk.aws_kms.IKey</code> | Optional KMS encryption key associated with this bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.isWebsite">is_website</a></code> | <code>bool</code> | If this bucket has been configured for static website hosting. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.policy">policy</a></code> | <code>aws_cdk.aws_s3.BucketPolicy</code> | The resource policy associated with this bucket. |
+
+---
+
+##### \`node\`<sup>Required</sup> <a name="node" id="construct-library.submod1.GoodbyeBucket.property.node"></a>
+
+\`\`\`python
+node: ConstructNode
+\`\`\`
+
+- *Type:* aws_cdk.core.ConstructNode
+
+The construct tree node associated with this construct.
+
+---
+
+##### \`env\`<sup>Required</sup> <a name="env" id="construct-library.submod1.GoodbyeBucket.property.env"></a>
+
+\`\`\`python
+env: ResourceEnvironment
+\`\`\`
+
+- *Type:* aws_cdk.core.ResourceEnvironment
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### \`stack\`<sup>Required</sup> <a name="stack" id="construct-library.submod1.GoodbyeBucket.property.stack"></a>
+
+\`\`\`python
+stack: Stack
+\`\`\`
+
+- *Type:* aws_cdk.core.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### \`bucket_arn\`<sup>Required</sup> <a name="bucket_arn" id="construct-library.submod1.GoodbyeBucket.property.bucketArn"></a>
+
+\`\`\`python
+bucket_arn: str
+\`\`\`
+
+- *Type:* str
+
+The ARN of the bucket.
+
+---
+
+##### \`bucket_domain_name\`<sup>Required</sup> <a name="bucket_domain_name" id="construct-library.submod1.GoodbyeBucket.property.bucketDomainName"></a>
+
+\`\`\`python
+bucket_domain_name: str
+\`\`\`
+
+- *Type:* str
+
+The IPv4 DNS name of the specified bucket.
+
+---
+
+##### \`bucket_dual_stack_domain_name\`<sup>Required</sup> <a name="bucket_dual_stack_domain_name" id="construct-library.submod1.GoodbyeBucket.property.bucketDualStackDomainName"></a>
+
+\`\`\`python
+bucket_dual_stack_domain_name: str
+\`\`\`
+
+- *Type:* str
+
+The IPv6 DNS name of the specified bucket.
+
+---
+
+##### \`bucket_name\`<sup>Required</sup> <a name="bucket_name" id="construct-library.submod1.GoodbyeBucket.property.bucketName"></a>
+
+\`\`\`python
+bucket_name: str
+\`\`\`
+
+- *Type:* str
+
+The name of the bucket.
+
+---
+
+##### \`bucket_regional_domain_name\`<sup>Required</sup> <a name="bucket_regional_domain_name" id="construct-library.submod1.GoodbyeBucket.property.bucketRegionalDomainName"></a>
+
+\`\`\`python
+bucket_regional_domain_name: str
+\`\`\`
+
+- *Type:* str
+
+The regional domain name of the specified bucket.
+
+---
+
+##### \`bucket_website_domain_name\`<sup>Required</sup> <a name="bucket_website_domain_name" id="construct-library.submod1.GoodbyeBucket.property.bucketWebsiteDomainName"></a>
+
+\`\`\`python
+bucket_website_domain_name: str
+\`\`\`
+
+- *Type:* str
+
+The Domain name of the static website.
+
+---
+
+##### \`bucket_website_url\`<sup>Required</sup> <a name="bucket_website_url" id="construct-library.submod1.GoodbyeBucket.property.bucketWebsiteUrl"></a>
+
+\`\`\`python
+bucket_website_url: str
+\`\`\`
+
+- *Type:* str
+
+The URL of the static website.
+
+---
+
+##### \`encryption_key\`<sup>Optional</sup> <a name="encryption_key" id="construct-library.submod1.GoodbyeBucket.property.encryptionKey"></a>
+
+\`\`\`python
+encryption_key: IKey
+\`\`\`
+
+- *Type:* aws_cdk.aws_kms.IKey
+
+Optional KMS encryption key associated with this bucket.
+
+---
+
+##### \`is_website\`<sup>Optional</sup> <a name="is_website" id="construct-library.submod1.GoodbyeBucket.property.isWebsite"></a>
+
+\`\`\`python
+is_website: bool
+\`\`\`
+
+- *Type:* bool
+
+If this bucket has been configured for static website hosting.
+
+---
+
+##### \`policy\`<sup>Optional</sup> <a name="policy" id="construct-library.submod1.GoodbyeBucket.property.policy"></a>
+
+\`\`\`python
+policy: BucketPolicy
+\`\`\`
+
+- *Type:* aws_cdk.aws_s3.BucketPolicy
+
+The resource policy associated with this bucket.
+
+If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the
+first call to addToResourcePolicy(s).
+
+---
+
+
+
+
+
+"
+`;
+
+exports[`specify languages and split-by-submodule creates submodule files next to output: submod1.typescript.md 1`] = `
+"# \`submod1\` Submodule <a name="\`submod1\` Submodule" id="construct-library.submod1"></a>
+
+## Constructs <a name="Constructs" id="Constructs"></a>
+
+### GoodbyeBucket <a name="GoodbyeBucket" id="construct-library.submod1.GoodbyeBucket"></a>
+
+#### Initializers <a name="Initializers" id="construct-library.submod1.GoodbyeBucket.Initializer"></a>
+
+\`\`\`typescript
+import { submod1 } from 'construct-library'
+
+new submod1.GoodbyeBucket(scope: Construct, id: string, props?: BucketProps)
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.Initializer.parameter.props">props</a></code> | <code>@aws-cdk/aws-s3.BucketProps</code> | *No description.* |
+
+---
+
+##### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### \`props\`<sup>Optional</sup> <a name="props" id="construct-library.submod1.GoodbyeBucket.Initializer.parameter.props"></a>
+
+- *Type:* @aws-cdk/aws-s3.BucketProps
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addEventNotification">addEventNotification</a></code> | Adds a bucket notification event destination. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification">addObjectCreatedNotification</a></code> | Subscribes a destination to receive notifications when an object is created in the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addObjectRemovedNotification">addObjectRemovedNotification</a></code> | Subscribes a destination to receive notifications when an object is removed from the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addToResourcePolicy">addToResourcePolicy</a></code> | Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.arnForObjects">arnForObjects</a></code> | Returns an ARN that represents all objects within the bucket that match the key pattern specified. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantDelete">grantDelete</a></code> | Grants s3:DeleteObject* permission to an IAM principal for objects in this bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantPublicAccess">grantPublicAccess</a></code> | Allows unrestricted access to objects from this bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantPut">grantPut</a></code> | Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantPutAcl">grantPutAcl</a></code> | Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantRead">grantRead</a></code> | Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User). |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantReadWrite">grantReadWrite</a></code> | Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User). |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.grantWrite">grantWrite</a></code> | Grant write permissions to this bucket to an IAM principal. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.onCloudTrailEvent">onCloudTrailEvent</a></code> | Define a CloudWatch event that triggers when something happens to this repository. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject">onCloudTrailPutObject</a></code> | Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject">onCloudTrailWriteObject</a></code> | Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.s3UrlForObject">s3UrlForObject</a></code> | The S3 URL of an S3 object. For example:. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.transferAccelerationUrlForObject">transferAccelerationUrlForObject</a></code> | The https Transfer Acceleration URL of an S3 object. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.urlForObject">urlForObject</a></code> | The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.virtualHostedUrlForObject">virtualHostedUrlForObject</a></code> | The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addCorsRule">addCorsRule</a></code> | Adds a cross-origin access configuration for objects in an Amazon S3 bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addInventory">addInventory</a></code> | Add an inventory configuration. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addLifecycleRule">addLifecycleRule</a></code> | Add a lifecycle rule to the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.addMetric">addMetric</a></code> | Adds a metrics configuration for the CloudWatch request metrics from the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.goodbye">goodbye</a></code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase">goodbyeWithPhrase</a></code> | *No description.* |
+
+---
+
+##### \`toString\` <a name="toString" id="construct-library.submod1.GoodbyeBucket.toString"></a>
+
+\`\`\`typescript
+public toString(): string
+\`\`\`
+
+Returns a string representation of this construct.
+
+##### \`applyRemovalPolicy\` <a name="applyRemovalPolicy" id="construct-library.submod1.GoodbyeBucket.applyRemovalPolicy"></a>
+
+\`\`\`typescript
+public applyRemovalPolicy(policy: RemovalPolicy): void
+\`\`\`
+
+Apply the given removal policy to this resource.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (\`RemovalPolicy.DESTROY\`), or left in your AWS
+account for data recovery and cleanup later (\`RemovalPolicy.RETAIN\`).
+
+###### \`policy\`<sup>Required</sup> <a name="policy" id="construct-library.submod1.GoodbyeBucket.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* @aws-cdk/core.RemovalPolicy
+
+---
+
+##### \`addEventNotification\` <a name="addEventNotification" id="construct-library.submod1.GoodbyeBucket.addEventNotification"></a>
+
+\`\`\`typescript
+public addEventNotification(event: EventType, dest: IBucketNotificationDestination, filters: NotificationKeyFilter): void
+\`\`\`
+
+Adds a bucket notification event destination.
+
+> [https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html)
+
+*Example*
+
+\`\`\`typescript
+   declare const myLambda: lambda.Function;
+   const bucket = new s3.Bucket(this, 'MyBucket');
+   bucket.addEventNotification(s3.EventType.OBJECT_CREATED, new s3n.LambdaDestination(myLambda), {prefix: 'home/myusername/*'});
+\`\`\`
+
+
+###### \`event\`<sup>Required</sup> <a name="event" id="construct-library.submod1.GoodbyeBucket.addEventNotification.parameter.event"></a>
+
+- *Type:* @aws-cdk/aws-s3.EventType
+
+The event to trigger the notification.
+
+---
+
+###### \`dest\`<sup>Required</sup> <a name="dest" id="construct-library.submod1.GoodbyeBucket.addEventNotification.parameter.dest"></a>
+
+- *Type:* @aws-cdk/aws-s3.IBucketNotificationDestination
+
+The notification destination (Lambda, SNS Topic or SQS Queue).
+
+---
+
+###### \`filters\`<sup>Required</sup> <a name="filters" id="construct-library.submod1.GoodbyeBucket.addEventNotification.parameter.filters"></a>
+
+- *Type:* @aws-cdk/aws-s3.NotificationKeyFilter
+
+S3 object key filter rules to determine which objects trigger this event.
+
+Each filter must include a \`prefix\` and/or \`suffix\`
+that will be matched against the s3 object key. Refer to the S3 Developer Guide
+for details about allowed filter rules.
+
+---
+
+##### \`addObjectCreatedNotification\` <a name="addObjectCreatedNotification" id="construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification"></a>
+
+\`\`\`typescript
+public addObjectCreatedNotification(dest: IBucketNotificationDestination, filters: NotificationKeyFilter): void
+\`\`\`
+
+Subscribes a destination to receive notifications when an object is created in the bucket.
+
+This is identical to calling
+\`onEvent(EventType.OBJECT_CREATED)\`.
+
+###### \`dest\`<sup>Required</sup> <a name="dest" id="construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification.parameter.dest"></a>
+
+- *Type:* @aws-cdk/aws-s3.IBucketNotificationDestination
+
+The notification destination (see onEvent).
+
+---
+
+###### \`filters\`<sup>Required</sup> <a name="filters" id="construct-library.submod1.GoodbyeBucket.addObjectCreatedNotification.parameter.filters"></a>
+
+- *Type:* @aws-cdk/aws-s3.NotificationKeyFilter
+
+Filters (see onEvent).
+
+---
+
+##### \`addObjectRemovedNotification\` <a name="addObjectRemovedNotification" id="construct-library.submod1.GoodbyeBucket.addObjectRemovedNotification"></a>
+
+\`\`\`typescript
+public addObjectRemovedNotification(dest: IBucketNotificationDestination, filters: NotificationKeyFilter): void
+\`\`\`
+
+Subscribes a destination to receive notifications when an object is removed from the bucket.
+
+This is identical to calling
+\`onEvent(EventType.OBJECT_REMOVED)\`.
+
+###### \`dest\`<sup>Required</sup> <a name="dest" id="construct-library.submod1.GoodbyeBucket.addObjectRemovedNotification.parameter.dest"></a>
+
+- *Type:* @aws-cdk/aws-s3.IBucketNotificationDestination
+
+The notification destination (see onEvent).
+
+---
+
+###### \`filters\`<sup>Required</sup> <a name="filters" id="construct-library.submod1.GoodbyeBucket.addObjectRemovedNotification.parameter.filters"></a>
+
+- *Type:* @aws-cdk/aws-s3.NotificationKeyFilter
+
+Filters (see onEvent).
+
+---
+
+##### \`addToResourcePolicy\` <a name="addToResourcePolicy" id="construct-library.submod1.GoodbyeBucket.addToResourcePolicy"></a>
+
+\`\`\`typescript
+public addToResourcePolicy(permission: PolicyStatement): AddToResourcePolicyResult
+\`\`\`
+
+Adds a statement to the resource policy for a principal (i.e. account/role/service) to perform actions on this bucket and/or its contents. Use \`bucketArn\` and \`arnForObjects(keys)\` to obtain ARNs for this bucket or objects.
+
+Note that the policy statement may or may not be added to the policy.
+For example, when an \`IBucket\` is created from an existing bucket,
+it's not possible to tell whether the bucket already has a policy
+attached, let alone to re-use that policy to add more statements to it.
+So it's safest to do nothing in these cases.
+
+###### \`permission\`<sup>Required</sup> <a name="permission" id="construct-library.submod1.GoodbyeBucket.addToResourcePolicy.parameter.permission"></a>
+
+- *Type:* @aws-cdk/aws-iam.PolicyStatement
+
+the policy statement to be added to the bucket's policy.
+
+---
+
+##### \`arnForObjects\` <a name="arnForObjects" id="construct-library.submod1.GoodbyeBucket.arnForObjects"></a>
+
+\`\`\`typescript
+public arnForObjects(keyPattern: string): string
+\`\`\`
+
+Returns an ARN that represents all objects within the bucket that match the key pattern specified.
+
+To represent all keys, specify \`\`"*"\`\`.
+
+If you need to specify a keyPattern with multiple components, concatenate them into a single string, e.g.:
+
+   arnForObjects(\`home/\${team}/\${user}/*\`)
+
+###### \`keyPattern\`<sup>Required</sup> <a name="keyPattern" id="construct-library.submod1.GoodbyeBucket.arnForObjects.parameter.keyPattern"></a>
+
+- *Type:* string
+
+---
+
+##### \`grantDelete\` <a name="grantDelete" id="construct-library.submod1.GoodbyeBucket.grantDelete"></a>
+
+\`\`\`typescript
+public grantDelete(identity: IGrantable, objectsKeyPattern?: any): Grant
+\`\`\`
+
+Grants s3:DeleteObject* permission to an IAM principal for objects in this bucket.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantDelete.parameter.identity"></a>
+
+- *Type:* @aws-cdk/aws-iam.IGrantable
+
+The principal.
+
+---
+
+###### \`objectsKeyPattern\`<sup>Optional</sup> <a name="objectsKeyPattern" id="construct-library.submod1.GoodbyeBucket.grantDelete.parameter.objectsKeyPattern"></a>
+
+- *Type:* any
+
+Restrict the permission to a certain key pattern (default '*').
+
+---
+
+##### \`grantPublicAccess\` <a name="grantPublicAccess" id="construct-library.submod1.GoodbyeBucket.grantPublicAccess"></a>
+
+\`\`\`typescript
+public grantPublicAccess(allowedActions: string, keyPrefix?: string): Grant
+\`\`\`
+
+Allows unrestricted access to objects from this bucket.
+
+IMPORTANT: This permission allows anyone to perform actions on S3 objects
+in this bucket, which is useful for when you configure your bucket as a
+website and want everyone to be able to read objects in the bucket without
+needing to authenticate.
+
+Without arguments, this method will grant read ("s3:GetObject") access to
+all objects ("*") in the bucket.
+
+The method returns the \`iam.Grant\` object, which can then be modified
+as needed. For example, you can add a condition that will restrict access only
+to an IPv4 range like this:
+
+     const grant = bucket.grantPublicAccess();
+     grant.resourceStatement!.addCondition(‘IpAddress’, { “aws:SourceIp”: “54.240.143.0/24” });
+
+Note that if this \`IBucket\` refers to an existing bucket, possibly not
+managed by CloudFormation, this method will have no effect, since it's
+impossible to modify the policy of an existing bucket.
+
+###### \`allowedActions\`<sup>Required</sup> <a name="allowedActions" id="construct-library.submod1.GoodbyeBucket.grantPublicAccess.parameter.allowedActions"></a>
+
+- *Type:* string
+
+the set of S3 actions to allow.
+
+Default is "s3:GetObject".
+
+---
+
+###### \`keyPrefix\`<sup>Optional</sup> <a name="keyPrefix" id="construct-library.submod1.GoodbyeBucket.grantPublicAccess.parameter.keyPrefix"></a>
+
+- *Type:* string
+
+the prefix of S3 object keys (e.g. \`home/*\`). Default is "*".
+
+---
+
+##### \`grantPut\` <a name="grantPut" id="construct-library.submod1.GoodbyeBucket.grantPut"></a>
+
+\`\`\`typescript
+public grantPut(identity: IGrantable, objectsKeyPattern?: any): Grant
+\`\`\`
+
+Grants s3:PutObject* and s3:Abort* permissions for this bucket to an IAM principal.
+
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantPut.parameter.identity"></a>
+
+- *Type:* @aws-cdk/aws-iam.IGrantable
+
+The principal.
+
+---
+
+###### \`objectsKeyPattern\`<sup>Optional</sup> <a name="objectsKeyPattern" id="construct-library.submod1.GoodbyeBucket.grantPut.parameter.objectsKeyPattern"></a>
+
+- *Type:* any
+
+Restrict the permission to a certain key pattern (default '*').
+
+---
+
+##### \`grantPutAcl\` <a name="grantPutAcl" id="construct-library.submod1.GoodbyeBucket.grantPutAcl"></a>
+
+\`\`\`typescript
+public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
+\`\`\`
+
+Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
+
+If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
+calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+in this case, if you need to modify object ACLs, call this method explicitly.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.identity"></a>
+
+- *Type:* @aws-cdk/aws-iam.IGrantable
+
+---
+
+###### \`objectsKeyPattern\`<sup>Optional</sup> <a name="objectsKeyPattern" id="construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.objectsKeyPattern"></a>
+
+- *Type:* string
+
+---
+
+##### \`grantRead\` <a name="grantRead" id="construct-library.submod1.GoodbyeBucket.grantRead"></a>
+
+\`\`\`typescript
+public grantRead(identity: IGrantable, objectsKeyPattern?: any): Grant
+\`\`\`
+
+Grant read permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
+
+If encryption is used, permission to use the key to decrypt the contents
+of the bucket will also be granted to the same principal.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantRead.parameter.identity"></a>
+
+- *Type:* @aws-cdk/aws-iam.IGrantable
+
+The principal.
+
+---
+
+###### \`objectsKeyPattern\`<sup>Optional</sup> <a name="objectsKeyPattern" id="construct-library.submod1.GoodbyeBucket.grantRead.parameter.objectsKeyPattern"></a>
+
+- *Type:* any
+
+Restrict the permission to a certain key pattern (default '*').
+
+---
+
+##### \`grantReadWrite\` <a name="grantReadWrite" id="construct-library.submod1.GoodbyeBucket.grantReadWrite"></a>
+
+\`\`\`typescript
+public grantReadWrite(identity: IGrantable, objectsKeyPattern?: any): Grant
+\`\`\`
+
+Grants read/write permissions for this bucket and it's contents to an IAM principal (Role/Group/User).
+
+If an encryption key is used, permission to use the key for
+encrypt/decrypt will also be granted.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.identity"></a>
+
+- *Type:* @aws-cdk/aws-iam.IGrantable
+
+---
+
+###### \`objectsKeyPattern\`<sup>Optional</sup> <a name="objectsKeyPattern" id="construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.objectsKeyPattern"></a>
+
+- *Type:* any
+
+---
+
+##### \`grantWrite\` <a name="grantWrite" id="construct-library.submod1.GoodbyeBucket.grantWrite"></a>
+
+\`\`\`typescript
+public grantWrite(identity: IGrantable, objectsKeyPattern?: any): Grant
+\`\`\`
+
+Grant write permissions to this bucket to an IAM principal.
+
+If encryption is used, permission to use the key to encrypt the contents
+of written files will also be granted to the same principal.
+
+Before CDK version 1.85.0, this method granted the \`s3:PutObject*\` permission that included \`s3:PutObjectAcl\`,
+which could be used to grant read/write object access to IAM principals in other accounts.
+If you want to get rid of that behavior, update your CDK version to 1.85.0 or later,
+and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
+in the \`context\` key of your cdk.json file.
+If you've already updated, but still need the principal to have permissions to modify the ACLs,
+use the {@link grantPutAcl} method.
+
+###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantWrite.parameter.identity"></a>
+
+- *Type:* @aws-cdk/aws-iam.IGrantable
+
+---
+
+###### \`objectsKeyPattern\`<sup>Optional</sup> <a name="objectsKeyPattern" id="construct-library.submod1.GoodbyeBucket.grantWrite.parameter.objectsKeyPattern"></a>
+
+- *Type:* any
+
+---
+
+##### \`onCloudTrailEvent\` <a name="onCloudTrailEvent" id="construct-library.submod1.GoodbyeBucket.onCloudTrailEvent"></a>
+
+\`\`\`typescript
+public onCloudTrailEvent(id: string, options?: OnCloudTrailBucketEventOptions): Rule
+\`\`\`
+
+Define a CloudWatch event that triggers when something happens to this repository.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.onCloudTrailEvent.parameter.id"></a>
+
+- *Type:* string
+
+The id of the rule.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name="options" id="construct-library.submod1.GoodbyeBucket.onCloudTrailEvent.parameter.options"></a>
+
+- *Type:* @aws-cdk/aws-s3.OnCloudTrailBucketEventOptions
+
+Options for adding the rule.
+
+---
+
+##### \`onCloudTrailPutObject\` <a name="onCloudTrailPutObject" id="construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject"></a>
+
+\`\`\`typescript
+public onCloudTrailPutObject(id: string, options?: OnCloudTrailBucketEventOptions): Rule
+\`\`\`
+
+Defines an AWS CloudWatch event that triggers when an object is uploaded to the specified paths (keys) in this bucket using the PutObject API call.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using \`onCloudTrailWriteObject\` may be preferable.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject.parameter.id"></a>
+
+- *Type:* string
+
+The id of the rule.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name="options" id="construct-library.submod1.GoodbyeBucket.onCloudTrailPutObject.parameter.options"></a>
+
+- *Type:* @aws-cdk/aws-s3.OnCloudTrailBucketEventOptions
+
+Options for adding the rule.
+
+---
+
+##### \`onCloudTrailWriteObject\` <a name="onCloudTrailWriteObject" id="construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject"></a>
+
+\`\`\`typescript
+public onCloudTrailWriteObject(id: string, options?: OnCloudTrailBucketEventOptions): Rule
+\`\`\`
+
+Defines an AWS CloudWatch event that triggers when an object at the specified paths (keys) in this bucket are written to.
+
+This includes
+the events PutObject, CopyObject, and CompleteMultipartUpload.
+
+Note that some tools like \`aws s3 cp\` will automatically use either
+PutObject or the multipart upload API depending on the file size,
+so using this method may be preferable to \`onCloudTrailPutObject\`.
+
+Requires that there exists at least one CloudTrail Trail in your account
+that captures the event. This method will not create the Trail.
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject.parameter.id"></a>
+
+- *Type:* string
+
+The id of the rule.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name="options" id="construct-library.submod1.GoodbyeBucket.onCloudTrailWriteObject.parameter.options"></a>
+
+- *Type:* @aws-cdk/aws-s3.OnCloudTrailBucketEventOptions
+
+Options for adding the rule.
+
+---
+
+##### \`s3UrlForObject\` <a name="s3UrlForObject" id="construct-library.submod1.GoodbyeBucket.s3UrlForObject"></a>
+
+\`\`\`typescript
+public s3UrlForObject(key?: string): string
+\`\`\`
+
+The S3 URL of an S3 object. For example:.
+
+\`s3://onlybucket\`
+- \`s3://bucket/key\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.submod1.GoodbyeBucket.s3UrlForObject.parameter.key"></a>
+
+- *Type:* string
+
+The S3 key of the object.
+
+If not specified, the S3 URL of the
+bucket is returned.
+
+---
+
+##### \`transferAccelerationUrlForObject\` <a name="transferAccelerationUrlForObject" id="construct-library.submod1.GoodbyeBucket.transferAccelerationUrlForObject"></a>
+
+\`\`\`typescript
+public transferAccelerationUrlForObject(key?: string, options?: TransferAccelerationUrlOptions): string
+\`\`\`
+
+The https Transfer Acceleration URL of an S3 object.
+
+Specify \`dualStack: true\` at the options
+for dual-stack endpoint (connect to the bucket over IPv6). For example:
+
+- \`https://bucket.s3-accelerate.amazonaws.com\`
+- \`https://bucket.s3-accelerate.amazonaws.com/key\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.submod1.GoodbyeBucket.transferAccelerationUrlForObject.parameter.key"></a>
+
+- *Type:* string
+
+The S3 key of the object.
+
+If not specified, the URL of the
+bucket is returned.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name="options" id="construct-library.submod1.GoodbyeBucket.transferAccelerationUrlForObject.parameter.options"></a>
+
+- *Type:* @aws-cdk/aws-s3.TransferAccelerationUrlOptions
+
+Options for generating URL.
+
+---
+
+##### \`urlForObject\` <a name="urlForObject" id="construct-library.submod1.GoodbyeBucket.urlForObject"></a>
+
+\`\`\`typescript
+public urlForObject(key?: string): string
+\`\`\`
+
+The https URL of an S3 object. Specify \`regional: false\` at the options for non-regional URLs. For example:.
+
+\`https://s3.us-west-1.amazonaws.com/onlybucket\`
+- \`https://s3.us-west-1.amazonaws.com/bucket/key\`
+- \`https://s3.cn-north-1.amazonaws.com.cn/china-bucket/mykey\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.submod1.GoodbyeBucket.urlForObject.parameter.key"></a>
+
+- *Type:* string
+
+The S3 key of the object.
+
+If not specified, the URL of the
+bucket is returned.
+
+---
+
+##### \`virtualHostedUrlForObject\` <a name="virtualHostedUrlForObject" id="construct-library.submod1.GoodbyeBucket.virtualHostedUrlForObject"></a>
+
+\`\`\`typescript
+public virtualHostedUrlForObject(key?: string, options?: VirtualHostedStyleUrlOptions): string
+\`\`\`
+
+The virtual hosted-style URL of an S3 object. Specify \`regional: false\` at the options for non-regional URL. For example:.
+
+\`https://only-bucket.s3.us-west-1.amazonaws.com\`
+- \`https://bucket.s3.us-west-1.amazonaws.com/key\`
+- \`https://bucket.s3.amazonaws.com/key\`
+- \`https://china-bucket.s3.cn-north-1.amazonaws.com.cn/mykey\`
+
+###### \`key\`<sup>Optional</sup> <a name="key" id="construct-library.submod1.GoodbyeBucket.virtualHostedUrlForObject.parameter.key"></a>
+
+- *Type:* string
+
+The S3 key of the object.
+
+If not specified, the URL of the
+bucket is returned.
+
+---
+
+###### \`options\`<sup>Optional</sup> <a name="options" id="construct-library.submod1.GoodbyeBucket.virtualHostedUrlForObject.parameter.options"></a>
+
+- *Type:* @aws-cdk/aws-s3.VirtualHostedStyleUrlOptions
+
+Options for generating URL.
+
+---
+
+##### \`addCorsRule\` <a name="addCorsRule" id="construct-library.submod1.GoodbyeBucket.addCorsRule"></a>
+
+\`\`\`typescript
+public addCorsRule(rule: CorsRule): void
+\`\`\`
+
+Adds a cross-origin access configuration for objects in an Amazon S3 bucket.
+
+###### \`rule\`<sup>Required</sup> <a name="rule" id="construct-library.submod1.GoodbyeBucket.addCorsRule.parameter.rule"></a>
+
+- *Type:* @aws-cdk/aws-s3.CorsRule
+
+The CORS configuration rule to add.
+
+---
+
+##### \`addInventory\` <a name="addInventory" id="construct-library.submod1.GoodbyeBucket.addInventory"></a>
+
+\`\`\`typescript
+public addInventory(inventory: Inventory): void
+\`\`\`
+
+Add an inventory configuration.
+
+###### \`inventory\`<sup>Required</sup> <a name="inventory" id="construct-library.submod1.GoodbyeBucket.addInventory.parameter.inventory"></a>
+
+- *Type:* @aws-cdk/aws-s3.Inventory
+
+configuration to add.
+
+---
+
+##### \`addLifecycleRule\` <a name="addLifecycleRule" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule"></a>
+
+\`\`\`typescript
+public addLifecycleRule(rule: LifecycleRule): void
+\`\`\`
+
+Add a lifecycle rule to the bucket.
+
+###### \`rule\`<sup>Required</sup> <a name="rule" id="construct-library.submod1.GoodbyeBucket.addLifecycleRule.parameter.rule"></a>
+
+- *Type:* @aws-cdk/aws-s3.LifecycleRule
+
+The rule to add.
+
+---
+
+##### \`addMetric\` <a name="addMetric" id="construct-library.submod1.GoodbyeBucket.addMetric"></a>
+
+\`\`\`typescript
+public addMetric(metric: BucketMetrics): void
+\`\`\`
+
+Adds a metrics configuration for the CloudWatch request metrics from the bucket.
+
+###### \`metric\`<sup>Required</sup> <a name="metric" id="construct-library.submod1.GoodbyeBucket.addMetric.parameter.metric"></a>
+
+- *Type:* @aws-cdk/aws-s3.BucketMetrics
+
+The metric configuration to add.
+
+---
+
+##### \`goodbye\` <a name="goodbye" id="construct-library.submod1.GoodbyeBucket.goodbye"></a>
+
+\`\`\`typescript
+public goodbye(): void
+\`\`\`
+
+##### \`goodbyeWithPhrase\` <a name="goodbyeWithPhrase" id="construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase"></a>
+
+\`\`\`typescript
+public goodbyeWithPhrase(phrase: string): void
+\`\`\`
+
+###### \`phrase\`<sup>Required</sup> <a name="phrase" id="construct-library.submod1.GoodbyeBucket.goodbyeWithPhrase.parameter.phrase"></a>
+
+- *Type:* string
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.isConstruct">isConstruct</a></code> | Return whether the given object is a Construct. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.fromBucketArn">fromBucketArn</a></code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.fromBucketAttributes">fromBucketAttributes</a></code> | Creates a Bucket construct that represents an external bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.fromBucketName">fromBucketName</a></code> | *No description.* |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.validateBucketName">validateBucketName</a></code> | Thrown an exception if the given bucket name is not valid. |
+
+---
+
+##### \`isConstruct\` <a name="isConstruct" id="construct-library.submod1.GoodbyeBucket.isConstruct"></a>
+
+\`\`\`typescript
+import { submod1 } from 'construct-library'
+
+submod1.GoodbyeBucket.isConstruct(x: any)
+\`\`\`
+
+Return whether the given object is a Construct.
+
+###### \`x\`<sup>Required</sup> <a name="x" id="construct-library.submod1.GoodbyeBucket.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+---
+
+##### \`isResource\` <a name="isResource" id="construct-library.submod1.GoodbyeBucket.isResource"></a>
+
+\`\`\`typescript
+import { submod1 } from 'construct-library'
+
+submod1.GoodbyeBucket.isResource(construct: IConstruct)
+\`\`\`
+
+Check whether the given construct is a Resource.
+
+###### \`construct\`<sup>Required</sup> <a name="construct" id="construct-library.submod1.GoodbyeBucket.isResource.parameter.construct"></a>
+
+- *Type:* @aws-cdk/core.IConstruct
+
+---
+
+##### \`fromBucketArn\` <a name="fromBucketArn" id="construct-library.submod1.GoodbyeBucket.fromBucketArn"></a>
+
+\`\`\`typescript
+import { submod1 } from 'construct-library'
+
+submod1.GoodbyeBucket.fromBucketArn(scope: Construct, id: string, bucketArn: string)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.submod1.GoodbyeBucket.fromBucketArn.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.fromBucketArn.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### \`bucketArn\`<sup>Required</sup> <a name="bucketArn" id="construct-library.submod1.GoodbyeBucket.fromBucketArn.parameter.bucketArn"></a>
+
+- *Type:* string
+
+---
+
+##### \`fromBucketAttributes\` <a name="fromBucketAttributes" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes"></a>
+
+\`\`\`typescript
+import { submod1 } from 'construct-library'
+
+submod1.GoodbyeBucket.fromBucketAttributes(scope: Construct, id: string, attrs: BucketAttributes)
+\`\`\`
+
+Creates a Bucket construct that represents an external bucket.
+
+###### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually \`this\`).
+
+---
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### \`attrs\`<sup>Required</sup> <a name="attrs" id="construct-library.submod1.GoodbyeBucket.fromBucketAttributes.parameter.attrs"></a>
+
+- *Type:* @aws-cdk/aws-s3.BucketAttributes
+
+A \`BucketAttributes\` object.
+
+Can be obtained from a call to
+\`bucket.export()\` or manually created.
+
+---
+
+##### \`fromBucketName\` <a name="fromBucketName" id="construct-library.submod1.GoodbyeBucket.fromBucketName"></a>
+
+\`\`\`typescript
+import { submod1 } from 'construct-library'
+
+submod1.GoodbyeBucket.fromBucketName(scope: Construct, id: string, bucketName: string)
+\`\`\`
+
+###### \`scope\`<sup>Required</sup> <a name="scope" id="construct-library.submod1.GoodbyeBucket.fromBucketName.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### \`id\`<sup>Required</sup> <a name="id" id="construct-library.submod1.GoodbyeBucket.fromBucketName.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### \`bucketName\`<sup>Required</sup> <a name="bucketName" id="construct-library.submod1.GoodbyeBucket.fromBucketName.parameter.bucketName"></a>
+
+- *Type:* string
+
+---
+
+##### \`validateBucketName\` <a name="validateBucketName" id="construct-library.submod1.GoodbyeBucket.validateBucketName"></a>
+
+\`\`\`typescript
+import { submod1 } from 'construct-library'
+
+submod1.GoodbyeBucket.validateBucketName(physicalName: string)
+\`\`\`
+
+Thrown an exception if the given bucket name is not valid.
+
+###### \`physicalName\`<sup>Required</sup> <a name="physicalName" id="construct-library.submod1.GoodbyeBucket.validateBucketName.parameter.physicalName"></a>
+
+- *Type:* string
+
+name of the bucket.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.node">node</a></code> | <code>@aws-cdk/core.ConstructNode</code> | The construct tree node associated with this construct. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.env">env</a></code> | <code>@aws-cdk/core.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.stack">stack</a></code> | <code>@aws-cdk/core.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketArn">bucketArn</a></code> | <code>string</code> | The ARN of the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketDomainName">bucketDomainName</a></code> | <code>string</code> | The IPv4 DNS name of the specified bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketDualStackDomainName">bucketDualStackDomainName</a></code> | <code>string</code> | The IPv6 DNS name of the specified bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketName">bucketName</a></code> | <code>string</code> | The name of the bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketRegionalDomainName">bucketRegionalDomainName</a></code> | <code>string</code> | The regional domain name of the specified bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketWebsiteDomainName">bucketWebsiteDomainName</a></code> | <code>string</code> | The Domain name of the static website. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.bucketWebsiteUrl">bucketWebsiteUrl</a></code> | <code>string</code> | The URL of the static website. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.encryptionKey">encryptionKey</a></code> | <code>@aws-cdk/aws-kms.IKey</code> | Optional KMS encryption key associated with this bucket. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.isWebsite">isWebsite</a></code> | <code>boolean</code> | If this bucket has been configured for static website hosting. |
+| <code><a href="#construct-library.submod1.GoodbyeBucket.property.policy">policy</a></code> | <code>@aws-cdk/aws-s3.BucketPolicy</code> | The resource policy associated with this bucket. |
+
+---
+
+##### \`node\`<sup>Required</sup> <a name="node" id="construct-library.submod1.GoodbyeBucket.property.node"></a>
+
+\`\`\`typescript
+public readonly node: ConstructNode;
+\`\`\`
+
+- *Type:* @aws-cdk/core.ConstructNode
+
+The construct tree node associated with this construct.
+
+---
+
+##### \`env\`<sup>Required</sup> <a name="env" id="construct-library.submod1.GoodbyeBucket.property.env"></a>
+
+\`\`\`typescript
+public readonly env: ResourceEnvironment;
+\`\`\`
+
+- *Type:* @aws-cdk/core.ResourceEnvironment
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### \`stack\`<sup>Required</sup> <a name="stack" id="construct-library.submod1.GoodbyeBucket.property.stack"></a>
+
+\`\`\`typescript
+public readonly stack: Stack;
+\`\`\`
+
+- *Type:* @aws-cdk/core.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### \`bucketArn\`<sup>Required</sup> <a name="bucketArn" id="construct-library.submod1.GoodbyeBucket.property.bucketArn"></a>
+
+\`\`\`typescript
+public readonly bucketArn: string;
+\`\`\`
+
+- *Type:* string
+
+The ARN of the bucket.
+
+---
+
+##### \`bucketDomainName\`<sup>Required</sup> <a name="bucketDomainName" id="construct-library.submod1.GoodbyeBucket.property.bucketDomainName"></a>
+
+\`\`\`typescript
+public readonly bucketDomainName: string;
+\`\`\`
+
+- *Type:* string
+
+The IPv4 DNS name of the specified bucket.
+
+---
+
+##### \`bucketDualStackDomainName\`<sup>Required</sup> <a name="bucketDualStackDomainName" id="construct-library.submod1.GoodbyeBucket.property.bucketDualStackDomainName"></a>
+
+\`\`\`typescript
+public readonly bucketDualStackDomainName: string;
+\`\`\`
+
+- *Type:* string
+
+The IPv6 DNS name of the specified bucket.
+
+---
+
+##### \`bucketName\`<sup>Required</sup> <a name="bucketName" id="construct-library.submod1.GoodbyeBucket.property.bucketName"></a>
+
+\`\`\`typescript
+public readonly bucketName: string;
+\`\`\`
+
+- *Type:* string
+
+The name of the bucket.
+
+---
+
+##### \`bucketRegionalDomainName\`<sup>Required</sup> <a name="bucketRegionalDomainName" id="construct-library.submod1.GoodbyeBucket.property.bucketRegionalDomainName"></a>
+
+\`\`\`typescript
+public readonly bucketRegionalDomainName: string;
+\`\`\`
+
+- *Type:* string
+
+The regional domain name of the specified bucket.
+
+---
+
+##### \`bucketWebsiteDomainName\`<sup>Required</sup> <a name="bucketWebsiteDomainName" id="construct-library.submod1.GoodbyeBucket.property.bucketWebsiteDomainName"></a>
+
+\`\`\`typescript
+public readonly bucketWebsiteDomainName: string;
+\`\`\`
+
+- *Type:* string
+
+The Domain name of the static website.
+
+---
+
+##### \`bucketWebsiteUrl\`<sup>Required</sup> <a name="bucketWebsiteUrl" id="construct-library.submod1.GoodbyeBucket.property.bucketWebsiteUrl"></a>
+
+\`\`\`typescript
+public readonly bucketWebsiteUrl: string;
+\`\`\`
+
+- *Type:* string
+
+The URL of the static website.
+
+---
+
+##### \`encryptionKey\`<sup>Optional</sup> <a name="encryptionKey" id="construct-library.submod1.GoodbyeBucket.property.encryptionKey"></a>
+
+\`\`\`typescript
+public readonly encryptionKey: IKey;
+\`\`\`
+
+- *Type:* @aws-cdk/aws-kms.IKey
+
+Optional KMS encryption key associated with this bucket.
+
+---
+
+##### \`isWebsite\`<sup>Optional</sup> <a name="isWebsite" id="construct-library.submod1.GoodbyeBucket.property.isWebsite"></a>
+
+\`\`\`typescript
+public readonly isWebsite: boolean;
+\`\`\`
+
+- *Type:* boolean
+
+If this bucket has been configured for static website hosting.
+
+---
+
+##### \`policy\`<sup>Optional</sup> <a name="policy" id="construct-library.submod1.GoodbyeBucket.property.policy"></a>
+
+\`\`\`typescript
+public readonly policy: BucketPolicy;
+\`\`\`
+
+- *Type:* @aws-cdk/aws-s3.BucketPolicy
+
+The resource policy associated with this bucket.
+
+If \`autoCreatePolicy\` is true, a \`BucketPolicy\` will be created upon the
+first call to addToResourcePolicy(s).
+
+---
+
+
+
+
+
+"
+`;
+
 exports[`specify root submodule 1`] = `
 "# API Reference <a name="API Reference" id="api-reference"></a>
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -89,6 +89,7 @@ test('specify languages and split-by-submodule creates submodule files next to o
   const rootTs = readFileSync(join(fixture, 'docs/API.typescript.md'), 'utf-8');
   const submoduleTs = readFileSync(join(fixture, 'docs/submod1.typescript.md'), 'utf-8');
   expect(rootTs).toMatchSnapshot('API.typescript.md');
+  expect(rootTs).toContain('./submod1.typescript.md');
   expect(rootTs).toContain('greetWithSalutation');
   expect(submoduleTs).toMatchSnapshot('submod1.typescript.md');
   expect(submoduleTs).toContain('goodbyeWithPhrase');
@@ -97,6 +98,7 @@ test('specify languages and split-by-submodule creates submodule files next to o
   const rootPy = readFileSync(join(fixture, 'docs/API.python.md'), 'utf-8');
   const submodulePy = readFileSync(join(fixture, 'docs/submod1.python.md'), 'utf-8');
   expect(rootPy).toMatchSnapshot('API.python.md');
+  expect(rootPy).toContain('./submod1.python.md');
   expect(rootPy).toContain('greet_with_salutation');
   expect(submodulePy).toMatchSnapshot('submod1.python.md');
   expect(submodulePy).toContain('goodbye_with_phrase');

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -76,3 +76,29 @@ test('split-by-submodule creates submodule files next to output', () => {
   expect(submoduleMd).toMatchSnapshot();
 
 });
+
+test('specify languages and split-by-submodule creates submodule files next to output', () => {
+
+  const libraryName = 'construct-library';
+  const fixture = join(`${__dirname}/__fixtures__/libraries/${libraryName}`);
+
+  // generate the documentation
+  execSync(`${process.execPath} ${cli} --output=docs/API.md --split-by-submodule -l typescript -l python`, { cwd: fixture });
+
+  // TypeScript
+  const rootTs = readFileSync(join(fixture, 'docs/API.typescript.md'), 'utf-8');
+  const submoduleTs = readFileSync(join(fixture, 'docs/submod1.typescript.md'), 'utf-8');
+  expect(rootTs).toMatchSnapshot('API.typescript.md');
+  expect(rootTs).toContain('greetWithSalutation');
+  expect(submoduleTs).toMatchSnapshot('submod1.typescript.md');
+  expect(submoduleTs).toContain('goodbyeWithPhrase');
+
+  // Python
+  const rootPy = readFileSync(join(fixture, 'docs/API.python.md'), 'utf-8');
+  const submodulePy = readFileSync(join(fixture, 'docs/submod1.python.md'), 'utf-8');
+  expect(rootPy).toMatchSnapshot('API.python.md');
+  expect(rootPy).toContain('greet_with_salutation');
+  expect(submodulePy).toMatchSnapshot('submod1.python.md');
+  expect(submodulePy).toContain('goodbye_with_phrase');
+
+});


### PR DESCRIPTION
Fixes #1250

Given the command

```console
jsii-docgen -o docs/api/API.md --split-by-submodule -l typescript -l python -l java -l go
```

the output now looks like this:

<img width="189" alt="image" src="https://github.com/cdklabs/jsii-docgen/assets/379814/f564a98f-7a5b-4774-8a3d-922b95c735a5">


