### PR TITLE
feat: add support for class-covariant-overrides jsii feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,12 +62,12 @@
     "jsii-rosetta": "^1.85.0 || ~5.0.14 || ~5.1.2 || ~5.2.0 || ~5.3.0 || ~5.4.0 || ~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ~5.9.1"
   },
   "dependencies": {
-    "@jsii/spec": "^1.116.0",
+    "@jsii/spec": "^1.117.0",
     "case": "^1.6.3",
     "fs-extra": "^10.1.0",
     "glob": "^8.1.0",
     "glob-promise": "^6.0.7",
-    "jsii-reflect": "^1.116.0",
+    "jsii-reflect": "^1.117.0",
     "json-stream-stringify": "^3.1.6",
     "semver": "^7.7.3",
     "yargs": "^16.2.0"

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -23,7 +23,7 @@ import { TypeScriptTranspile } from '../transpile/typescript';
 // https://github.com/aws/jsii/blob/main/packages/jsii-reflect/lib/assembly.ts#L175
 const NOT_FOUND_IN_ASSEMBLY_REGEX = /Type '(.*)\..*' not found in assembly (.*)$/;
 
-export const SUPPORTED_ASSEMBLY_FEATURES: JsiiFeature[] = ['intersection-types'];
+export const SUPPORTED_ASSEMBLY_FEATURES: JsiiFeature[] = ['intersection-types', 'class-covariant-overrides'];
 
 /**
  * Options for rendering a `Documentation` object.

--- a/yarn.lock
+++ b/yarn.lock
@@ -673,18 +673,18 @@
     chalk "^4.1.2"
     semver "^7.7.2"
 
-"@jsii/check-node@1.116.0":
-  version "1.116.0"
-  resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.116.0.tgz#f4db6461511f60232aa02bfaf46bd607da49bbae"
-  integrity sha512-Avk6AKggZJcWpDLGH8lb5duyfGIVHCmmeglM3LfmQvKU/zumbRfeg4LvUXGqJflnRB7GAbzbx8iDNo8FMjIWjg==
+"@jsii/check-node@1.117.0":
+  version "1.117.0"
+  resolved "https://registry.yarnpkg.com/@jsii/check-node/-/check-node-1.117.0.tgz#44110172f6b4df86c3f0172599c64d2f08ce362c"
+  integrity sha512-OtCwbCGGV41O4zuv11aioMFOSUHKm3cVBFmmwsls0ilcgzAKQ5Dk4/gqbzhpissiiDfFZuW+WjXO1lgTm8oRfw==
   dependencies:
     chalk "^4.1.2"
     semver "^7.7.2"
 
-"@jsii/spec@1.116.0", "@jsii/spec@^1.116.0":
-  version "1.116.0"
-  resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.116.0.tgz#8da502da897f15b46ac969033cea5cbee4738f43"
-  integrity sha512-BqsOMsE7Md6EwaLammXeCOi20GlsA4lAawIrPN0jHeFjZnEqUsiWRXZw+9EG3lTImW9QLVN1cF9kbQ3t3vAXeQ==
+"@jsii/spec@1.117.0", "@jsii/spec@^1.117.0":
+  version "1.117.0"
+  resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.117.0.tgz#c2e73ceac03d48504d2f0d0a2fc6b0860ea38656"
+  integrity sha512-Uru/sg3RN9Rr0smN3MS5gueeGdQdPHQ9fTVSxEOuzpxr5z1gej51rs73luj1cYPncMryHo+YkygpucCdLiQItg==
   dependencies:
     ajv "^8.17.1"
 
@@ -3599,16 +3599,16 @@ jsesc@^3.0.2:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
-jsii-reflect@^1.116.0:
-  version "1.116.0"
-  resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.116.0.tgz#2dda056b311b9b7eed49ac27c45743f64f0057d7"
-  integrity sha512-ZIHznFUMHQinqNLu48JibrnB0O0EeINCUgtkgV+SqEN7wsM1kxT3SBLHEbCQqPzB5ZsQzrdl9JW1vMi14/YqGA==
+jsii-reflect@^1.117.0:
+  version "1.117.0"
+  resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.117.0.tgz#71ccc04bd1dbe6cc8da13ce189f1cf8768e9a808"
+  integrity sha512-ttdzWulvjV8pdn/hdZQt/lLSizH8TXIFM22y3tIHD6yxapO07r0KTekbAR+XZ2zlUiOz4Url6+7wOs4IMijhag==
   dependencies:
-    "@jsii/check-node" "1.116.0"
-    "@jsii/spec" "1.116.0"
+    "@jsii/check-node" "1.117.0"
+    "@jsii/spec" "1.117.0"
     chalk "^4"
     fs-extra "^10.1.0"
-    oo-ascii-tree "^1.116.0"
+    oo-ascii-tree "^1.117.0"
     yargs "^17.7.2"
 
 "jsii-rosetta@^1.85.0 || ~5.0.14 || ~5.1.2 || ~5.2.0 || ~5.3.0 || ~5.4.0 || ~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ~5.9.1":
@@ -4136,10 +4136,10 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-oo-ascii-tree@^1.116.0:
-  version "1.116.0"
-  resolved "https://registry.yarnpkg.com/oo-ascii-tree/-/oo-ascii-tree-1.116.0.tgz#2bd95d7de16b842289e01bd83e29f93ea463eaf5"
-  integrity sha512-GI0n8coDIoZPywmZp5l2qPO1tqZxN40/tFPYBxWD2vpPeciKiB/nxZ7blDjp97ejxtmdkNouvAmtg4nCYgZihg==
+oo-ascii-tree@^1.117.0:
+  version "1.117.0"
+  resolved "https://registry.yarnpkg.com/oo-ascii-tree/-/oo-ascii-tree-1.117.0.tgz#0831bf9079634d6acb525ee57bbc6768866eac69"
+  integrity sha512-Kzl5NSpj1LzCFqsEpKaOKZCk1X/gTpfLAFXkbEpdKS1LLuhxgMaHIVHjpeJ5EdXudJWiA9+HRFb7UjFrO0a+UA==
 
 optionator@^0.9.3:
   version "0.9.4"


### PR DESCRIPTION
This PR adds support for the `class-covariant-overrides` jsii feature to the list of supported assembly features.

This change doesn't require any code modifications beyond adding the feature name to the supported list. The existing jsii-docgen infrastructure already handles this feature type correctly - we just need to explicitly declare support for it to prevent compatibility warnings.

Fixes #