### PR TITLE
feat: type intersections

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -89,6 +89,14 @@
         {
           "exec": "npm run compile",
           "cwd": "./test/__fixtures__/libraries/construct-library"
+        },
+        {
+          "exec": "npm ci",
+          "cwd": "./test/__fixtures__/libraries/lib-with-intersections"
+        },
+        {
+          "exec": "npm run compile",
+          "cwd": "./test/__fixtures__/libraries/lib-with-intersections"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -90,7 +90,7 @@ new RosettaPeerDependency(project, {
 project.github?.tryFindWorkflow('release')?.file?.patch(JsonPatch.add('/jobs/release/env/NODE_OPTIONS', '--max_old_space_size=4096'));
 project.github?.tryFindWorkflow('build')?.file?.patch(JsonPatch.add('/jobs/build/env/NODE_OPTIONS', '--max_old_space_size=4096'));
 
-const libraryFixtures = ['construct-library'];
+const libraryFixtures = ['construct-library', 'lib-with-intersections'];
 
 // compile the test fixtures with jsii
 for (const library of libraryFixtures) {

--- a/src/docgen/transpile/csharp.ts
+++ b/src/docgen/transpile/csharp.ts
@@ -67,7 +67,7 @@ export class CSharpTranspile extends transpile.TranspileBase {
     const paramsFormatted = parameters.map(p => this.formatFnParam(this.parameter(p))).join(', ');
     const prefix = isInitializer || callable.protected ? 'protected' : 'private';
 
-    let returnType: transpile.TranspiledTypeReference | undefined;
+    let returnType: transpile.ITranspiledTypeReference | undefined;
     if (reflect.Initializer.isInitializer(callable)) {
       returnType = this.typeReference(callable.parentType.reference);
     } else if (reflect.Method.isMethod(callable)) {
@@ -167,6 +167,10 @@ export class CSharpTranspile extends transpile.TranspileBase {
     return 'object';
   }
 
+  public intersectionOf(types: string[]): string {
+    return `${types[0]} /* and ${types.slice(1).join(' + ')} */`;
+  }
+
   public listOf(type: string): string {
     return `${type}[]`;
   }
@@ -238,7 +242,7 @@ export class CSharpTranspile extends transpile.TranspileBase {
     ].join('\n');
   };
 
-  private formatParameter(name: string, typeReference: transpile.TranspiledTypeReference) {
+  private formatParameter(name: string, typeReference: transpile.ITranspiledTypeReference) {
     const tf = typeReference.toString({
       typeFormatter: (t) => t.name,
     });
@@ -248,7 +252,7 @@ export class CSharpTranspile extends transpile.TranspileBase {
 
   private formatProperty(
     name: string,
-    typeReference: transpile.TranspiledTypeReference,
+    typeReference: transpile.ITranspiledTypeReference,
     property: reflect.Property,
   ): string {
     const tf = typeReference.toString({

--- a/src/docgen/transpile/go.ts
+++ b/src/docgen/transpile/go.ts
@@ -77,7 +77,7 @@ export class GoTranspile extends transpile.TranspileBase {
     const parameters = callable.parameters.sort(this.optionalityCompare);
     const paramsFormatted = parameters.map(p => this.formatFnParam(this.parameter(p))).join(', ');
 
-    let returnType: transpile.TranspiledTypeReference | undefined;
+    let returnType: transpile.ITranspiledTypeReference | undefined;
     if (isInitializer) {
       returnType = this.typeReference(callable.parentType.reference);
     } else if (reflect.Method.isMethod(callable)) {
@@ -177,6 +177,10 @@ export class GoTranspile extends transpile.TranspileBase {
     return this.any();
   }
 
+  public intersectionOf(types: string[]): string {
+    return `interface { ${types.join('; ')} }`;
+  }
+
   public listOf(type: string): string {
     return `*[]${type}`;
   }
@@ -231,7 +235,7 @@ export class GoTranspile extends transpile.TranspileBase {
     return `import "${type.module}${type.submodule ? `/${type.submodule}` : ''}"`;
   }
 
-  private formatParameter(name: string, typeReference: transpile.TranspiledTypeReference, variadic: boolean) {
+  private formatParameter(name: string, typeReference: transpile.ITranspiledTypeReference, variadic: boolean) {
     const tf = typeReference.toString({
       typeFormatter: (t) => t.name,
     });
@@ -253,7 +257,7 @@ export class GoTranspile extends transpile.TranspileBase {
 
   private formatProperty(
     name: string,
-    typeReference: transpile.TranspiledTypeReference,
+    typeReference: transpile.ITranspiledTypeReference,
     property: reflect.Property,
   ): string {
     const tf = typeReference.toString({

--- a/src/docgen/transpile/java.ts
+++ b/src/docgen/transpile/java.ts
@@ -128,7 +128,7 @@ export class JavaTranspile extends transpile.TranspileBase {
       return [...requiredParams, ...optionals].map((p) => this.formatParameter(this.parameter(p)));
     });
 
-    let returnType: transpile.TranspiledTypeReference | undefined;
+    let returnType: transpile.ITranspiledTypeReference | undefined;
     if (reflect.Initializer.isInitializer(callable)) {
       returnType = this.typeReference(callable.parentType.reference);
     } else if (reflect.Method.isMethod(callable)) {
@@ -245,6 +245,10 @@ export class JavaTranspile extends transpile.TranspileBase {
 
   public unionOf(types: string[]): string {
     return types.join(' OR ');
+  }
+
+  public intersectionOf(types: string[]): string {
+    return `${types[0]} /* and ${types.slice(1).join(' + ')} */`;
   }
 
   public listOf(type: string): string {
@@ -422,7 +426,7 @@ export class JavaTranspile extends transpile.TranspileBase {
 
   private formatProperty(
     name: string,
-    typeReference: transpile.TranspiledTypeReference,
+    typeReference: transpile.ITranspiledTypeReference,
   ): string {
     const tf = typeReference.toString({
       typeFormatter: (t) => t.name,

--- a/src/docgen/transpile/python.ts
+++ b/src/docgen/transpile/python.ts
@@ -93,6 +93,11 @@ export class PythonTranspile extends transpile.TranspileBase {
     return `${this.typing('Union')}[${types.join(', ')}]`;
   }
 
+  public intersectionOf(types: string[]): string {
+    // Not valid syntax but it gets the point across
+    return types.join(' & ');
+  }
+
   public listOf(type: string): string {
     return `${this.typing('List')}[${type}]`;
   }
@@ -215,7 +220,7 @@ export class PythonTranspile extends transpile.TranspileBase {
     const name = toSnakeCase(callable.name);
     const inputs = parameters.map((p) => this.formatParameters(this.parameter(p)));
 
-    let returnType: transpile.TranspiledTypeReference | undefined;
+    let returnType: transpile.ITranspiledTypeReference | undefined;
     if (reflect.Initializer.isInitializer(callable)) {
       returnType = this.typeReference(callable.parentType.reference);
     } else if (reflect.Method.isMethod(callable)) {
@@ -322,7 +327,7 @@ export class PythonTranspile extends transpile.TranspileBase {
 
   private formatProperty(
     name: string,
-    typeReference: transpile.TranspiledTypeReference,
+    typeReference: transpile.ITranspiledTypeReference,
   ): string {
     const tf = typeReference.toString({
       typeFormatter: (t) => t.name,

--- a/src/docgen/transpile/typescript.ts
+++ b/src/docgen/transpile/typescript.ts
@@ -66,6 +66,10 @@ export class TypeScriptTranspile extends transpile.TranspileBase {
     return `${types.join(' | ')}`;
   }
 
+  public intersectionOf(types: string[]): string {
+    return types.join(' & ');
+  }
+
   public listOf(type: string): string {
     return `${type}[]`;
   }
@@ -172,7 +176,7 @@ export class TypeScriptTranspile extends transpile.TranspileBase {
       ? formatClassInitialization(type, inputs)
       : formatInvocation(type, inputs, name);
 
-    let returnType: transpile.TranspiledTypeReference | undefined;
+    let returnType: transpile.ITranspiledTypeReference | undefined;
     if (reflect.Initializer.isInitializer(callable)) {
       returnType = this.typeReference(callable.parentType.reference);
     } else if (reflect.Method.isMethod(callable)) {
@@ -251,7 +255,7 @@ export class TypeScriptTranspile extends transpile.TranspileBase {
 
   private formatProperty(
     name: string,
-    typeReference: transpile.TranspiledTypeReference,
+    typeReference: transpile.ITranspiledTypeReference,
   ): string {
     const tf = typeReference.toString({
       typeFormatter: (t) => t.name,

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -1,6 +1,6 @@
 import * as os from 'os';
 import * as path from 'path';
-import { loadAssemblyFromFile, SPEC_FILE_NAME } from '@jsii/spec';
+import { JsiiFeature, loadAssemblyFromFile, SPEC_FILE_NAME } from '@jsii/spec';
 import * as fs from 'fs-extra';
 import * as glob from 'glob-promise';
 import * as reflect from 'jsii-reflect';
@@ -22,6 +22,8 @@ import { TypeScriptTranspile } from '../transpile/typescript';
 
 // https://github.com/aws/jsii/blob/main/packages/jsii-reflect/lib/assembly.ts#L175
 const NOT_FOUND_IN_ASSEMBLY_REGEX = /Type '(.*)\..*' not found in assembly (.*)$/;
+
+export const SUPPORTED_ASSEMBLY_FEATURES: JsiiFeature[] = ['intersection-types'];
 
 /**
  * Options for rendering a `Documentation` object.
@@ -424,7 +426,7 @@ export class Documentation {
         // for expanded python arguments - which we don't to right now anyway.
         // we don't want to make any assumption of the directory structure, so this is the most
         // robust way to detect the root assembly.
-        const spec = loadAssemblyFromFile(dotJsii, false); // don't validate we only need this for the spec name
+        const spec = loadAssemblyFromFile(dotJsii, false, SUPPORTED_ASSEMBLY_FEATURES); // don't validate we only need this for the spec name
         if (language && spec.name === this.assemblyName) {
           const packageDir = path.dirname(dotJsii);
           try {
@@ -481,7 +483,7 @@ async function loadAssembly(
   ts: reflect.TypeSystem,
   { validate }: { readonly validate?: boolean } = {},
 ): Promise<reflect.Assembly> {
-  const loaded = await ts.load(dotJsii, { validate });
+  const loaded = await ts.load(dotJsii, { validate, supportedFeatures: SUPPORTED_ASSEMBLY_FEATURES });
 
   for (const dep of Object.keys(loaded.spec.dependencies ?? {})) {
     if (ts.tryFindAssembly(dep) != null) {

--- a/test/__fixtures__/libraries/lib-with-intersections/.gitignore
+++ b/test/__fixtures__/libraries/lib-with-intersections/.gitignore
@@ -1,0 +1,8 @@
+*.js
+*.d.ts
+*.jsii
+API.md
+docs/**
+node_modules/
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/test/__fixtures__/libraries/lib-with-intersections/index.ts
+++ b/test/__fixtures__/libraries/lib-with-intersections/index.ts
@@ -1,0 +1,33 @@
+export interface IFoo {
+  readonly foo: string;
+}
+
+export interface IBar {
+  bar(x: string): string;
+}
+
+export interface Props {
+  readonly input: IFoo & IBar;
+}
+
+export class FooBer implements IFoo, IBar {
+  public readonly foo: string = 'foo';
+
+  public bar(x: string) {
+    return `BAR${x}BAR`;
+  }
+}
+
+export class Hello {
+  public static useStatic(param: IFoo & IBar) {
+    return param.bar(param.foo);
+  }
+
+  public use(param: IFoo & IBar) {
+    return param.bar(param.foo);
+  }
+
+  public useProps(props: Props) {
+    return props.input.bar(props.input.foo);
+  }
+}

--- a/test/__fixtures__/libraries/lib-with-intersections/package-lock.json
+++ b/test/__fixtures__/libraries/lib-with-intersections/package-lock.json
@@ -1,0 +1,1200 @@
+{
+  "name": "lib-with-intersections",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lib-with-intersections",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^14.0.0",
+        "@types/prettier": "2.7.1",
+        "jsii": "^5.9.6",
+        "jsii-pacmak": "^1.101.0",
+        "typescript": "^4.9.3"
+      }
+    },
+    "node_modules/@jsii/check-node": {
+      "version": "1.114.1",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.114.1.tgz",
+      "integrity": "sha512-SE9H1xBo4D+y259zRWqbrUnWVzCzxZh8ek2G1u5P+wP1n86GcgU+vz8uhJfGagdWFwW1EMW6t4PkPvbYoQG0yw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
+    "node_modules/@jsii/spec": {
+      "version": "1.114.1",
+      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.114.1.tgz",
+      "integrity": "sha512-SdjVQaNqLkTUK+2R0/t/MnM/NBvv1vzqxO5sn1nnoFD5Wlih8TFOIjl+Q8npzYmOtN+et3D+BMVYrxmVfq4X0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.17.1"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/case": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
+      "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codemaker": {
+      "version": "1.114.1",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.114.1.tgz",
+      "integrity": "sha512-X3KgS+Jof8gi3mIVnuyDrQX/g4loOlIHpwyladoSWLxv8B+nIdnGOd2TFNtxOlNGCGyuy2RY5+nASBziLiwu9w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "camelcase": "^6.3.0",
+        "decamelize": "^5.0.1",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commonmark": {
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/commonmark/-/commonmark-0.31.2.tgz",
+      "integrity": "sha512-2fRLTyb9r/2835k5cwcAwOj0DEc44FARnMp5veGsJ+mEAZdi52sNopLu07ZyElQUz058H43whzlERDIaaSw4rg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "entities": "~3.0.1",
+        "mdurl": "~1.0.1",
+        "minimist": "~1.2.8"
+      },
+      "bin": {
+        "commonmark": "bin/commonmark"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/date-format": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
+      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+      "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/detect-indent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+      "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jsii": {
+      "version": "5.9.7",
+      "resolved": "https://registry.npmjs.org/jsii/-/jsii-5.9.7.tgz",
+      "integrity": "sha512-ozdEz7gF5uxlYvC+Ze8IkcpQI6svLvusqNSfhl7l5nzi1gYdPedzEQp0Vl8M4cSDxkOmgh2Bz3/K/d7HkGM2qQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsii/check-node": "1.114.1",
+        "@jsii/spec": "1.114.1",
+        "case": "^1.6.3",
+        "chalk": "^4",
+        "fast-deep-equal": "^3.1.3",
+        "log4js": "^6.9.1",
+        "semver": "^7.7.2",
+        "semver-intersect": "^1.5.0",
+        "sort-json": "^2.0.1",
+        "spdx-license-list": "^6.10.0",
+        "typescript": "~5.9",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jsii": "bin/jsii"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      }
+    },
+    "node_modules/jsii-pacmak": {
+      "version": "1.114.1",
+      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.114.1.tgz",
+      "integrity": "sha512-Ks/PmxhznYhLIbQIo4fFPgWAa/cQb6RPudvvT08IKVIJE7i9LbzXE3go0hjbDjuhNFF6r8eYOAd1mqtbIyVB2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsii/check-node": "1.114.1",
+        "@jsii/spec": "1.114.1",
+        "clone": "^2.1.2",
+        "codemaker": "^1.114.1",
+        "commonmark": "^0.31.2",
+        "escape-string-regexp": "^4.0.0",
+        "fs-extra": "^10.1.0",
+        "jsii-reflect": "^1.114.1",
+        "semver": "^7.7.2",
+        "spdx-license-list": "^6.10.0",
+        "xmlbuilder": "^15.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jsii-pacmak": "bin/jsii-pacmak"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      },
+      "peerDependencies": {
+        "jsii-rosetta": ">=5.7.0"
+      }
+    },
+    "node_modules/jsii-reflect": {
+      "version": "1.114.1",
+      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.114.1.tgz",
+      "integrity": "sha512-t+p1eYPfzHa8d99Ywa/LwunEtgHQgNGhxCU8XaupWtgW+kLODoQ3eovddSMZOtIH6CQnbHneEqCMVmDeU8dzNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsii/check-node": "1.114.1",
+        "@jsii/spec": "1.114.1",
+        "chalk": "^4",
+        "fs-extra": "^10.1.0",
+        "oo-ascii-tree": "^1.114.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jsii-tree": "bin/jsii-tree"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
+    "node_modules/jsii-rosetta": {
+      "version": "5.9.5",
+      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-5.9.5.tgz",
+      "integrity": "sha512-CpkaRtf/7sX8zbPUjGuqzCK3jjp3Ph5mvWReTZ/N/lUcn9OPE+/5/Uxy9c6N9Ht9lr8/CMgCWhI+VCp9WVprnA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@jsii/check-node": "1.113.0",
+        "@jsii/spec": "^1.113.0",
+        "@xmldom/xmldom": "^0.9.8",
+        "chalk": "^4",
+        "commonmark": "^0.31.2",
+        "fast-glob": "^3.3.3",
+        "jsii": "~5.9.1",
+        "semver": "^7.7.2",
+        "semver-intersect": "^1.5.0",
+        "stream-json": "^1.9.1",
+        "typescript": "~5.9",
+        "workerpool": "^6.5.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jsii-rosetta": "bin/jsii-rosetta"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      }
+    },
+    "node_modules/jsii-rosetta/node_modules/@jsii/check-node": {
+      "version": "1.113.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.113.0.tgz",
+      "integrity": "sha512-6iPLiQiSVn8/D89ycIpj78cMfmxOIU/F9RUTVYwLqKPw4cxpR+BCC4N83WKyGkZxhOxULLa9f5q+rkWq/vAMpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
+    "node_modules/jsii-rosetta/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/jsii/node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/log4js": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
+      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "flatted": "^3.2.7",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.1.5"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/oo-ascii-tree": {
+      "version": "1.114.1",
+      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.114.1.tgz",
+      "integrity": "sha512-+xac1eA8pc16YTNQ3Joxfw1+C3kySirXJmZvKvbtvw2m16CQXpBjETp19EPIvXH6b4dthokP4NbVHm75btcGIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 14.17.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-intersect": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/semver-intersect/-/semver-intersect-1.5.0.tgz",
+      "integrity": "sha512-BDjWX7yCC0haX4W/zrnV2JaMpVirwaEkGOBmgRQtH++F1N3xl9v7k9H44xfTqwl+yLNNSbMKosoVSTIiJVQ2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.3.0"
+      }
+    },
+    "node_modules/semver-intersect/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/sort-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sort-json/-/sort-json-2.0.1.tgz",
+      "integrity": "sha512-s8cs2bcsQCzo/P2T/uoU6Js4dS/jnX8+4xunziNoq9qmSpZNCrRIAIvp4avsz0ST18HycV4z/7myJ7jsHWB2XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-indent": "^5.0.0",
+        "detect-newline": "^2.1.0",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "sort-json": "app/cmd.js"
+      }
+    },
+    "node_modules/spdx-license-list": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-6.10.0.tgz",
+      "integrity": "sha512-wF3RhDFoqdu14d1Prv6c8aNU0FSRuSFJpNjWeygIZcNZEwPxp7I5/Hwo8j6lSkBKWAIkSQrKefrC5N0lvOP0Gw==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
+    "node_modules/streamroller": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
+      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "fs-extra": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/streamroller/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/streamroller/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/streamroller/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/test/__fixtures__/libraries/lib-with-intersections/package.json
+++ b/test/__fixtures__/libraries/lib-with-intersections/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "lib-with-intersections",
+  "private": true,
+  "main": "index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "compile": "jsii --silence-warnings=reserved-word --no-fix-peer-dependencies",
+    "package": "jsii-pacmak"
+  },
+  "jsii": {
+    "outdir": "dist",
+    "tsc": {
+      "types": [
+        "node"
+      ]
+    },
+    "targets": {
+      "python": {
+        "distName": "lib-with-intersections",
+        "module": "lib_with_intersections"
+      },
+      "java": {
+        "package": "software.test.intersections.lib",
+        "maven": {
+          "groupId": "software.test.intersections",
+          "artifactId": "lib"
+        }
+      },
+      "dotnet": {
+        "namespace": "Intersections.Lib",
+        "packageId": "Intersections.Lib"
+      },
+      "go": {
+        "moduleName": "github.com/cdklabs/intersections_lib"
+      }
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://dummy.com"
+  },
+  "author": {
+    "name": "dummy",
+    "email": "dummy@example.com",
+    "organization": false
+  },
+  "devDependencies": {
+    "@types/node": "^14.0.0",
+    "@types/prettier": "2.7.1",
+    "jsii": "^5.9.6",
+    "jsii-pacmak": "^1.101.0",
+    "typescript": "^4.9.3"
+  },
+  "license": "Apache-2.0",
+  "version": "0.0.0"
+}

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -2161,6 +2161,1104 @@ first call to addToResourcePolicy(s).
 "
 `;
 
+exports[`docs for library: lib-with-intersections 1`] = `
+{
+  "docs/API.csharp.md": "# API Reference <a name="API Reference" id="api-reference"></a>
+
+
+## Structs <a name="Structs" id="Structs"></a>
+
+### Props <a name="Props" id="lib-with-intersections.Props"></a>
+
+#### Initializer <a name="Initializer" id="lib-with-intersections.Props.Initializer"></a>
+
+\`\`\`csharp
+using Intersections.Lib;
+
+new Props {
+    IFoo /* and IBar */ Input
+};
+\`\`\`
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.Props.property.input">Input</a></code> | <code><a href="#lib-with-intersections.IFoo">IFoo</a> /* and <a href="#lib-with-intersections.IBar">IBar</a> */</code> | *No description.* |
+
+---
+
+##### \`Input\`<sup>Required</sup> <a name="Input" id="lib-with-intersections.Props.property.input"></a>
+
+\`\`\`csharp
+public IFoo /* and IBar */ Input { get; set; }
+\`\`\`
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> /* and <a href="#lib-with-intersections.IBar">IBar</a> */
+
+---
+
+## Classes <a name="Classes" id="Classes"></a>
+
+### FooBer <a name="FooBer" id="lib-with-intersections.FooBer"></a>
+
+- *Implements:* <a href="#lib-with-intersections.IFoo">IFoo</a>, <a href="#lib-with-intersections.IBar">IBar</a>
+
+#### Initializers <a name="Initializers" id="lib-with-intersections.FooBer.Initializer"></a>
+
+\`\`\`csharp
+using Intersections.Lib;
+
+new FooBer();
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.FooBer.bar">Bar</a></code> | *No description.* |
+
+---
+
+##### \`Bar\` <a name="Bar" id="lib-with-intersections.FooBer.bar"></a>
+
+\`\`\`csharp
+private string Bar(string X)
+\`\`\`
+
+###### \`X\`<sup>Required</sup> <a name="X" id="lib-with-intersections.FooBer.bar.parameter.x"></a>
+
+- *Type:* string
+
+---
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.FooBer.property.foo">Foo</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### \`Foo\`<sup>Required</sup> <a name="Foo" id="lib-with-intersections.FooBer.property.foo"></a>
+
+\`\`\`csharp
+public string Foo { get; }
+\`\`\`
+
+- *Type:* string
+
+---
+
+
+### Hello <a name="Hello" id="lib-with-intersections.Hello"></a>
+
+#### Initializers <a name="Initializers" id="lib-with-intersections.Hello.Initializer"></a>
+
+\`\`\`csharp
+using Intersections.Lib;
+
+new Hello();
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.Hello.use">Use</a></code> | *No description.* |
+| <code><a href="#lib-with-intersections.Hello.useProps">UseProps</a></code> | *No description.* |
+
+---
+
+##### \`Use\` <a name="Use" id="lib-with-intersections.Hello.use"></a>
+
+\`\`\`csharp
+private string Use(IFoo /* and IBar */ Param)
+\`\`\`
+
+###### \`Param\`<sup>Required</sup> <a name="Param" id="lib-with-intersections.Hello.use.parameter.param"></a>
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> /* and <a href="#lib-with-intersections.IBar">IBar</a> */
+
+---
+
+##### \`UseProps\` <a name="UseProps" id="lib-with-intersections.Hello.useProps"></a>
+
+\`\`\`csharp
+private string UseProps(Props Props)
+\`\`\`
+
+###### \`Props\`<sup>Required</sup> <a name="Props" id="lib-with-intersections.Hello.useProps.parameter.props"></a>
+
+- *Type:* <a href="#lib-with-intersections.Props">Props</a>
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.Hello.useStatic">UseStatic</a></code> | *No description.* |
+
+---
+
+##### \`UseStatic\` <a name="UseStatic" id="lib-with-intersections.Hello.useStatic"></a>
+
+\`\`\`csharp
+using Intersections.Lib;
+
+Hello.UseStatic(IFoo /* and IBar */ Param);
+\`\`\`
+
+###### \`Param\`<sup>Required</sup> <a name="Param" id="lib-with-intersections.Hello.useStatic.parameter.param"></a>
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> /* and <a href="#lib-with-intersections.IBar">IBar</a> */
+
+---
+
+
+
+## Protocols <a name="Protocols" id="Protocols"></a>
+
+### IBar <a name="IBar" id="lib-with-intersections.IBar"></a>
+
+- *Implemented By:* <a href="#lib-with-intersections.FooBer">FooBer</a>, <a href="#lib-with-intersections.IBar">IBar</a>
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.IBar.bar">Bar</a></code> | *No description.* |
+
+---
+
+##### \`Bar\` <a name="Bar" id="lib-with-intersections.IBar.bar"></a>
+
+\`\`\`csharp
+private string Bar(string X)
+\`\`\`
+
+###### \`X\`<sup>Required</sup> <a name="X" id="lib-with-intersections.IBar.bar.parameter.x"></a>
+
+- *Type:* string
+
+---
+
+
+### IFoo <a name="IFoo" id="lib-with-intersections.IFoo"></a>
+
+- *Implemented By:* <a href="#lib-with-intersections.FooBer">FooBer</a>, <a href="#lib-with-intersections.IFoo">IFoo</a>
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.IFoo.property.foo">Foo</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### \`Foo\`<sup>Required</sup> <a name="Foo" id="lib-with-intersections.IFoo.property.foo"></a>
+
+\`\`\`csharp
+public string Foo { get; }
+\`\`\`
+
+- *Type:* string
+
+---
+
+",
+  "docs/API.go.md": "# API Reference <a name="API Reference" id="api-reference"></a>
+
+
+## Structs <a name="Structs" id="Structs"></a>
+
+### Props <a name="Props" id="lib-with-intersections.Props"></a>
+
+#### Initializer <a name="Initializer" id="lib-with-intersections.Props.Initializer"></a>
+
+\`\`\`go
+import "github.com/cdklabs/intersections_lib/libwithintersections"
+
+&libwithintersections.Props {
+	Input: interface { github.com/cdklabs/intersections_lib/libwithintersections.IFoo; github.com/cdklabs/intersections_lib/libwithintersections.IBar },
+}
+\`\`\`
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.Props.property.input">Input</a></code> | <code>interface { <a href="#lib-with-intersections.IFoo">IFoo</a>; <a href="#lib-with-intersections.IBar">IBar</a> }</code> | *No description.* |
+
+---
+
+##### \`Input\`<sup>Required</sup> <a name="Input" id="lib-with-intersections.Props.property.input"></a>
+
+\`\`\`go
+Input interface { IFoo; IBar }
+\`\`\`
+
+- *Type:* interface { <a href="#lib-with-intersections.IFoo">IFoo</a>; <a href="#lib-with-intersections.IBar">IBar</a> }
+
+---
+
+## Classes <a name="Classes" id="Classes"></a>
+
+### FooBer <a name="FooBer" id="lib-with-intersections.FooBer"></a>
+
+- *Implements:* <a href="#lib-with-intersections.IFoo">IFoo</a>, <a href="#lib-with-intersections.IBar">IBar</a>
+
+#### Initializers <a name="Initializers" id="lib-with-intersections.FooBer.Initializer"></a>
+
+\`\`\`go
+import "github.com/cdklabs/intersections_lib/libwithintersections"
+
+libwithintersections.NewFooBer() FooBer
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.FooBer.bar">Bar</a></code> | *No description.* |
+
+---
+
+##### \`Bar\` <a name="Bar" id="lib-with-intersections.FooBer.bar"></a>
+
+\`\`\`go
+func Bar(x *string) *string
+\`\`\`
+
+###### \`x\`<sup>Required</sup> <a name="x" id="lib-with-intersections.FooBer.bar.parameter.x"></a>
+
+- *Type:* *string
+
+---
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.FooBer.property.foo">Foo</a></code> | <code>*string</code> | *No description.* |
+
+---
+
+##### \`Foo\`<sup>Required</sup> <a name="Foo" id="lib-with-intersections.FooBer.property.foo"></a>
+
+\`\`\`go
+func Foo() *string
+\`\`\`
+
+- *Type:* *string
+
+---
+
+
+### Hello <a name="Hello" id="lib-with-intersections.Hello"></a>
+
+#### Initializers <a name="Initializers" id="lib-with-intersections.Hello.Initializer"></a>
+
+\`\`\`go
+import "github.com/cdklabs/intersections_lib/libwithintersections"
+
+libwithintersections.NewHello() Hello
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.Hello.use">Use</a></code> | *No description.* |
+| <code><a href="#lib-with-intersections.Hello.useProps">UseProps</a></code> | *No description.* |
+
+---
+
+##### \`Use\` <a name="Use" id="lib-with-intersections.Hello.use"></a>
+
+\`\`\`go
+func Use(param interface { IFoo; IBar }) *string
+\`\`\`
+
+###### \`param\`<sup>Required</sup> <a name="param" id="lib-with-intersections.Hello.use.parameter.param"></a>
+
+- *Type:* interface { <a href="#lib-with-intersections.IFoo">IFoo</a>; <a href="#lib-with-intersections.IBar">IBar</a> }
+
+---
+
+##### \`UseProps\` <a name="UseProps" id="lib-with-intersections.Hello.useProps"></a>
+
+\`\`\`go
+func UseProps(props Props) *string
+\`\`\`
+
+###### \`props\`<sup>Required</sup> <a name="props" id="lib-with-intersections.Hello.useProps.parameter.props"></a>
+
+- *Type:* <a href="#lib-with-intersections.Props">Props</a>
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.Hello.useStatic">UseStatic</a></code> | *No description.* |
+
+---
+
+##### \`UseStatic\` <a name="UseStatic" id="lib-with-intersections.Hello.useStatic"></a>
+
+\`\`\`go
+import "github.com/cdklabs/intersections_lib/libwithintersections"
+
+libwithintersections.Hello_UseStatic(param interface { IFoo; IBar }) *string
+\`\`\`
+
+###### \`param\`<sup>Required</sup> <a name="param" id="lib-with-intersections.Hello.useStatic.parameter.param"></a>
+
+- *Type:* interface { <a href="#lib-with-intersections.IFoo">IFoo</a>; <a href="#lib-with-intersections.IBar">IBar</a> }
+
+---
+
+
+
+## Protocols <a name="Protocols" id="Protocols"></a>
+
+### IBar <a name="IBar" id="lib-with-intersections.IBar"></a>
+
+- *Implemented By:* <a href="#lib-with-intersections.FooBer">FooBer</a>, <a href="#lib-with-intersections.IBar">IBar</a>
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.IBar.bar">Bar</a></code> | *No description.* |
+
+---
+
+##### \`Bar\` <a name="Bar" id="lib-with-intersections.IBar.bar"></a>
+
+\`\`\`go
+func Bar(x *string) *string
+\`\`\`
+
+###### \`x\`<sup>Required</sup> <a name="x" id="lib-with-intersections.IBar.bar.parameter.x"></a>
+
+- *Type:* *string
+
+---
+
+
+### IFoo <a name="IFoo" id="lib-with-intersections.IFoo"></a>
+
+- *Implemented By:* <a href="#lib-with-intersections.FooBer">FooBer</a>, <a href="#lib-with-intersections.IFoo">IFoo</a>
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.IFoo.property.foo">Foo</a></code> | <code>*string</code> | *No description.* |
+
+---
+
+##### \`Foo\`<sup>Required</sup> <a name="Foo" id="lib-with-intersections.IFoo.property.foo"></a>
+
+\`\`\`go
+func Foo() *string
+\`\`\`
+
+- *Type:* *string
+
+---
+
+",
+  "docs/API.java.md": "# API Reference <a name="API Reference" id="api-reference"></a>
+
+
+## Structs <a name="Structs" id="Structs"></a>
+
+### Props <a name="Props" id="lib-with-intersections.Props"></a>
+
+#### Initializer <a name="Initializer" id="lib-with-intersections.Props.Initializer"></a>
+
+\`\`\`java
+import software.test.intersections.lib.Props;
+
+Props.builder()
+    .input(IFoo AND IBar)
+    .build();
+\`\`\`
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.Props.property.input">input</a></code> | <code><a href="#lib-with-intersections.IFoo">IFoo</a> AND <a href="#lib-with-intersections.IBar">IBar</a></code> | *No description.* |
+
+---
+
+##### \`input\`<sup>Required</sup> <a name="input" id="lib-with-intersections.Props.property.input"></a>
+
+\`\`\`java
+public IFoo AND IBar getInput();
+\`\`\`
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> AND <a href="#lib-with-intersections.IBar">IBar</a>
+
+---
+
+## Classes <a name="Classes" id="Classes"></a>
+
+### FooBer <a name="FooBer" id="lib-with-intersections.FooBer"></a>
+
+- *Implements:* <a href="#lib-with-intersections.IFoo">IFoo</a>, <a href="#lib-with-intersections.IBar">IBar</a>
+
+#### Initializers <a name="Initializers" id="lib-with-intersections.FooBer.Initializer"></a>
+
+\`\`\`java
+import software.test.intersections.lib.FooBer;
+
+new FooBer();
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.FooBer.bar">bar</a></code> | *No description.* |
+
+---
+
+##### \`bar\` <a name="bar" id="lib-with-intersections.FooBer.bar"></a>
+
+\`\`\`java
+public java.lang.String bar(java.lang.String x)
+\`\`\`
+
+###### \`x\`<sup>Required</sup> <a name="x" id="lib-with-intersections.FooBer.bar.parameter.x"></a>
+
+- *Type:* java.lang.String
+
+---
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.FooBer.property.foo">foo</a></code> | <code>java.lang.String</code> | *No description.* |
+
+---
+
+##### \`foo\`<sup>Required</sup> <a name="foo" id="lib-with-intersections.FooBer.property.foo"></a>
+
+\`\`\`java
+public java.lang.String getFoo();
+\`\`\`
+
+- *Type:* java.lang.String
+
+---
+
+
+### Hello <a name="Hello" id="lib-with-intersections.Hello"></a>
+
+#### Initializers <a name="Initializers" id="lib-with-intersections.Hello.Initializer"></a>
+
+\`\`\`java
+import software.test.intersections.lib.Hello;
+
+new Hello();
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.Hello.use">use</a></code> | *No description.* |
+| <code><a href="#lib-with-intersections.Hello.useProps">useProps</a></code> | *No description.* |
+
+---
+
+##### \`use\` <a name="use" id="lib-with-intersections.Hello.use"></a>
+
+\`\`\`java
+public java.lang.String use(IFoo AND IBar param)
+\`\`\`
+
+###### \`param\`<sup>Required</sup> <a name="param" id="lib-with-intersections.Hello.use.parameter.param"></a>
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> AND <a href="#lib-with-intersections.IBar">IBar</a>
+
+---
+
+##### \`useProps\` <a name="useProps" id="lib-with-intersections.Hello.useProps"></a>
+
+\`\`\`java
+public java.lang.String useProps(Props props)
+\`\`\`
+
+###### \`props\`<sup>Required</sup> <a name="props" id="lib-with-intersections.Hello.useProps.parameter.props"></a>
+
+- *Type:* <a href="#lib-with-intersections.Props">Props</a>
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.Hello.useStatic">useStatic</a></code> | *No description.* |
+
+---
+
+##### \`useStatic\` <a name="useStatic" id="lib-with-intersections.Hello.useStatic"></a>
+
+\`\`\`java
+import software.test.intersections.lib.Hello;
+
+Hello.useStatic(IFoo AND IBar param)
+\`\`\`
+
+###### \`param\`<sup>Required</sup> <a name="param" id="lib-with-intersections.Hello.useStatic.parameter.param"></a>
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> AND <a href="#lib-with-intersections.IBar">IBar</a>
+
+---
+
+
+
+## Protocols <a name="Protocols" id="Protocols"></a>
+
+### IBar <a name="IBar" id="lib-with-intersections.IBar"></a>
+
+- *Implemented By:* <a href="#lib-with-intersections.FooBer">FooBer</a>, <a href="#lib-with-intersections.IBar">IBar</a>
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.IBar.bar">bar</a></code> | *No description.* |
+
+---
+
+##### \`bar\` <a name="bar" id="lib-with-intersections.IBar.bar"></a>
+
+\`\`\`java
+public java.lang.String bar(java.lang.String x)
+\`\`\`
+
+###### \`x\`<sup>Required</sup> <a name="x" id="lib-with-intersections.IBar.bar.parameter.x"></a>
+
+- *Type:* java.lang.String
+
+---
+
+
+### IFoo <a name="IFoo" id="lib-with-intersections.IFoo"></a>
+
+- *Implemented By:* <a href="#lib-with-intersections.FooBer">FooBer</a>, <a href="#lib-with-intersections.IFoo">IFoo</a>
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.IFoo.property.foo">foo</a></code> | <code>java.lang.String</code> | *No description.* |
+
+---
+
+##### \`foo\`<sup>Required</sup> <a name="foo" id="lib-with-intersections.IFoo.property.foo"></a>
+
+\`\`\`java
+public java.lang.String getFoo();
+\`\`\`
+
+- *Type:* java.lang.String
+
+---
+
+",
+  "docs/API.python.md": "# API Reference <a name="API Reference" id="api-reference"></a>
+
+
+## Structs <a name="Structs" id="Structs"></a>
+
+### Props <a name="Props" id="lib-with-intersections.Props"></a>
+
+#### Initializer <a name="Initializer" id="lib-with-intersections.Props.Initializer"></a>
+
+\`\`\`python
+import lib_with_intersections
+
+lib_with_intersections.Props(
+  input: IFoo & IBar
+)
+\`\`\`
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.Props.property.input">input</a></code> | <code><a href="#lib-with-intersections.IFoo">IFoo</a> & <a href="#lib-with-intersections.IBar">IBar</a></code> | *No description.* |
+
+---
+
+##### \`input\`<sup>Required</sup> <a name="input" id="lib-with-intersections.Props.property.input"></a>
+
+\`\`\`python
+input: IFoo & IBar
+\`\`\`
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> & <a href="#lib-with-intersections.IBar">IBar</a>
+
+---
+
+## Classes <a name="Classes" id="Classes"></a>
+
+### FooBer <a name="FooBer" id="lib-with-intersections.FooBer"></a>
+
+- *Implements:* <a href="#lib-with-intersections.IFoo">IFoo</a>, <a href="#lib-with-intersections.IBar">IBar</a>
+
+#### Initializers <a name="Initializers" id="lib-with-intersections.FooBer.Initializer"></a>
+
+\`\`\`python
+import lib_with_intersections
+
+lib_with_intersections.FooBer()
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.FooBer.bar">bar</a></code> | *No description.* |
+
+---
+
+##### \`bar\` <a name="bar" id="lib-with-intersections.FooBer.bar"></a>
+
+\`\`\`python
+def bar(
+  x: str
+) -> str
+\`\`\`
+
+###### \`x\`<sup>Required</sup> <a name="x" id="lib-with-intersections.FooBer.bar.parameter.x"></a>
+
+- *Type:* str
+
+---
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.FooBer.property.foo">foo</a></code> | <code>str</code> | *No description.* |
+
+---
+
+##### \`foo\`<sup>Required</sup> <a name="foo" id="lib-with-intersections.FooBer.property.foo"></a>
+
+\`\`\`python
+foo: str
+\`\`\`
+
+- *Type:* str
+
+---
+
+
+### Hello <a name="Hello" id="lib-with-intersections.Hello"></a>
+
+#### Initializers <a name="Initializers" id="lib-with-intersections.Hello.Initializer"></a>
+
+\`\`\`python
+import lib_with_intersections
+
+lib_with_intersections.Hello()
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.Hello.use">use</a></code> | *No description.* |
+| <code><a href="#lib-with-intersections.Hello.useProps">use_props</a></code> | *No description.* |
+
+---
+
+##### \`use\` <a name="use" id="lib-with-intersections.Hello.use"></a>
+
+\`\`\`python
+def use(
+  param: IFoo & IBar
+) -> str
+\`\`\`
+
+###### \`param\`<sup>Required</sup> <a name="param" id="lib-with-intersections.Hello.use.parameter.param"></a>
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> & <a href="#lib-with-intersections.IBar">IBar</a>
+
+---
+
+##### \`use_props\` <a name="use_props" id="lib-with-intersections.Hello.useProps"></a>
+
+\`\`\`python
+def use_props(
+  input: IFoo & IBar
+) -> str
+\`\`\`
+
+###### \`input\`<sup>Required</sup> <a name="input" id="lib-with-intersections.Hello.useProps.parameter.input"></a>
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> & <a href="#lib-with-intersections.IBar">IBar</a>
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.Hello.useStatic">use_static</a></code> | *No description.* |
+
+---
+
+##### \`use_static\` <a name="use_static" id="lib-with-intersections.Hello.useStatic"></a>
+
+\`\`\`python
+import lib_with_intersections
+
+lib_with_intersections.Hello.use_static(
+  param: IFoo & IBar
+)
+\`\`\`
+
+###### \`param\`<sup>Required</sup> <a name="param" id="lib-with-intersections.Hello.useStatic.parameter.param"></a>
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> & <a href="#lib-with-intersections.IBar">IBar</a>
+
+---
+
+
+
+## Protocols <a name="Protocols" id="Protocols"></a>
+
+### IBar <a name="IBar" id="lib-with-intersections.IBar"></a>
+
+- *Implemented By:* <a href="#lib-with-intersections.FooBer">FooBer</a>, <a href="#lib-with-intersections.IBar">IBar</a>
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.IBar.bar">bar</a></code> | *No description.* |
+
+---
+
+##### \`bar\` <a name="bar" id="lib-with-intersections.IBar.bar"></a>
+
+\`\`\`python
+def bar(
+  x: str
+) -> str
+\`\`\`
+
+###### \`x\`<sup>Required</sup> <a name="x" id="lib-with-intersections.IBar.bar.parameter.x"></a>
+
+- *Type:* str
+
+---
+
+
+### IFoo <a name="IFoo" id="lib-with-intersections.IFoo"></a>
+
+- *Implemented By:* <a href="#lib-with-intersections.FooBer">FooBer</a>, <a href="#lib-with-intersections.IFoo">IFoo</a>
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.IFoo.property.foo">foo</a></code> | <code>str</code> | *No description.* |
+
+---
+
+##### \`foo\`<sup>Required</sup> <a name="foo" id="lib-with-intersections.IFoo.property.foo"></a>
+
+\`\`\`python
+foo: str
+\`\`\`
+
+- *Type:* str
+
+---
+
+",
+  "docs/API.typescript.md": "# API Reference <a name="API Reference" id="api-reference"></a>
+
+
+## Structs <a name="Structs" id="Structs"></a>
+
+### Props <a name="Props" id="lib-with-intersections.Props"></a>
+
+#### Initializer <a name="Initializer" id="lib-with-intersections.Props.Initializer"></a>
+
+\`\`\`typescript
+import { Props } from 'lib-with-intersections'
+
+const props: Props = { ... }
+\`\`\`
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.Props.property.input">input</a></code> | <code><a href="#lib-with-intersections.IFoo">IFoo</a> & <a href="#lib-with-intersections.IBar">IBar</a></code> | *No description.* |
+
+---
+
+##### \`input\`<sup>Required</sup> <a name="input" id="lib-with-intersections.Props.property.input"></a>
+
+\`\`\`typescript
+public readonly input: IFoo & IBar;
+\`\`\`
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> & <a href="#lib-with-intersections.IBar">IBar</a>
+
+---
+
+## Classes <a name="Classes" id="Classes"></a>
+
+### FooBer <a name="FooBer" id="lib-with-intersections.FooBer"></a>
+
+- *Implements:* <a href="#lib-with-intersections.IFoo">IFoo</a>, <a href="#lib-with-intersections.IBar">IBar</a>
+
+#### Initializers <a name="Initializers" id="lib-with-intersections.FooBer.Initializer"></a>
+
+\`\`\`typescript
+import { FooBer } from 'lib-with-intersections'
+
+new FooBer()
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.FooBer.bar">bar</a></code> | *No description.* |
+
+---
+
+##### \`bar\` <a name="bar" id="lib-with-intersections.FooBer.bar"></a>
+
+\`\`\`typescript
+public bar(x: string): string
+\`\`\`
+
+###### \`x\`<sup>Required</sup> <a name="x" id="lib-with-intersections.FooBer.bar.parameter.x"></a>
+
+- *Type:* string
+
+---
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.FooBer.property.foo">foo</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### \`foo\`<sup>Required</sup> <a name="foo" id="lib-with-intersections.FooBer.property.foo"></a>
+
+\`\`\`typescript
+public readonly foo: string;
+\`\`\`
+
+- *Type:* string
+
+---
+
+
+### Hello <a name="Hello" id="lib-with-intersections.Hello"></a>
+
+#### Initializers <a name="Initializers" id="lib-with-intersections.Hello.Initializer"></a>
+
+\`\`\`typescript
+import { Hello } from 'lib-with-intersections'
+
+new Hello()
+\`\`\`
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.Hello.use">use</a></code> | *No description.* |
+| <code><a href="#lib-with-intersections.Hello.useProps">useProps</a></code> | *No description.* |
+
+---
+
+##### \`use\` <a name="use" id="lib-with-intersections.Hello.use"></a>
+
+\`\`\`typescript
+public use(param: IFoo & IBar): string
+\`\`\`
+
+###### \`param\`<sup>Required</sup> <a name="param" id="lib-with-intersections.Hello.use.parameter.param"></a>
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> & <a href="#lib-with-intersections.IBar">IBar</a>
+
+---
+
+##### \`useProps\` <a name="useProps" id="lib-with-intersections.Hello.useProps"></a>
+
+\`\`\`typescript
+public useProps(props: Props): string
+\`\`\`
+
+###### \`props\`<sup>Required</sup> <a name="props" id="lib-with-intersections.Hello.useProps.parameter.props"></a>
+
+- *Type:* <a href="#lib-with-intersections.Props">Props</a>
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.Hello.useStatic">useStatic</a></code> | *No description.* |
+
+---
+
+##### \`useStatic\` <a name="useStatic" id="lib-with-intersections.Hello.useStatic"></a>
+
+\`\`\`typescript
+import { Hello } from 'lib-with-intersections'
+
+Hello.useStatic(param: IFoo & IBar)
+\`\`\`
+
+###### \`param\`<sup>Required</sup> <a name="param" id="lib-with-intersections.Hello.useStatic.parameter.param"></a>
+
+- *Type:* <a href="#lib-with-intersections.IFoo">IFoo</a> & <a href="#lib-with-intersections.IBar">IBar</a>
+
+---
+
+
+
+## Protocols <a name="Protocols" id="Protocols"></a>
+
+### IBar <a name="IBar" id="lib-with-intersections.IBar"></a>
+
+- *Implemented By:* <a href="#lib-with-intersections.FooBer">FooBer</a>, <a href="#lib-with-intersections.IBar">IBar</a>
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#lib-with-intersections.IBar.bar">bar</a></code> | *No description.* |
+
+---
+
+##### \`bar\` <a name="bar" id="lib-with-intersections.IBar.bar"></a>
+
+\`\`\`typescript
+public bar(x: string): string
+\`\`\`
+
+###### \`x\`<sup>Required</sup> <a name="x" id="lib-with-intersections.IBar.bar.parameter.x"></a>
+
+- *Type:* string
+
+---
+
+
+### IFoo <a name="IFoo" id="lib-with-intersections.IFoo"></a>
+
+- *Implemented By:* <a href="#lib-with-intersections.FooBer">FooBer</a>, <a href="#lib-with-intersections.IFoo">IFoo</a>
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#lib-with-intersections.IFoo.property.foo">foo</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### \`foo\`<sup>Required</sup> <a name="foo" id="lib-with-intersections.IFoo.property.foo"></a>
+
+\`\`\`typescript
+public readonly foo: string;
+\`\`\`
+
+- *Type:* string
+
+---
+
+",
+}
+`;
+
 exports[`specify language 1`] = `
 "# API Reference <a name="API Reference" id="api-reference"></a>
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -78,7 +78,6 @@ test('split-by-submodule creates submodule files next to output', () => {
 });
 
 test('specify languages and split-by-submodule creates submodule files next to output', () => {
-
   const libraryName = 'construct-library';
   const fixture = join(`${__dirname}/__fixtures__/libraries/${libraryName}`);
 
@@ -102,5 +101,23 @@ test('specify languages and split-by-submodule creates submodule files next to o
   expect(rootPy).toContain('greet_with_salutation');
   expect(submodulePy).toMatchSnapshot('submod1.python.md');
   expect(submodulePy).toContain('goodbye_with_phrase');
+});
 
+test.each(['lib-with-intersections'])('docs for library: %s', async (libraryName) => {
+  const fixture = join(`${__dirname}/__fixtures__/libraries/${libraryName}`);
+
+  // generate the documentation
+  execSync(`"${process.execPath}" ${cli} --output=docs/API.md --split-by-submodule -l typescript -l java -l python -l csharp -l go`, { cwd: fixture });
+
+  // TypeScript
+  const files = [
+    'docs/API.typescript.md',
+    'docs/API.java.md',
+    'docs/API.python.md',
+    'docs/API.csharp.md',
+    'docs/API.go.md',
+  ];
+
+  const docs = Object.fromEntries(files.map((file) => [file, readFileSync(join(fixture, file), 'utf-8')]));
+  expect(docs).toMatchSnapshot();
 });


### PR DESCRIPTION
Update `jsii-docgen` to handle type intersections. We don't have fantastically idiomatic representations of them in all languages, but given the constraints of how we have to choose a rendering in type position, without being able to change any of the syntax around it, we're doing the following:

```
// C#
IFoo /* and IBar */ ParameterName

// Java
IFoo /* and IBar */ parameterName

// TypeScript
parameterName: IFoo & IBar

// Python
parameterName: IFoo & IBar

// Go
parameterName interface { IFoo; IBar }
```

Fixes #