### PR TITLE
feat(render): support the TSDoc `{@link}` tag

### DIFF
--- a/src/docgen/render/markdown-doc.ts
+++ b/src/docgen/render/markdown-doc.ts
@@ -95,71 +95,56 @@ export class MarkdownDocument {
   }
 
   /**
-   * Convert JSDoc `{@link}` inline tags into markdown.
+   * Convert TSDoc `{@link}` inline tags into markdown.
    *
-   * Supports every syntax variant described in
-   * https://jsdoc.app/tags-inline-link, including the `{@linkcode}` and
-   * `{@linkplain}` synonyms:
+   * Supports the syntax described in https://tsdoc.org/pages/tags/link/:
    *
    * - `{@link https://example.com}`
-   * - `{@link https://example.com|link text}`
-   * - `{@link https://example.com link text}`
-   * - `[link text]{@link https://example.com}`
-   * - `{@link SomeType}` (namepath reference)
+   * - `{@link https://example.com | link text}`
+   * - `{@link Button}` (declaration reference)
+   * - `{@link Button | the Button class}`
    *
-   * URLs are rendered as clickable markdown links. Namepath references (that
-   * don't resolve to a URL) are rendered as inline code, since there is no
-   * reliable way to resolve an arbitrary namepath to an anchor at render time.
-   * `{@linkcode}` always renders its text as inline code, while `{@linkplain}`
-   * always renders its text as plain text.
+   * A target and an optional custom link text are separated by a `|`. URLs are
+   * rendered as clickable markdown links. Declaration references are not turned
+   * into links, since there is no reliable way to resolve a declaration
+   * reference to an anchor at render time; instead a bare reference is rendered
+   * as inline code and a reference with custom text is rendered as that text.
    */
   public static formatLinks(text: string): string {
-    // An optional `[prefix text]` may immediately precede the inline tag.
-    const linkRegExp = /(?:\[([^\]]*)\])?\{@(link|linkcode|linkplain)\s+([^}]*)\}/g;
+    const linkRegExp = /\{@link\s+([^}]*)\}/g;
 
