### PR TITLE
fix: transliteration is needlessly slow

### DIFF
--- a/src/docgen/view/assembly.ts
+++ b/src/docgen/view/assembly.ts
@@ -5,6 +5,7 @@ import { AssemblyRedirect, isAssemblyRedirect, SPEC_FILE_NAME, validateAssemblyR
 import * as fg from 'fast-glob';
 import { Assembly } from 'jsii-reflect';
 import * as semver from 'semver';
+import { CorruptedAssemblyError } from '../../errors';
 
 export interface AssemblyInfo {
   readonly name: string;
@@ -28,14 +29,16 @@ export type AssemblyLookup = Record<string, AssemblyInfo>;
  *
  * @returns the best matching assembly info or undefined if no match was found
  */
-export function bestAssemblyMatch(assemblies: AssemblyLookup, constraint: string): AssemblyInfo | undefined {
+export function bestAssemblyMatch(assemblies: AssemblyLookup, constraint: string): AssemblyInfo {
   const lastAtIndex = constraint.lastIndexOf('@');
   const name = lastAtIndex === -1 ? constraint : constraint.substring(0, lastAtIndex);
   const versionConstraint = lastAtIndex === -1 ? undefined : constraint.substring(lastAtIndex + 1);
   const candidates = Object.values(assemblies).filter(a => a.name === name);
 
   if (candidates.length === 0) {
-    return undefined;
+    // `assemblies` is a view on top of the installation directory,
+    // it should contain the assembly.
+    throw new CorruptedAssemblyError(`Unable to locate assembly for dependency: ${constraint}`);
   }
 
   candidates.sort((a, b) => semver.rcompare(a.version, b.version) || 0);

--- a/src/docgen/view/documentation.ts
+++ b/src/docgen/view/documentation.ts
@@ -405,16 +405,6 @@ export class Documentation {
 
     const created = await withTempDir(async (workdir: string) => {
 
-      // always better not to pollute an externally provided directory
-      await fs.copy(this.assembliesDir, workdir, {
-        // Ensure we don't try to copy socket files, as they can be found under .git when
-        // core.fsmonitor is enabled.
-        filter: async (src) => {
-          const stat = await fs.stat(src);
-          return stat.isFile() || stat.isDirectory();
-        },
-      });
-
       const ts = new reflect.TypeSystem();
 
       const assemblies = discoverAssemblies(this.assembliesDir);
@@ -494,10 +484,10 @@ async function loadAssembly(
       // dependency already loaded... move on...
       continue;
     }
+
+    const depPath = bestAssemblyMatch(availableAssemblies, `${dep}@${version}`).path;
+
     try {
-      // Use path from look up or try to resolve the dependencies relative to the dependent's package root.
-      const depPath = bestAssemblyMatch(availableAssemblies, `${dep}@${version}`)?.path
-        ?? require.resolve(`${dep}/.jsii`, { paths: [path.dirname(dotJsii)] });
       await loadAssembly(depPath, ts, availableAssemblies, { validate });
     } catch (error) {
       // Silently ignore any resolution errors... We'll fail later if the dependency is

--- a/test/docgen/view/assembly.test.ts
+++ b/test/docgen/view/assembly.test.ts
@@ -1,4 +1,5 @@
 import { bestAssemblyMatch, AssemblyLookup } from '../../../src/docgen/view/assembly';
+import { CorruptedAssemblyError } from '../../../src/errors';
 
 describe('bestAssemblyMatch', () => {
   const assemblies: AssemblyLookup = {
@@ -9,8 +10,8 @@ describe('bestAssemblyMatch', () => {
     'other-lib@1.0.0': { name: 'other-lib', version: '1.0.0', path: '/path/other' },
   };
 
-  test('returns undefined for non-existent assembly', () => {
-    expect(bestAssemblyMatch(assemblies, 'missing@1.0.0')).toBeUndefined();
+  test('throws CorruptedAssemblyError for non-existent assembly', () => {
+    expect(() => bestAssemblyMatch(assemblies, 'missing@1.0.0')).toThrow(CorruptedAssemblyError);
   });
 
   test('returns exact version match', () => {

--- a/test/docgen/view/documentation.test.ts
+++ b/test/docgen/view/documentation.test.ts
@@ -118,7 +118,7 @@ describe('python', () => {
   });
 
   test('snapshot - with dependencies', async () => {
-    const docs = await Documentation.forPackage('@aws-cdk/aws-glue-alpha@2.245.0-alpha.0');
+    const docs = await Documentation.forPackage('cdk8s-jenkins@0.0.556');
     try {
       const markdown = await docs.toMarkdown({ language: Language.PYTHON });
       expect(markdown.render()).toMatchSnapshot();

--- a/test/docgen/view/documentation.test.ts
+++ b/test/docgen/view/documentation.test.ts
@@ -116,6 +116,17 @@ describe('python', () => {
       await docs.cleanup();
     }
   });
+
+  test('snapshot - with dependencies', async () => {
+    const docs = await Documentation.forPackage('@aws-cdk/aws-glue-alpha@2.245.0-alpha.0');
+    try {
+      const markdown = await docs.toMarkdown({ language: Language.PYTHON });
+      expect(markdown.render()).toMatchSnapshot();
+    } finally {
+      await docs.cleanup();
+    }
+  });
+
 });
 
 describe('typescript', () => {


### PR DESCRIPTION
Fixes https://github.com/cdklabs/jsii-docgen/issues/1895.

We used to:

1. Install the package with NPM into temp directory A.
2. Create temp directory B.
3. Copy temp directory A to temp directory B. 
4. Produce transliterated assemblies into directory B.

Why (3)? Because it was used as a fallback lookup path in case directory A didn't contain the assembly of a dependency. This fallback doesn't make sense because the assembly should have been installed into A; if it didn't - the root assembly is corrupt.

Now we:

1. Install the package with NPM into temp directory A.
2. Create temp directory B.
3. Produce transliterated assemblies into directory B (assuming all required dep assemblies are in A).

Supersedes https://github.com/cdklabs/jsii-docgen/pull/1896 