### PR TITLE
chore: `cli.test.ts` may fail on Mac/Windows

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -10,7 +10,7 @@ test('construct-library', () => {
   const fixture = join(`${__dirname}/__fixtures__/libraries/${libraryName}`);
 
   // generate the documentation
-  execSync(`${process.execPath} ${cli}`, { cwd: fixture });
+  execSync(`"${process.execPath}" ${cli}`, { cwd: fixture });
 
   const md = readFileSync(join(fixture, 'API.md'), 'utf-8');
   expect(md).toMatchSnapshot();
@@ -23,7 +23,7 @@ test('specify language', () => {
   const fixture = join(`${__dirname}/__fixtures__/libraries/${libraryName}`);
 
   // generate the documentation
-  execSync(`${process.execPath} ${cli} --language python`, { cwd: fixture });
+  execSync(`"${process.execPath}" ${cli} --language python`, { cwd: fixture });
 
   const md = readFileSync(join(fixture, 'API.md'), 'utf-8');
   expect(md).toMatchSnapshot();
@@ -36,7 +36,7 @@ test('specify submodule', () => {
   const fixture = join(`${__dirname}/__fixtures__/libraries/${libraryName}`);
 
   // generate the documentation
-  execSync(`${process.execPath} ${cli} --submodule submod1`, { cwd: fixture });
+  execSync(`"${process.execPath}" ${cli} --submodule submod1`, { cwd: fixture });
 
   const md = readFileSync(join(fixture, 'API.md'), 'utf-8');
   expect(md).toMatchSnapshot();
@@ -49,7 +49,7 @@ test('specify root submodule', () => {
   const fixture = join(`${__dirname}/__fixtures__/libraries/${libraryName}`);
 
   // generate the documentation
-  execSync(`${process.execPath} ${cli} --submodule root`, { cwd: fixture });
+  execSync(`"${process.execPath}" ${cli} --submodule root`, { cwd: fixture });
 
   const md = readFileSync(join(fixture, 'API.md'), 'utf-8');
   expect(md).toMatchSnapshot();
@@ -63,7 +63,7 @@ test('split-by-submodule creates submodule files next to output', () => {
   const fixture = join(`${__dirname}/__fixtures__/libraries/${libraryName}`);
 
   // generate the documentation
-  execSync(`${process.execPath} ${cli} --output=docs/API.md --split-by-submodule`, { cwd: fixture });
+  execSync(`"${process.execPath}" ${cli} --output=docs/API.md --split-by-submodule`, { cwd: fixture });
 
   const rootMd = readFileSync(join(fixture, 'docs/API.md'), 'utf-8');
   const submoduleMd = readFileSync(join(fixture, 'docs/submod1.md'), 'utf-8');
@@ -83,7 +83,7 @@ test('specify languages and split-by-submodule creates submodule files next to o
   const fixture = join(`${__dirname}/__fixtures__/libraries/${libraryName}`);
 
   // generate the documentation
-  execSync(`${process.execPath} ${cli} --output=docs/API.md --split-by-submodule -l typescript -l python`, { cwd: fixture });
+  execSync(`"${process.execPath}" ${cli} --output=docs/API.md --split-by-submodule -l typescript -l python`, { cwd: fixture });
 
   // TypeScript
   const rootTs = readFileSync(join(fixture, 'docs/API.typescript.md'), 'utf-8');


### PR DESCRIPTION
When using NodeJS version managers like [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm), the NodeJS binary location can be a bit "funny".

For example on macOS with fnm, the NodeJS binary path may contain folder `Application Support` which has a space in it.

Wrapping the process.execPath interpolated value into quotes solves this:
```ts
execSync(`"${process.execPath}" ${cli}`, { cwd: fixture });
```

Fixes #1644.