-    return text.replace(linkRegExp, (match, prefixText: string | undefined, tag: string, body: string) => {
+    return text.replace(linkRegExp, (match, body: string) => {
       const content = (body ?? '').trim();
       if (content.length === 0) {
         // malformed tag (no target), leave it untouched
         return match;
       }
 
-      // Split the tag body into a target and optional link text. A pipe takes
-      // precedence as the separator, otherwise the first run of whitespace is
-      // used (e.g. `{@link target|text}` or `{@link target text}`).
+      // Split the tag body into a target and optional custom link text on the
+      // first `|`, e.g. `{@link target | text}`.
       let target = content;
-      let inlineText: string | undefined;
+      let customText: string | undefined;
       const pipeIdx = content.indexOf('|');
       if (pipeIdx >= 0) {
         target = content.substring(0, pipeIdx).trim();
-        inlineText = content.substring(pipeIdx + 1).trim();
-      } else {
-        const wsMatch = /\s/.exec(content);
-        if (wsMatch) {
-          target = content.substring(0, wsMatch.index).trim();
-          inlineText = content.substring(wsMatch.index).trim();
-        }
+        customText = content.substring(pipeIdx + 1).trim();
       }
 
-      // The `[prefix]{@link ...}` form takes precedence over text given inside
-      // the braces.
-      const prefix = prefixText?.trim();
-      const displayText = prefix && prefix.length > 0
-        ? prefix
-        : (inlineText && inlineText.length > 0 ? inlineText : target);
+      if (target.length === 0) {
+        // malformed tag (e.g. `{@link | text}`), leave it untouched
+        return match;
+      }
 
-      const code = tag === 'linkcode';
-      const plain = tag === 'linkplain';
+      const hasCustomText = customText !== undefined && customText.length > 0;
 
-      const isUrl = /^(?:https?|ftp|mailto):/i.test(target) || /^www\./i.test(target);
+      const isUrl = /^(?:https?|ftp|mailto):/i.test(target);
       if (isUrl) {
-        const url = /^www\./i.test(target) ? `https://${target}` : target;
-        const label = code ? `\`${displayText}\`` : displayText;
-        return `[${label}](${url})`;
+        return `[${hasCustomText ? customText : target}](${target})`;
       }
 
-      // Namepath reference without a resolvable target.
-      return plain ? displayText : `\`${displayText}\``;
+      // Declaration reference without a resolvable target: render the custom
+      // text as-is, or the bare reference as inline code.
+      return hasCustomText ? customText! : `\`${target}\``;
     });
   }
 

--- a/src/docgen/render/markdown-doc.ts
+++ b/src/docgen/render/markdown-doc.ts
@@ -94,6 +94,75 @@ export class MarkdownDocument {
     return `*${text}*`;
   }
 
+  /**
+   * Convert JSDoc `{@link}` inline tags into markdown.
+   *
+   * Supports every syntax variant described in
+   * https://jsdoc.app/tags-inline-link, including the `{@linkcode}` and
+   * `{@linkplain}` synonyms:
+   *
+   * - `{@link https://example.com}`
+   * - `{@link https://example.com|link text}`
+   * - `{@link https://example.com link text}`
+   * - `[link text]{@link https://example.com}`
+   * - `{@link SomeType}` (namepath reference)
+   *
+   * URLs are rendered as clickable markdown links. Namepath references (that
+   * don't resolve to a URL) are rendered as inline code, since there is no
+   * reliable way to resolve an arbitrary namepath to an anchor at render time.
+   * `{@linkcode}` always renders its text as inline code, while `{@linkplain}`
+   * always renders its text as plain text.
+   */
+  public static formatLinks(text: string): string {
+    // An optional `[prefix text]` may immediately precede the inline tag.
+    const linkRegExp = /(?:\[([^\]]*)\])?\{@(link|linkcode|linkplain)\s+([^}]*)\}/g;
+
+    return text.replace(linkRegExp, (match, prefixText: string | undefined, tag: string, body: string) => {
+      const content = (body ?? '').trim();
+      if (content.length === 0) {
+        // malformed tag (no target), leave it untouched
+        return match;
+      }
+
+      // Split the tag body into a target and optional link text. A pipe takes
+      // precedence as the separator, otherwise the first run of whitespace is
+      // used (e.g. `{@link target|text}` or `{@link target text}`).
+      let target = content;
+      let inlineText: string | undefined;
+      const pipeIdx = content.indexOf('|');
+      if (pipeIdx >= 0) {
+        target = content.substring(0, pipeIdx).trim();
+        inlineText = content.substring(pipeIdx + 1).trim();
+      } else {
+        const wsMatch = /\s/.exec(content);
+        if (wsMatch) {
+          target = content.substring(0, wsMatch.index).trim();
+          inlineText = content.substring(wsMatch.index).trim();
+        }
+      }
+
+      // The `[prefix]{@link ...}` form takes precedence over text given inside
+      // the braces.
+      const prefix = prefixText?.trim();
+      const displayText = prefix && prefix.length > 0
+        ? prefix
+        : (inlineText && inlineText.length > 0 ? inlineText : target);
+
+      const code = tag === 'linkcode';
+      const plain = tag === 'linkplain';
+
+      const isUrl = /^(?:https?|ftp|mailto):/i.test(target) || /^www\./i.test(target);
+      if (isUrl) {
+        const url = /^www\./i.test(target) ? `https://${target}` : target;
+        const label = code ? `\`${displayText}\`` : displayText;
+        return `[${label}](${url})`;
+      }
+
+      // Namepath reference without a resolvable target.
+      return plain ? displayText : `\`${displayText}\``;
+    });
+  }
+
   private readonly _lines = new Array<string>();
   private readonly _sections = new Array<MarkdownDocument>();
 
