### PR TITLE
fix: npm installation allows shell injection

### DIFF
--- a/src/docgen/view/_npm.ts
+++ b/src/docgen/view/_npm.ts
@@ -60,7 +60,7 @@ export class Npm {
         await this.npmCommandPath(),
         [
           'install',
-          JSON.stringify(target),
+          target,
           ...commonFlags,
           // ensures we are installing devDependencies, too.
           '--include=dev',
@@ -187,6 +187,8 @@ export class Npm {
    * the command was successful or not. Use the `assertSuccess` function to
    * throw/reject in case the execution was not successful.
    *
+   * The arguments are escaped, and will not be interpreted by the shell.
+   *
    * @param command         the command to invoke.
    * @param args            arguments to provide to the command.
    * @param outputTransform the function that will parse STDOUT data.
@@ -199,10 +201,15 @@ export class Npm {
     options?: SpawnOptionsWithoutStdio,
   ): Promise<CommandResult<T>> {
     return new Promise<CommandResult<T>>((ok, ko) => {
-      // On Windows, spawning a program ending in .cmd or .bat needs to run in a shell
+      // On Windows, spawning a program ending in .cmd or .bat needs to run in a shell.
+      // (Even if the program is a .cmd/.bat file that gets resolved implicitly, it still needs that shell,
+      // but then it's the caller's responsibility to pass { shell: true }).
       // https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
-      const shell = onWindows() && (command.endsWith('.cmd') || command.endsWith('.bat'));
-      const child = spawn(command, args, { shell, ...options, stdio: ['inherit', 'pipe', 'pipe'] });
+      //
+      // If we are going through the shell, escape the arguments.
+      const shell = options?.shell || (onWindows() && (command.endsWith('.cmd') || command.endsWith('.bat')));
+      const safeArgs = shell ? args.map(escapeForShell) : args;
+      const child = spawn(command, safeArgs, { ...options, shell, stdio: ['inherit', 'pipe', 'pipe'] });
       const stdout = new Array<Buffer>();
       child.stdout.on('data', (chunk) => {
         stdout.push(Buffer.from(chunk));
@@ -215,7 +222,7 @@ export class Npm {
       child.once('close', (exitCode, signal) => {
         try {
           ok({
-            command: `${command} ${args.join(' ')}`,
+            command: `${command} ${safeArgs.join(' ')}`,
             exitCode,
             signal,
             stdout: outputTransform(stdout),
@@ -225,6 +232,21 @@ export class Npm {
         }
       });
     });
+  }
+}
+
+function escapeForShell(arg: string): string {
+  if (arg.match(/^[a-z0-9_\/.=-]+$/i)) {
+    // If the argument contains only safe characters, we can return it as is, to keep the command line readable.
+    return arg;
+  }
+
+  if (onWindows()) {
+    // On Windows, we need to wrap the argument in double quotes and escape any existing double quotes by doubling them.
+    return `"${arg.replace(/"/g, '""')}"`;
+  } else {
+    // On Unix-like systems, we can wrap the argument in single quotes and escape any existing single quotes by closing the quote, adding an escaped single quote, and reopening the quote.
+    return `'${arg.replace(/'/g, `'\\''`)}'`;
   }
 }
 

--- a/src/docgen/view/_npm.ts
+++ b/src/docgen/view/_npm.ts
@@ -246,7 +246,7 @@ function escapeForShell(arg: string): string {
     return `"${arg.replace(/"/g, '""')}"`;
   } else {
     // On Unix-like systems, we can wrap the argument in single quotes and escape any existing single quotes by closing the quote, adding an escaped single quote, and reopening the quote.
-    return `'${arg.replace(/'/g, `'\\''`)}'`;
+    return `'${arg.replace(/'/g, '\'\\\'\'')}'`;
   }
 }
 

--- a/src/docgen/view/_npm.ts
+++ b/src/docgen/view/_npm.ts
@@ -123,7 +123,7 @@ export class Npm {
       if (version == null) {
         continue;
       }
-      result.push(JSON.stringify(`${name}@${version}`));
+      result.push(`${name}@${version}`);
     }
 
     return result;

--- a/test/docgen/view/_npm.test.ts
+++ b/test/docgen/view/_npm.test.ts
@@ -135,6 +135,30 @@ test.each(UNISTALLABLE_PACKAGE_ERROR_CODES)('%s error is converted to an UnInsta
   }
 });
 
+test('NPM commands are shell escaped', async () => {
+  // GIVEN
+  const npm = new Npm(TMPDIR, () => void 0, 'mock-npm');
+
+  // WHEN
+  const mockChildProcess = new MockChildProcess(42, {
+    stdout: [],
+  });
+  mockSpawn.mockReturnValue(mockChildProcess);
+
+  // THEN
+  await expect(npm.install('x$(rm -rf /)')).rejects.toThrow(/exited with code 42/);
+
+  const expected = process.platform === 'win32'
+    ? '"x$(rm -rf /)"'
+    : '\'x$(rm -rf /)\'';
+
+  expect(mockSpawn).toHaveBeenCalledWith(
+    'mock-npm',
+    expect.arrayContaining([expected]),
+    expect.anything(),
+  );
+});
+
 test('NpmError error (invalid JSON output)', async () => {
   // GIVEN
   const npm = new Npm(TMPDIR, () => void 0, 'mock-npm');


### PR DESCRIPTION
We used to escape *some* arguments to the NPM installation shell command.

The escaping was done with `JSON.stringify()`, which is not good enough: because the end result ends up between `"` double quotes, it still allow shell substitution in POSIX shells.

Also, some arguments are loaded from `package.json` sections, and those were not escaped, allowing for injection.

Change the `this.runCommand()` function to escape all arguments automatically, using `'` on POSIX (which doesn't allow any type of escape) and `"` on Windows.
