### PR TITLE
fix: incorrect error thrown for transliteration failures

### DIFF
--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -8,7 +8,7 @@ import { TargetLanguage, transliterateAssembly, UnknownSnippetMode } from 'jsii-
 import { Npm } from './_npm';
 import { ApiReference } from './api-reference';
 import { Readme } from './readme';
-import { CorruptedAssemblyError, LanguageNotSupportedError } from '../..';
+import { CorruptedAssemblyError, LanguageNotSupportedError, TransliterationError } from '../..';
 import { Json } from '../render/json';
 import { MarkdownDocument } from '../render/markdown-doc';
 import { MarkdownFormattingOptions, MarkdownRenderer } from '../render/markdown-render';
@@ -427,7 +427,7 @@ export class Documentation {
             await transliterateAssembly([packageDir], [language],
               { loose: options.loose, unknownSnippets: UnknownSnippetMode.FAIL, outdir: workdir });
           } catch (e: any) {
-            throw new LanguageNotSupportedError(`Laguage ${language} is not supported for package ${this.assemblyFqn} (cause: ${e.message})`);
+            throw new TransliterationError(`Could not transliterate snippets in '${this.assemblyFqn}' to ${language}: ${e.message}`);
           }
           dotJsii = path.join(workdir, `${SPEC_FILE_NAME}.${language}`);
         }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -64,6 +64,11 @@ export class CorruptedAssemblyError extends DocGenError {}
 export class LanguageNotSupportedError extends DocGenError {};
 
 /**
+ * Raised when snippet transliteration into a target language failed.
+ */
+export class TransliterationError extends DocGenError {};
+
+/**
  * The error raised when `npm` commands fail with an "opaque" exit code,
  * attempting to obtain more information from the commands output.
  */

--- a/test/docgen/view/documentation.test.ts
+++ b/test/docgen/view/documentation.test.ts
@@ -2,7 +2,7 @@ import * as child from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import { Language, Documentation, UnInstallablePackageError, CorruptedAssemblyError, LanguageNotSupportedError } from '../../../src';
+import { Language, Documentation, UnInstallablePackageError, CorruptedAssemblyError, LanguageNotSupportedError, TransliterationError } from '../../../src';
 import { extractPackageName } from '../../../src/docgen/view/documentation';
 import { Assemblies } from '../assemblies';
 
@@ -269,10 +269,10 @@ test('throws unsupported language with invalid config', async () => {
   await expect(docs.toJson({ language: Language.GO })).rejects.toThrowError(LanguageNotSupportedError);
 });
 
-test('throws unsupported language when tablet was generated before rosetta supported go', async () => {
+test('throws transliteration error when tablet was generated before rosetta supported go', async () => {
   const docs = await Documentation.forPackage('aws-cdk-lib@2.16.0', { verbose: false });
-  await expect(docs.toMarkdown({ language: Language.GO })).rejects.toThrowError(LanguageNotSupportedError);
-  await expect(docs.toJson({ language: Language.GO })).rejects.toThrowError(LanguageNotSupportedError);
+  await expect(docs.toMarkdown({ language: Language.GO })).rejects.toThrowError(TransliterationError);
+  await expect(docs.toJson({ language: Language.GO })).rejects.toThrowError(TransliterationError);
 });
 
 test('does not throw if unrelated assembly is corrupted', async () => {


### PR DESCRIPTION
This leads to downstream tools reacting incorrectly. While both errors "Unsupported language" &  "Transliteration error"   indicate a fix is required by the assembly producer, the reaction might be handled differently by the upstream tool. For example a "Transliteration error" should indicate to stop processing all other submodules. 