### PR TITLE
fix: removing unnecessary copy

### DIFF
--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -405,16 +405,6 @@ export class Documentation {
 
     const created = await withTempDir(async (workdir: string) => {
 
-      // always better not to pollute an externally provided directory
-      await fs.copy(this.assembliesDir, workdir, {
-        // Ensure we don't try to copy socket files, as they can be found under .git when
-        // core.fsmonitor is enabled.
-        filter: async (src) => {
-          const stat = await fs.stat(src);
-          return stat.isFile() || stat.isDirectory();
-        },
-      });
-
       const ts = new reflect.TypeSystem();
 
       const assemblies = discoverAssemblies(this.assembliesDir);


### PR DESCRIPTION
## Why

This PR fixes #1895.

From researching the code-base, the only explicit output we do is when we render the final documentation. The actual type system compilation isn't producing any "polluting" files so this copy is unnecessary. 

This copy is causing a massive slowdown in our project repository because our `node_modules` is quite large (nearing ~1Gb).

## Testing

I tested this on our code-base and it doesn't produce any extra files in the node_modules or the working directory besides the output documentation.