@@ -110,11 +179,11 @@ export class MarkdownDocument {
    */
   public docs(docs: DocsSchema, language?: Language) {
     if (docs.summary) {
-      this.lines(MarkdownDocument.sanitize(docs.summary));
+      this.lines(MarkdownDocument.formatLinks(MarkdownDocument.sanitize(docs.summary)));
       this.lines('');
     }
     if (docs.remarks) {
-      this.lines(MarkdownDocument.sanitize(docs.remarks));
+      this.lines(MarkdownDocument.formatLinks(MarkdownDocument.sanitize(docs.remarks)));
       this.lines('');
     }
 

--- a/src/docgen/render/markdown-render.ts
+++ b/src/docgen/render/markdown-render.ts
@@ -526,7 +526,7 @@ export class MarkdownRenderer {
 
     if (em.docs.deprecated) {
       md.bullet(
-        `${MarkdownDocument.italic('Deprecated:')} ${em.docs.deprecationReason}`,
+        `${MarkdownDocument.italic('Deprecated:')} ${MarkdownDocument.formatLinks(em.docs.deprecationReason ?? '')}`,
       );
       md.lines('');
     }
@@ -565,7 +565,7 @@ export class MarkdownRenderer {
 
     if (prop.docs.deprecated) {
       md.bullet(
-        `${MarkdownDocument.italic('Deprecated:')} ${prop.docs.deprecationReason}`,
+        `${MarkdownDocument.italic('Deprecated:')} ${MarkdownDocument.formatLinks(prop.docs.deprecationReason ?? '')}`,
       );
       md.lines('');
     }
@@ -619,7 +619,7 @@ export class MarkdownRenderer {
 
     if (parameter.docs.deprecated) {
       md.bullet(
-        `${MarkdownDocument.italic('Deprecated:')} ${parameter.docs.deprecationReason}`,
+        `${MarkdownDocument.italic('Deprecated:')} ${MarkdownDocument.formatLinks(parameter.docs.deprecationReason ?? '')}`,
       );
       md.lines('');
     }
@@ -730,7 +730,7 @@ export class MarkdownRenderer {
         ...this.metadata,
       }, this.metadata));
       const description = item.docs?.summary && item.docs?.summary.length > 0
-        ? item.docs?.summary
+        ? MarkdownDocument.formatLinks(item.docs?.summary)
         : MarkdownDocument.italic('No description.');
       tableRows.push([link, description]);
     }
@@ -751,7 +751,7 @@ export class MarkdownRenderer {
       }, this.metadata));
       const type = MarkdownDocument.pre(this.typeFormatter(item.type, this.metadata, this.linkFormatter));
       const description = item.docs?.summary && item.docs?.summary.length > 0
-        ? item.docs?.summary
+        ? MarkdownDocument.formatLinks(item.docs?.summary)
         : MarkdownDocument.italic('No description.');
       tableRows.push([link, type, description]);
     }

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -353,7 +353,7 @@ public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
 If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
-calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+calling \`grantWrite\` or \`grantReadWrite\` no longer grants permissions to modify the ACLs of the objects;
 in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.identity"></a>
@@ -412,7 +412,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.identity"></a>
 
@@ -443,7 +443,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantWrite.parameter.identity"></a>
 
@@ -1428,7 +1428,7 @@ public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
 If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
-calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+calling \`grantWrite\` or \`grantReadWrite\` no longer grants permissions to modify the ACLs of the objects;
 in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantPutAcl.parameter.identity"></a>
@@ -1487,7 +1487,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantReadWrite.parameter.identity"></a>
 
@@ -1518,7 +1518,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantWrite.parameter.identity"></a>
 
@@ -3391,7 +3391,7 @@ The block public access configuration of this bucket.
 
 Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket.
 
-Only relevant, when Encryption is set to {@link BucketEncryption.KMS}
+Only relevant, when Encryption is set to \`BucketEncryption.KMS\`
 
 ---
 
@@ -3983,7 +3983,7 @@ def grant_put_acl(
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
 If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
-calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+calling \`grantWrite\` or \`grantReadWrite\` no longer grants permissions to modify the ACLs of the objects;
 in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.identity"></a>
@@ -4048,7 +4048,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.identity"></a>
 
@@ -4082,7 +4082,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantWrite.parameter.identity"></a>
 
@@ -5454,7 +5454,7 @@ The block public access configuration of this bucket.
 
 Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket.
 
-Only relevant, when Encryption is set to {@link BucketEncryption.KMS}
+Only relevant, when Encryption is set to \`BucketEncryption.KMS\`
 
 ---
 
@@ -6046,7 +6046,7 @@ def grant_put_acl(
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
 If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
-calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+calling \`grantWrite\` or \`grantReadWrite\` no longer grants permissions to modify the ACLs of the objects;
 in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantPutAcl.parameter.identity"></a>
@@ -6111,7 +6111,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantReadWrite.parameter.identity"></a>
 
@@ -6145,7 +6145,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantWrite.parameter.identity"></a>
 
@@ -7534,7 +7534,7 @@ The block public access configuration of this bucket.
 
 Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket.
 
-Only relevant, when Encryption is set to {@link BucketEncryption.KMS}
+Only relevant, when Encryption is set to \`BucketEncryption.KMS\`
 
 ---
 
@@ -8126,7 +8126,7 @@ def grant_put_acl(
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
 If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
-calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+calling \`grantWrite\` or \`grantReadWrite\` no longer grants permissions to modify the ACLs of the objects;
 in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantPutAcl.parameter.identity"></a>
@@ -8191,7 +8191,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantReadWrite.parameter.identity"></a>
 
@@ -8225,7 +8225,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantWrite.parameter.identity"></a>
 
@@ -9835,7 +9835,7 @@ public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
 If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
-calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+calling \`grantWrite\` or \`grantReadWrite\` no longer grants permissions to modify the ACLs of the objects;
 in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantPutAcl.parameter.identity"></a>
@@ -9894,7 +9894,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantReadWrite.parameter.identity"></a>
 
@@ -9925,7 +9925,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantWrite.parameter.identity"></a>
 
@@ -10700,7 +10700,7 @@ The block public access configuration of this bucket.
 
 Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket.
 
-Only relevant, when Encryption is set to {@link BucketEncryption.KMS}
+Only relevant, when Encryption is set to \`BucketEncryption.KMS\`
 
 ---
 
@@ -11292,7 +11292,7 @@ def grant_put_acl(
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
 If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
-calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+calling \`grantWrite\` or \`grantReadWrite\` no longer grants permissions to modify the ACLs of the objects;
 in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.identity"></a>
@@ -11357,7 +11357,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.identity"></a>
 
@@ -11391,7 +11391,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantWrite.parameter.identity"></a>
 
@@ -12995,7 +12995,7 @@ public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
 If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
-calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+calling \`grantWrite\` or \`grantReadWrite\` no longer grants permissions to modify the ACLs of the objects;
 in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.identity"></a>
@@ -13054,7 +13054,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.identity"></a>
 
@@ -13085,7 +13085,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantWrite.parameter.identity"></a>
 
@@ -14081,7 +14081,7 @@ public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
 If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
-calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+calling \`grantWrite\` or \`grantReadWrite\` no longer grants permissions to modify the ACLs of the objects;
 in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantPutAcl.parameter.identity"></a>
@@ -14140,7 +14140,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantReadWrite.parameter.identity"></a>
 
@@ -14171,7 +14171,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantWrite.parameter.identity"></a>
 
@@ -15167,7 +15167,7 @@ public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
 If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
-calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+calling \`grantWrite\` or \`grantReadWrite\` no longer grants permissions to modify the ACLs of the objects;
 in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.identity"></a>
@@ -15226,7 +15226,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.identity"></a>
 
@@ -15257,7 +15257,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantWrite.parameter.identity"></a>
 
@@ -16259,7 +16259,7 @@ public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
 If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
-calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+calling \`grantWrite\` or \`grantReadWrite\` no longer grants permissions to modify the ACLs of the objects;
 in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantPutAcl.parameter.identity"></a>
@@ -16318,7 +16318,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantReadWrite.parameter.identity"></a>
 
@@ -16349,7 +16349,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.GreeterBucket.grantWrite.parameter.identity"></a>
 
@@ -17345,7 +17345,7 @@ public grantPutAcl(identity: IGrantable, objectsKeyPattern?: string): Grant
 Grant the given IAM identity permissions to modify the ACLs of objects in the given Bucket.
 
 If your application has the '@aws-cdk/aws-s3:grantWriteWithoutAcl' feature flag set,
-calling {@link grantWrite} or {@link grantReadWrite} no longer grants permissions to modify the ACLs of the objects;
+calling \`grantWrite\` or \`grantReadWrite\` no longer grants permissions to modify the ACLs of the objects;
 in this case, if you need to modify object ACLs, call this method explicitly.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantPutAcl.parameter.identity"></a>
@@ -17404,7 +17404,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantReadWrite.parameter.identity"></a>
 
@@ -17435,7 +17435,7 @@ If you want to get rid of that behavior, update your CDK version to 1.85.0 or la
 and make sure the \`@aws-cdk/aws-s3:grantWriteWithoutAcl\` feature flag is set to \`true\`
 in the \`context\` key of your cdk.json file.
 If you've already updated, but still need the principal to have permissions to modify the ACLs,
-use the {@link grantPutAcl} method.
+use the \`grantPutAcl\` method.
 
 ###### \`identity\`<sup>Required</sup> <a name="identity" id="construct-library.submod1.GoodbyeBucket.grantWrite.parameter.identity"></a>
 

--- a/test/docgen/render/markdown-doc.test.ts
+++ b/test/docgen/render/markdown-doc.test.ts
@@ -2,73 +2,61 @@ import { MarkdownDocument } from '../../../src/docgen/render/markdown-doc';
 
 describe('formatLinks', () => {
   test('URL only', () => {
-    expect(MarkdownDocument.formatLinks('See {@link https://example.com}.'))
-      .toEqual('See [https://example.com](https://example.com).');
+    expect(MarkdownDocument.formatLinks('See {@link https://github.com/microsoft/tsdoc}.'))
+      .toEqual('See [https://github.com/microsoft/tsdoc](https://github.com/microsoft/tsdoc).');
   });
 
-  test('URL with pipe-delimited link text', () => {
-    expect(MarkdownDocument.formatLinks('Check out {@link http://www.google.com|Google}.'))
-      .toEqual('Check out [Google](http://www.google.com).');
+  test('URL with custom link text', () => {
+    expect(MarkdownDocument.formatLinks('Check out {@link https://example.com | the docs}.'))
+      .toEqual('Check out [the docs](https://example.com).');
   });
 
-  test('URL with space-delimited link text', () => {
-    expect(MarkdownDocument.formatLinks('Check out {@link https://github.com GitHub}.'))
-      .toEqual('Check out [GitHub](https://github.com).');
-  });
-
-  test('prefix bracket link text takes precedence', () => {
-    expect(MarkdownDocument.formatLinks('[the docs]{@link https://example.com}'))
-      .toEqual('[the docs](https://example.com)');
-  });
-
-  test('prefix bracket overrides inline text', () => {
-    expect(MarkdownDocument.formatLinks('[prefix]{@link https://example.com|inline}'))
-      .toEqual('[prefix](https://example.com)');
-  });
-
-  test('namepath reference renders as inline code', () => {
-    expect(MarkdownDocument.formatLinks('See {@link MyClass} for details.'))
-      .toEqual('See `MyClass` for details.');
-  });
-
-  test('namepath reference with member', () => {
-    expect(MarkdownDocument.formatLinks("See [MyClass's foo property]{@link MyClass#foo}."))
-      .toEqual("See `MyClass's foo property`.");
-  });
-
-  test('namepath reference with explicit text', () => {
-    expect(MarkdownDocument.formatLinks('Use {@link MyClass#foo the foo prop} instead.'))
-      .toEqual('Use `the foo prop` instead.');
-  });
-
-  test('linkcode renders URL text as inline code', () => {
-    expect(MarkdownDocument.formatLinks('{@linkcode https://example.com Example}'))
-      .toEqual('[`Example`](https://example.com)');
-  });
-
-  test('linkcode namepath renders as inline code', () => {
-    expect(MarkdownDocument.formatLinks('{@linkcode MyClass}'))
-      .toEqual('`MyClass`');
-  });
-
-  test('linkplain namepath renders as plain text', () => {
-    expect(MarkdownDocument.formatLinks('{@linkplain MyClass the class}'))
-      .toEqual('the class');
-  });
-
-  test('www. prefix gets an https scheme', () => {
-    expect(MarkdownDocument.formatLinks('{@link www.example.com Example}'))
-      .toEqual('[Example](https://www.example.com)');
+  test('URL with custom link text without surrounding spaces', () => {
+    expect(MarkdownDocument.formatLinks('{@link https://example.com|Example}'))
+      .toEqual('[Example](https://example.com)');
   });
 
   test('mailto URL', () => {
-    expect(MarkdownDocument.formatLinks('{@link mailto:foo@example.com email us}'))
+    expect(MarkdownDocument.formatLinks('{@link mailto:foo@example.com | email us}'))
       .toEqual('[email us](mailto:foo@example.com)');
   });
 
+  test('declaration reference renders as inline code', () => {
+    expect(MarkdownDocument.formatLinks('See {@link Button} for details.'))
+      .toEqual('See `Button` for details.');
+  });
+
+  test('declaration reference with member', () => {
+    expect(MarkdownDocument.formatLinks('See {@link controls.Button.render}.'))
+      .toEqual('See `controls.Button.render`.');
+  });
+
+  test('declaration reference with package path', () => {
+    expect(MarkdownDocument.formatLinks('{@link @microsoft/my-control-library/lib/Button#Button}'))
+      .toEqual('`@microsoft/my-control-library/lib/Button#Button`');
+  });
+
+  test('declaration reference with custom text renders as that text', () => {
+    expect(MarkdownDocument.formatLinks('{@link Button | the Button class}'))
+      .toEqual('the Button class');
+  });
+
   test('multiple tags in one string', () => {
-    expect(MarkdownDocument.formatLinks('{@link MyClass} and {@link https://example.com|here}'))
-      .toEqual('`MyClass` and [here](https://example.com)');
+    expect(MarkdownDocument.formatLinks('{@link Button} and {@link https://example.com | here}'))
+      .toEqual('`Button` and [here](https://example.com)');
+  });
+
+  test('the JSDoc space-delimited form is NOT treated as link text', () => {
+    // TSDoc only uses `|` as the separator, so the trailing words are part of
+    // the declaration reference target (rendered as inline code).
+    expect(MarkdownDocument.formatLinks('{@link Button the Button class}'))
+      .toEqual('`Button the Button class`');
+  });
+
+  test('the JSDoc prefix form is NOT supported', () => {
+    // The bracket is left untouched; only the `{@link ...}` is converted.
+    expect(MarkdownDocument.formatLinks('[the docs]{@link https://example.com}'))
+      .toEqual('[the docs][https://example.com](https://example.com)');
   });
 
   test('malformed tag (no target) is left untouched', () => {
@@ -76,13 +64,13 @@ describe('formatLinks', () => {
       .toEqual('an empty {@link } tag');
   });
 
+  test('malformed tag (no target before pipe) is left untouched', () => {
+    expect(MarkdownDocument.formatLinks('{@link | text}'))
+      .toEqual('{@link | text}');
+  });
+
   test('text without any tags is unchanged', () => {
     expect(MarkdownDocument.formatLinks('plain text with no links'))
       .toEqual('plain text with no links');
-  });
-
-  test('bracket not adjacent to tag is not treated as prefix text', () => {
-    expect(MarkdownDocument.formatLinks('[unrelated] and {@link https://example.com}'))
-      .toEqual('[unrelated] and [https://example.com](https://example.com)');
   });
 });

--- a/test/docgen/render/markdown-doc.test.ts
+++ b/test/docgen/render/markdown-doc.test.ts
@@ -1,0 +1,88 @@
+import { MarkdownDocument } from '../../../src/docgen/render/markdown-doc';
+
+describe('formatLinks', () => {
+  test('URL only', () => {
+    expect(MarkdownDocument.formatLinks('See {@link https://example.com}.'))
+      .toEqual('See [https://example.com](https://example.com).');
+  });
+
+  test('URL with pipe-delimited link text', () => {
+    expect(MarkdownDocument.formatLinks('Check out {@link http://www.google.com|Google}.'))
+      .toEqual('Check out [Google](http://www.google.com).');
+  });
+
+  test('URL with space-delimited link text', () => {
+    expect(MarkdownDocument.formatLinks('Check out {@link https://github.com GitHub}.'))
+      .toEqual('Check out [GitHub](https://github.com).');
+  });
+
+  test('prefix bracket link text takes precedence', () => {
+    expect(MarkdownDocument.formatLinks('[the docs]{@link https://example.com}'))
+      .toEqual('[the docs](https://example.com)');
+  });
+
+  test('prefix bracket overrides inline text', () => {
+    expect(MarkdownDocument.formatLinks('[prefix]{@link https://example.com|inline}'))
+      .toEqual('[prefix](https://example.com)');
+  });
+
+  test('namepath reference renders as inline code', () => {
+    expect(MarkdownDocument.formatLinks('See {@link MyClass} for details.'))
+      .toEqual('See `MyClass` for details.');
+  });
+
+  test('namepath reference with member', () => {
+    expect(MarkdownDocument.formatLinks("See [MyClass's foo property]{@link MyClass#foo}."))
+      .toEqual("See `MyClass's foo property`.");
+  });
+
+  test('namepath reference with explicit text', () => {
+    expect(MarkdownDocument.formatLinks('Use {@link MyClass#foo the foo prop} instead.'))
+      .toEqual('Use `the foo prop` instead.');
+  });
+
+  test('linkcode renders URL text as inline code', () => {
+    expect(MarkdownDocument.formatLinks('{@linkcode https://example.com Example}'))
+      .toEqual('[`Example`](https://example.com)');
+  });
+
+  test('linkcode namepath renders as inline code', () => {
+    expect(MarkdownDocument.formatLinks('{@linkcode MyClass}'))
+      .toEqual('`MyClass`');
+  });
+
+  test('linkplain namepath renders as plain text', () => {
+    expect(MarkdownDocument.formatLinks('{@linkplain MyClass the class}'))
+      .toEqual('the class');
+  });
+
+  test('www. prefix gets an https scheme', () => {
+    expect(MarkdownDocument.formatLinks('{@link www.example.com Example}'))
+      .toEqual('[Example](https://www.example.com)');
+  });
+
+  test('mailto URL', () => {
+    expect(MarkdownDocument.formatLinks('{@link mailto:foo@example.com email us}'))
+      .toEqual('[email us](mailto:foo@example.com)');
+  });
+
+  test('multiple tags in one string', () => {
+    expect(MarkdownDocument.formatLinks('{@link MyClass} and {@link https://example.com|here}'))
+      .toEqual('`MyClass` and [here](https://example.com)');
+  });
+
+  test('malformed tag (no target) is left untouched', () => {
+    expect(MarkdownDocument.formatLinks('an empty {@link } tag'))
+      .toEqual('an empty {@link } tag');
+  });
+
+  test('text without any tags is unchanged', () => {
+    expect(MarkdownDocument.formatLinks('plain text with no links'))
+      .toEqual('plain text with no links');
+  });
+
+  test('bracket not adjacent to tag is not treated as prefix text', () => {
+    expect(MarkdownDocument.formatLinks('[unrelated] and {@link https://example.com}'))
+      .toEqual('[unrelated] and [https://example.com](https://example.com)');
+  });
+});


### PR DESCRIPTION
Adds support for the [TSDoc `{@link}` inline tag](https://tsdoc.org/pages/tags/link/) in doc comments. Previously the raw tag leaked into the generated docs (e.g. a literal `{@link https://example.com}`); now it renders properly wherever it appears — summaries, remarks, table descriptions and deprecation reasons.

A `{@link}` tag is a target with an optional custom text, separated by `|`:

- URLs become clickable links: `{@link https://aws.amazon.com | Learn more}` → [Learn more](https://aws.amazon.com)
- Declaration references render as inline code: `{@link MyClass}` → `MyClass`
- A reference with custom text renders as that text: `{@link MyClass | the class}` → the class

Declaration references aren't turned into anchor links: the markdown renderer works off the JSON schema and has no access to the jsii type system, so it can't reliably resolve a reference to an in-document anchor. Inline code keeps the output clean without risking broken links.
